### PR TITLE
ci: add build check and release+deploy workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,4 @@ jobs:
       - run: npm ci
       - run: npm install @rollup/rollup-linux-x64-gnu --no-save
 
-      - run: npm run package:plugins
-
       - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,28 +60,27 @@ jobs:
             "
           done
 
-      - name: Commit and tag
-        run: |
-          git add -A
-          git commit -m "v${{ steps.version.outputs.version }}"
-          git tag "v${{ steps.version.outputs.version }}"
-          git push origin HEAD:master --tags
+      - name: Build web app
+        run: npm run build
 
-      - name: Build plugins and web app
-        run: |
-          npm run package:plugins
-          npm run build
-
-      - name: Deploy to 5apps
+      - name: Setup SSH for 5apps
         env:
           FIVEAPPS_DEPLOY_KEY: ${{ secrets.FIVEAPPS_DEPLOY_KEY }}
         run: |
           mkdir -p ~/.ssh
           echo "$FIVEAPPS_DEPLOY_KEY" > ~/.ssh/5apps_key
           chmod 600 ~/.ssh/5apps_key
-          echo -e "Host 5apps.com\n  IdentityFile ~/.ssh/5apps_key\n  StrictHostKeyChecking no" >> ~/.ssh/config
+          ssh-keyscan -H 5apps.com >> ~/.ssh/known_hosts
+          echo -e "Host 5apps.com\n  IdentityFile ~/.ssh/5apps_key" >> ~/.ssh/config
 
-          git remote add 5apps git@5apps.com:silverbucket_inbox-rs.git
+      - name: Deploy to 5apps
+        run: |
+          git remote add 5apps git@5apps.com:silverbucket_inbox-rs.git 2>/dev/null || git remote set-url 5apps git@5apps.com:silverbucket_inbox-rs.git
           git add packages/web/dist -f
           git commit -m "deploy v${{ steps.version.outputs.version }}"
           git subtree push --prefix=packages/web/dist 5apps master
+
+      - name: Tag and push version
+        run: |
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin HEAD:master --tags


### PR DESCRIPTION
## Summary
- Adds PR build check workflow (CI on pull requests to master)
- Adds manual release workflow: version bump, tag, build, and deploy to 5apps
- Deploy uses `git subtree push --prefix=packages/web/dist` to 5apps remote

## Setup required
Add `FIVEAPPS_DEPLOY_KEY` secret (SSH private key for 5apps) in repo Settings > Secrets and variables > Actions.

## Test plan
- [ ] Open this PR and verify the CI workflow runs the build check
- [ ] After merge, trigger the Release & Deploy workflow from Actions tab with `patch`
- [ ] Verify version is bumped, tag created, and app deployed to 5apps