### PR TITLE
fix: persist version bump in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Deploy to 5apps
         run: |
           git remote add 5apps git@5apps.com:silverbucket_inbox-rs.git 2>/dev/null || git remote set-url 5apps git@5apps.com:silverbucket_inbox-rs.git
-          git add packages/web/dist -f
+          git add package.json packages/*/package.json packages/extension/manifest.json packages/extension/manifest.firefox.json packages/thunderbird/manifest.json packages/web/dist -f
           git commit -m "deploy v${{ steps.version.outputs.version }}"
           SPLIT_SHA=$(git subtree split --prefix=packages/web/dist)
           git push 5apps "$SPLIT_SHA":refs/heads/master --force

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inbox-rs",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/extension/manifest.firefox.json
+++ b/packages/extension/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Inbox RS",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "description": "Save links, text, and more to your remoteStorage inbox.",
   "permissions": [
     "contextMenus",

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Inbox RS",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "description": "Save links, text, and more to your remoteStorage inbox.",
   "permissions": [
     "contextMenus",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inbox-rs/extension",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/rs-module/package.json
+++ b/packages/rs-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inbox-rs/rs-module",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/thunderbird/manifest.json
+++ b/packages/thunderbird/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Inbox RS",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "description": "Save emails to your remoteStorage inbox.",
   "applications": {
     "gecko": {

--- a/packages/thunderbird/package.json
+++ b/packages/thunderbird/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inbox-rs/thunderbird",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inbox-rs/web",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- The release workflow bumped package versions but only staged `packages/web/dist` in the deploy commit — the bumped `package.json` and manifest files were never committed back to master
- Next release would re-derive the same version and fail with `fatal: tag 'vX.Y.Z' already exists`
- Fix: expand `git add` to include all version files alongside the dist build
- Also syncs all package/manifest versions to `0.2.2` to match the existing tag

## Test plan
- [ ] Trigger a patch release dispatch and verify it bumps to `v0.2.3` successfully
- [ ] Confirm the resulting commit on master includes updated `package.json` files