### PR TITLE
Fix extension OAuth invalid_client error

### DIFF
--- a/packages/extension/src/lib/rs.ts
+++ b/packages/extension/src/lib/rs.ts
@@ -52,7 +52,7 @@ export async function connectViaOAuth(userAddress: string): Promise<RSConfig> {
     : browser.identity.getRedirectURL();
 
   const oauthParams = new URLSearchParams({
-    client_id: 'inbox-rs-extension',
+    client_id: new URL(redirectUrl).origin,
     redirect_uri: redirectUrl,
     response_type: 'token',
     scope: 'inbox:rw'


### PR DESCRIPTION
## Summary
- Use the extension's redirect URL origin as the OAuth `client_id` instead of a hardcoded plain string
- RS servers expect `client_id` to be a valid URL origin per the remoteStorage OAuth spec; `'inbox-rs-extension'` was rejected as `invalid_client`

## Test plan
- [ ] Build extension (`npm run build:extension`)
- [ ] Load in Chrome and connect to `nick@silverbucket.net`
- [ ] Verify OAuth flow completes without `invalid_client` error