### PR TITLE
Fix migration banner flash on new item save

### DIFF
--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -168,7 +168,7 @@ export async function storeItem(item: InboxItem, fileData?: ArrayBuffer) {
     console.log('[inbox] stored file, triggering sync:', item.filePath);
     rs.startSync();
   }
-  items.update(current => ({ ...current, [item.id]: item }));
+  items.update(current => ({ ...current, [cleanItem.id]: cleanItem }));
 }
 
 export async function deleteItem(id: string, item?: InboxItem) {


### PR DESCRIPTION
## Summary
- `storeItem()` calls `inbox.store(cleanItem)` which stamps `_migrateVersion` on the deep copy, but then adds the original `item` (without `_migrateVersion`) to the Svelte store
- The `pendingMigrationCount` derived store sees the un-stamped item and shows the migration banner until page refresh
- Fix: use `cleanItem` in the store update so in-memory state matches what was persisted

## Test plan
- [ ] Create a new todo, verify the migration banner does not flash
- [ ] Edit an existing item, verify no banner appears
- [ ] Refresh the page, verify items load without banner