### PR TITLE
Fix migration banner appearing for newly created items

### DIFF
--- a/packages/rs-module/src/index.ts
+++ b/packages/rs-module/src/index.ts
@@ -50,8 +50,8 @@ const InboxModule = {
         async store(item: InboxItem, fileData?: ArrayBuffer): Promise<void> {
           // Stamp new items with the current migration version so they aren't
           // flagged as needing migration by getPending().
-          if (!(item as any)._migrateVersion) {
-            (item as any)._migrateVersion = migrator.getLatestVersion('items');
+          if (item._migrateVersion === undefined) {
+            item._migrateVersion = migrator.getLatestVersion('items');
           }
           if (fileData && 'filePath' in item && item.filePath && 'mimeType' in item && item.mimeType) {
             // Store file locally for immediate access

--- a/packages/rs-module/src/types.ts
+++ b/packages/rs-module/src/types.ts
@@ -6,6 +6,7 @@ export interface InboxItemBase {
   title: string;
   description?: string;
   createdAt: string; // ISO 8601
+  _migrateVersion?: number; // rs-migrate: tracks which migrations have been applied
   isTodo?: boolean;
   completed?: boolean;
   completedAt?: string;


### PR DESCRIPTION
## Summary
- New items lack a `_migrateVersion` field, so `rs-migrate`'s `getPending()` treats them as un-migrated (version 0) and incorrectly flags them for migration
- This caused the migration banner to appear when saving a new todo, even though no actual migration is needed
- Fix: stamp `_migrateVersion` with the latest migration version in the `store()` function so new items are recognized as up-to-date

## Test plan
- [ ] Create a new todo and verify the migration banner does not appear
- [ ] Verify that old `voice-memo` items (if any exist) still trigger the migration banner correctly