### PR TITLE
Add visual markdown editor for notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,26 @@
 {
   "name": "inbox-rs",
-  "version": "1.4.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inbox-rs",
-      "version": "1.4.1",
+      "version": "1.6.2",
       "workspaces": [
         "packages/*"
       ]
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.6.tgz",
-      "integrity": "sha512-BXWCh8dHs9GOfpo/fWGDJtDmleta2VePN9rn6WQt3GjEbxzutVF4t0x2pmH+7dbMCLtuv3MlwqRsAuxlzFXqFg==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.1.1",
-        "@csstools/css-color-parser": "^4.0.2",
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
         "@csstools/css-tokenizer": "^4.0.0"
       },
@@ -28,17 +29,28 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.7.tgz",
-      "integrity": "sha512-d2BgqDUOS1Hfp4IzKUZqCNz+Kg3Y88AkaBvJK/ZVSQPU1f7OpPNi7nQTH6/oI47Dkdg+Z3e8Yp6ynOu4UMINAQ==",
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.10.tgz",
+      "integrity": "sha512-KyOb19eytNSELkmdqzZZUXWCU25byIlOld5qVFg0RYdS0T3tt7jeDByxk9hIAC73frclD8GKrHttr0SUjKCCdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",
         "is-potential-custom-element-name": "^1.0.1"
       },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
@@ -84,9 +96,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
       "dev": true,
       "funding": [
         {
@@ -108,9 +120,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
-      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
       "dev": true,
       "funding": [
         {
@@ -125,7 +137,7 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.1.1"
+        "@csstools/css-calc": "^3.2.0"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -159,9 +171,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
-      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
       "dev": true,
       "funding": [
         {
@@ -201,6 +213,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -266,23 +312,6 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
       ],
       "engines": {
         "node": ">=18"
@@ -715,9 +744,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -734,9 +763,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -787,10 +816,14 @@
       "version": "1.1.0",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@remirror/core-constants": {
+      "version": "3.0.0",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
       "cpu": [
         "arm64"
       ],
@@ -805,9 +838,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
       "cpu": [
         "arm64"
       ],
@@ -822,9 +855,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
       "cpu": [
         "x64"
       ],
@@ -839,9 +872,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
       "cpu": [
         "x64"
       ],
@@ -856,9 +889,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
       "cpu": [
         "arm"
       ],
@@ -873,9 +906,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
       "cpu": [
         "arm64"
       ],
@@ -890,9 +923,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
       "cpu": [
         "arm64"
       ],
@@ -907,9 +940,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
       "cpu": [
         "ppc64"
       ],
@@ -924,9 +957,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
       "cpu": [
         "s390x"
       ],
@@ -941,9 +974,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
       "cpu": [
         "x64"
       ],
@@ -958,9 +991,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
       "cpu": [
         "x64"
       ],
@@ -975,9 +1008,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
       "cpu": [
         "arm64"
       ],
@@ -992,9 +1025,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
       "cpu": [
         "wasm32"
       ],
@@ -1002,16 +1035,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
       "cpu": [
         "arm64"
       ],
@@ -1026,9 +1061,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
       "cpu": [
         "x64"
       ],
@@ -1043,9 +1078,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -1073,6 +1108,344 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@tiptap/core": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block-lowlight": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/extension-code-block": "^3.22.1",
+        "@tiptap/pm": "^3.22.1",
+        "highlight.js": "^11",
+        "lowlight": "^2 || ^3"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.13.1",
+        "prosemirror-menu": "^1.2.4",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-trailing-node": "^3.0.0",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/extension-blockquote": "^3.22.1",
+        "@tiptap/extension-bold": "^3.22.1",
+        "@tiptap/extension-bullet-list": "^3.22.1",
+        "@tiptap/extension-code": "^3.22.1",
+        "@tiptap/extension-code-block": "^3.22.1",
+        "@tiptap/extension-document": "^3.22.1",
+        "@tiptap/extension-dropcursor": "^3.22.1",
+        "@tiptap/extension-gapcursor": "^3.22.1",
+        "@tiptap/extension-hard-break": "^3.22.1",
+        "@tiptap/extension-heading": "^3.22.1",
+        "@tiptap/extension-horizontal-rule": "^3.22.1",
+        "@tiptap/extension-italic": "^3.22.1",
+        "@tiptap/extension-link": "^3.22.1",
+        "@tiptap/extension-list": "^3.22.1",
+        "@tiptap/extension-list-item": "^3.22.1",
+        "@tiptap/extension-list-keymap": "^3.22.1",
+        "@tiptap/extension-ordered-list": "^3.22.1",
+        "@tiptap/extension-paragraph": "^3.22.1",
+        "@tiptap/extension-strike": "^3.22.1",
+        "@tiptap/extension-text": "^3.22.1",
+        "@tiptap/extension-underline": "^3.22.1",
+        "@tiptap/extensions": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -1108,10 +1481,31 @@
       "version": "1.0.8",
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "license": "MIT"
+    },
     "node_modules/@types/long": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1127,6 +1521,10 @@
     },
     "node_modules/@types/tv4": {
       "version": "1.2.33",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
       "license": "MIT"
     },
     "node_modules/@types/webextension-polyfill": {
@@ -1146,16 +1544,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1164,9 +1562,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1177,13 +1575,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "4.1.4",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1191,14 +1589,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1207,9 +1605,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1217,13 +1615,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
+        "@vitest/pretty-format": "4.1.4",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1233,8 +1631,6 @@
     },
     "node_modules/@xenova/transformers": {
       "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/@xenova/transformers/-/transformers-2.17.2.tgz",
-      "integrity": "sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/jinja": "^0.2.2",
@@ -1247,8 +1643,6 @@
     },
     "node_modules/@xenova/transformers/node_modules/@huggingface/jinja": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.2.2.tgz",
-      "integrity": "sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1256,8 +1650,6 @@
     },
     "node_modules/@xenova/transformers/node_modules/onnxruntime-node": {
       "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.14.0.tgz",
-      "integrity": "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1271,8 +1663,6 @@
     },
     "node_modules/@xenova/transformers/node_modules/sharp": {
       "version": "0.32.6",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
-      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1302,6 +1692,10 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "license": "Python-2.0"
+    },
     "node_modules/aria-query": {
       "version": "5.3.1",
       "license": "Apache-2.0",
@@ -1328,8 +1722,6 @@
     },
     "node_modules/b4a": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
-      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -1342,8 +1734,6 @@
     },
     "node_modules/bare-events": {
       "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -1356,8 +1746,6 @@
     },
     "node_modules/bare-fs": {
       "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.5.tgz",
-      "integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -1380,8 +1768,6 @@
     },
     "node_modules/bare-os": {
       "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.0.tgz",
-      "integrity": "sha512-Dc9/SlwfxkXIGYhvMQNUtKaXCaGkZYGcd1vuNUUADVqzu4/vQfvnMkYYOUnt2VwQ2AqKr/8qAVFRtwETljgeFg==",
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
@@ -1389,8 +1775,6 @@
     },
     "node_modules/bare-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-os": "^3.0.1"
@@ -1398,8 +1782,6 @@
     },
     "node_modules/bare-stream": {
       "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.1.tgz",
-      "integrity": "sha512-bSeR8RfvbRwDpD7HWZvn8M3uYNDrk7m9DQjYOFkENZlXW8Ju/MPaqUPQq5LqJ3kyjEm07siTaAQ7wBKCU59oHg==",
       "license": "Apache-2.0",
       "dependencies": {
         "streamx": "^2.21.0",
@@ -1420,8 +1802,6 @@
     },
     "node_modules/bare-url": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -1429,8 +1809,6 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "funding": [
         {
           "type": "github",
@@ -1459,8 +1837,6 @@
     },
     "node_modules/bl": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -1470,8 +1846,6 @@
     },
     "node_modules/buffer": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "funding": [
         {
           "type": "github",
@@ -1511,8 +1885,6 @@
     },
     "node_modules/color": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1",
@@ -1524,8 +1896,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1536,14 +1906,10 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
     "node_modules/color-string": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "license": "MIT",
       "dependencies": {
         "color-name": "^1.0.0",
@@ -1555,6 +1921,10 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
       "license": "MIT"
     },
     "node_modules/css-tree": {
@@ -1610,8 +1980,6 @@
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -1625,8 +1993,6 @@
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
@@ -1640,6 +2006,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "license": "Apache-2.0",
@@ -1651,20 +2024,26 @@
       "version": "5.6.4",
       "license": "MIT"
     },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
+      "version": "4.5.0",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -1679,6 +2058,16 @@
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/esm": {
       "version": "3.2.25",
@@ -1711,8 +2100,6 @@
     },
     "node_modules/events-universal": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
@@ -1720,8 +2107,6 @@
     },
     "node_modules/expand-template": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
@@ -1739,8 +2124,6 @@
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fdir": {
@@ -1769,14 +2152,10 @@
     },
     "node_modules/flatbuffers": {
       "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
-      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
     },
     "node_modules/fsevents": {
@@ -1792,8 +2171,6 @@
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
     "node_modules/guid-typescript": {
@@ -1802,8 +2179,6 @@
     },
     "node_modules/highlight.js": {
       "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
@@ -1824,8 +2199,6 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "funding": [
         {
           "type": "github",
@@ -1844,20 +2217,14 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
     },
     "node_modules/is-potential-custom-element-name": {
@@ -1875,14 +2242,14 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "29.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
-      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.0.1",
-        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
         "@bramus/specificity": "^2.4.2",
         "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
         "@exodus/bytes": "^1.15.0",
@@ -1953,20 +2320,273 @@
         "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "license": "MIT"
+    },
     "node_modules/locate-character": {
       "version": "3.0.0",
       "license": "MIT"
     },
     "node_modules/long": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
       "license": "Apache-2.0"
     },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.1.tgz",
-      "integrity": "sha512-Y71HWT4hydF1IAG/2OPync4dgQ/J2iWye7eg6CuzJHI+E97tvqFPlADzxiNnjH6WSljg8ecfXMr9k6bfFuqA5w==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1980,6 +2600,35 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-task-lists": {
+      "version": "2.1.1",
+      "license": "ISC"
+    },
+    "node_modules/marked": {
+      "version": "17.0.5",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -1987,10 +2636,12 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "license": "MIT"
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2001,8 +2652,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2010,8 +2659,6 @@
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -2038,14 +2685,10 @@
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/node-abi": {
       "version": "3.88.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.88.0.tgz",
-      "integrity": "sha512-At6b4UqIEVudaqPsXjmUO1r/N5BUr4yhDGs5PkBE8/oG5+TfLPhFechiskFsnT6Ql0VfUXbalUUCbfXxtj7K+w==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -2056,8 +2699,6 @@
     },
     "node_modules/node-addon-api": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "license": "MIT"
     },
     "node_modules/obug": {
@@ -2073,8 +2714,6 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -2082,8 +2721,6 @@
     },
     "node_modules/onnx-proto": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/onnx-proto/-/onnx-proto-4.0.4.tgz",
-      "integrity": "sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==",
       "license": "MIT",
       "dependencies": {
         "protobufjs": "^6.8.8"
@@ -2091,8 +2728,6 @@
     },
     "node_modules/onnx-proto/node_modules/protobufjs": {
       "version": "6.11.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
-      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2117,14 +2752,10 @@
     },
     "node_modules/onnxruntime-common": {
       "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.14.0.tgz",
-      "integrity": "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==",
       "license": "MIT"
     },
     "node_modules/onnxruntime-web": {
       "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.14.0.tgz",
-      "integrity": "sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==",
       "license": "MIT",
       "dependencies": {
         "flatbuffers": "^1.12.0",
@@ -2134,6 +2765,10 @@
         "onnxruntime-common": "~1.14.0",
         "platform": "^1.3.6"
       }
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -2146,6 +2781,19 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/pathe": {
@@ -2206,9 +2854,6 @@
     },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.0",
@@ -2233,14 +2878,10 @@
     },
     "node_modules/prebuild-install/node_modules/chownr": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
     "node_modules/prebuild-install/node_modules/tar-fs": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -2251,8 +2892,6 @@
     },
     "node_modules/prebuild-install/node_modules/tar-stream": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
@@ -2265,10 +2904,167 @@
         "node": ">=6"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.0",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-collab": {
+      "version": "1.3.1",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.4",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-menu": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "crelt": "^1.0.0",
+        "prosemirror-commands": "^1.0.0",
+        "prosemirror-history": "^1.0.0",
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.4",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-trailing-node": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@remirror/core-constants": "3.0.0",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -2285,10 +3081,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
         "deep-extend": "^0.6.0",
@@ -2302,8 +3103,6 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -2316,8 +3115,6 @@
     },
     "node_modules/remotestorage-module-shares": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/remotestorage-module-shares/-/remotestorage-module-shares-2.1.4.tgz",
-      "integrity": "sha512-PeRK6cHcxGoEL8np59u4b75rEyQePPE9rb3lL/s0l6zUZLV5srmT90sqawlUa1YfA8hdi8Y8odbP99uuJKzk9Q==",
       "license": "MIT"
     },
     "node_modules/remotestoragejs": {
@@ -2346,14 +3143,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -2362,21 +3159,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
     "node_modules/rollup": {
@@ -2422,16 +3219,16 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "license": "MIT"
+    },
     "node_modules/rs-migrate": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rs-migrate/-/rs-migrate-1.0.1.tgz",
-      "integrity": "sha512-58YafIo928IuoGSmtgsg5JZnPbct1PJ0Y9K1bk1Na4r5F1qHIl8JU95UaswZw3tqc3yNGLVY2nEZgFDyWF1agg==",
       "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -2480,8 +3277,6 @@
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
       "funding": [
         {
           "type": "github",
@@ -2500,8 +3295,6 @@
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
       "funding": [
         {
           "type": "github",
@@ -2525,8 +3318,6 @@
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.3.1"
@@ -2548,16 +3339,14 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/streamx": {
       "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -2567,8 +3356,6 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -2576,8 +3363,6 @@
     },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2585,8 +3370,6 @@
     },
     "node_modules/svelte": {
       "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.1.tgz",
-      "integrity": "sha512-QjvU7EFemf6mRzdMGlAFttMWtAAVXrax61SZYHdkD6yoVGQ89VeyKfZD4H1JrV1WLmJBxWhFch9H6ig/87VGjw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -2612,8 +3395,6 @@
     },
     "node_modules/svelte-dnd-action": {
       "version": "0.9.69",
-      "resolved": "https://registry.npmjs.org/svelte-dnd-action/-/svelte-dnd-action-0.9.69.tgz",
-      "integrity": "sha512-NAmSOH7htJoYraTQvr+q5whlIuVoq88vEuHr4NcFgscDRUxfWPPxgie2OoxepBCQCikrXZV4pqV86aun60wVyw==",
       "license": "MIT",
       "peerDependencies": {
         "svelte": ">=3.23.0 || ^5.0.0-next.0"
@@ -2628,8 +3409,6 @@
     },
     "node_modules/tar-fs": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
-      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
@@ -2642,8 +3421,6 @@
     },
     "node_modules/tar-stream": {
       "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
-      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
@@ -2654,8 +3431,6 @@
     },
     "node_modules/teex": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
       "license": "MIT",
       "dependencies": {
         "streamx": "^2.12.5"
@@ -2663,8 +3438,6 @@
     },
     "node_modules/text-decoder": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
-      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -2678,9 +3451,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2688,14 +3461,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2713,6 +3486,38 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tiptap-markdown": {
+      "version": "0.9.0",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "dependencies": {
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.1.0",
+        "markdown-it-task-lists": "^2.1.1",
+        "prosemirror-markdown": "^1.11.1"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.0.1"
+      }
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/linkify-it": {
+      "version": "3.0.5",
+      "license": "MIT"
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/markdown-it": {
+      "version": "13.0.9",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^3",
+        "@types/mdurl": "^1"
+      }
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/mdurl": {
+      "version": "1.0.5",
+      "license": "MIT"
     },
     "node_modules/tldts": {
       "version": "7.0.28",
@@ -2770,8 +3575,6 @@
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -2808,10 +3611,14 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "license": "MIT"
+    },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2824,8 +3631,6 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/vitefu": {
@@ -2847,19 +3652,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.2",
-        "@vitest/mocker": "4.1.2",
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/runner": "4.1.2",
-        "@vitest/snapshot": "4.1.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -2887,10 +3692,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.2",
-        "@vitest/browser-preview": "4.1.2",
-        "@vitest/browser-webdriverio": "4.1.2",
-        "@vitest/ui": "4.1.2",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -2914,6 +3721,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -2929,13 +3742,13 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.2",
+        "@vitest/spy": "4.1.4",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2956,16 +3769,16 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.4.tgz",
-      "integrity": "sha512-baBr4jUVSLJ0RPyZ2nK0zS2+W8hNHbM4hEzfvllukmRPVS3xDG5ATTNtbRXrKIOE2b8/FsPWJAOnuIxcs7g3cw==",
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
+        "rolldown": "1.0.0-rc.15",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -3032,6 +3845,10 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
@@ -3108,8 +3925,6 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
     "node_modules/xhr2": {
@@ -3142,7 +3957,7 @@
     },
     "packages/extension": {
       "name": "@inbox-rs/extension",
-      "version": "1.4.1",
+      "version": "1.6.2",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "remotestoragejs": "^2.0.0-beta.8",
@@ -3155,6 +3970,23 @@
         "typescript": "^5.4.0",
         "vite": "^6.0.0",
         "vitest": "^4.1.2"
+      }
+    },
+    "packages/extension/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/extension/node_modules/@sveltejs/vite-plugin-svelte": {
@@ -3316,7 +4148,7 @@
     },
     "packages/rs-module": {
       "name": "@inbox-rs/rs-module",
-      "version": "1.4.1",
+      "version": "1.6.2",
       "dependencies": {
         "remotestoragejs": "^2.0.0-beta.8",
         "rs-migrate": "^1.0.0"
@@ -3327,7 +4159,7 @@
     },
     "packages/thunderbird": {
       "name": "@inbox-rs/thunderbird",
-      "version": "1.4.1",
+      "version": "1.6.2",
       "dependencies": {
         "@inbox-rs/rs-module": "*"
       },
@@ -3336,6 +4168,23 @@
         "svelte": "^5.0.0",
         "typescript": "^5.4.0",
         "vite": "^6.0.0"
+      }
+    },
+    "packages/thunderbird/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/thunderbird/node_modules/@sveltejs/vite-plugin-svelte": {
@@ -3497,16 +4346,23 @@
     },
     "packages/web": {
       "name": "@inbox-rs/web",
-      "version": "1.4.1",
+      "version": "1.6.2",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/extension-code-block-lowlight": "^3.22.1",
+        "@tiptap/pm": "^3.22.1",
+        "@tiptap/starter-kit": "^3.22.1",
         "@xenova/transformers": "^2.17.2",
         "fflate": "^0.8.2",
         "highlight.js": "^11.11.1",
+        "lowlight": "^3.3.0",
+        "marked": "^17.0.5",
         "onnxruntime-web": "^1.14.0",
         "remotestorage-module-shares": "^2.1.4",
         "remotestoragejs": "^2.0.0-beta.8",
-        "svelte-dnd-action": "^0.9.69"
+        "svelte-dnd-action": "^0.9.69",
+        "tiptap-markdown": "^0.9.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
@@ -3515,6 +4371,23 @@
         "typescript": "^5.4.0",
         "vite": "^6.0.0",
         "vitest": "^4.1.2"
+      }
+    },
+    "packages/web/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/web/node_modules/@sveltejs/vite-plugin-svelte": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2035,6 +2035,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "license": "MIT",
@@ -4354,6 +4363,7 @@
         "@tiptap/pm": "^3.22.1",
         "@tiptap/starter-kit": "^3.22.1",
         "@xenova/transformers": "^2.17.2",
+        "dompurify": "^3.2.7",
         "fflate": "^0.8.2",
         "highlight.js": "^11.11.1",
         "lowlight": "^3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1111,14 +1111,16 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.22.1",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.3.tgz",
+      "integrity": "sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.22.1"
+        "@tiptap/pm": "^3.22.3"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
@@ -1341,6 +1343,19 @@
         "@tiptap/core": "^3.22.1"
       }
     },
+    "node_modules/@tiptap/extension-placeholder": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.22.3.tgz",
+      "integrity": "sha512-7vbtlDVO00odqCnsMSmA4b6wjL5PFdfExFsdsDO0K0VemqHZ/doIRx/tosNUD1VYSOyKQd8U7efUjkFyVoIPlg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.22.3"
+      }
+    },
     "node_modules/@tiptap/extension-strike": {
       "version": "3.22.1",
       "license": "MIT",
@@ -1375,19 +1390,23 @@
       }
     },
     "node_modules/@tiptap/extensions": {
-      "version": "3.22.1",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.3.tgz",
+      "integrity": "sha512-s5eiMq0m5N6N+W7dU6rd60KgZyyCD7FvtPNNswISfPr12EQwJBfbjWwTqd0UKNzA4fNrhQEERXnzORkykttPeA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.1",
-        "@tiptap/pm": "^3.22.1"
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/pm": "^3.22.3"
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.22.1",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.3.tgz",
+      "integrity": "sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
@@ -4360,6 +4379,7 @@
         "@inbox-rs/rs-module": "*",
         "@tiptap/core": "^3.22.1",
         "@tiptap/extension-code-block-lowlight": "^3.22.1",
+        "@tiptap/extension-placeholder": "^3.22.1",
         "@tiptap/pm": "^3.22.1",
         "@tiptap/starter-kit": "^3.22.1",
         "@xenova/transformers": "^2.17.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,13 +13,20 @@
   },
   "dependencies": {
     "@inbox-rs/rs-module": "*",
+    "@tiptap/core": "^3.22.1",
+    "@tiptap/extension-code-block-lowlight": "^3.22.1",
+    "@tiptap/pm": "^3.22.1",
+    "@tiptap/starter-kit": "^3.22.1",
     "@xenova/transformers": "^2.17.2",
     "fflate": "^0.8.2",
     "highlight.js": "^11.11.1",
+    "lowlight": "^3.3.0",
+    "marked": "^17.0.5",
     "onnxruntime-web": "^1.14.0",
     "remotestorage-module-shares": "^2.1.4",
     "remotestoragejs": "^2.0.0-beta.8",
-    "svelte-dnd-action": "^0.9.69"
+    "svelte-dnd-action": "^0.9.69",
+    "tiptap-markdown": "^0.9.0"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^5.0.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -18,6 +18,7 @@
     "@tiptap/pm": "^3.22.1",
     "@tiptap/starter-kit": "^3.22.1",
     "@xenova/transformers": "^2.17.2",
+    "dompurify": "^3.2.7",
     "fflate": "^0.8.2",
     "highlight.js": "^11.11.1",
     "lowlight": "^3.3.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -15,6 +15,7 @@
     "@inbox-rs/rs-module": "*",
     "@tiptap/core": "^3.22.1",
     "@tiptap/extension-code-block-lowlight": "^3.22.1",
+    "@tiptap/extension-placeholder": "^3.22.1",
     "@tiptap/pm": "^3.22.1",
     "@tiptap/starter-kit": "^3.22.1",
     "@xenova/transformers": "^2.17.2",

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+  import type { Component } from 'svelte';
   import { onDestroy } from 'svelte';
   import type { InboxItemType, InboxItem } from '@inbox-rs/rs-module';
   import { storeItem, moveItemToCollection } from '../lib/stores';
   import { transcribeAudio } from '../lib/transcribe';
-  import MarkdownEditor from './MarkdownEditor.svelte';
+  import { loadMarkdownEditorComponent, shouldSubmitAddEntryForm } from '../lib/add-entry-modal';
 
   let { type, editItem = undefined, collectionId = undefined, onclose, ondelete }: {
     type: InboxItemType;
@@ -29,6 +30,8 @@
 
   // Markdown editor mode for notes
   let editorMode = $state<'visual' | 'write' | 'preview'>('visual');
+  let MarkdownEditorComponent = $state<Component<any> | null>(null);
+  let markdownEditorLoadError = $state('');
 
   // Voice recording state
   let recording = $state(false);
@@ -289,6 +292,32 @@
     if (recordedUrl) URL.revokeObjectURL(recordedUrl);
   });
 
+  $effect(() => {
+    if (type !== 'note' || MarkdownEditorComponent || markdownEditorLoadError) {
+      return;
+    }
+
+    let cancelled = false;
+
+    loadMarkdownEditorComponent()
+      .then((component) => {
+        if (!cancelled) {
+          MarkdownEditorComponent = component;
+        }
+      })
+      .catch((loadError) => {
+        console.error('Failed to load markdown editor:', loadError);
+        if (!cancelled) {
+          markdownEditorLoadError = 'Visual editor unavailable. Markdown mode is still available.';
+          editorMode = 'write';
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  });
+
   const needsFile = $derived(type === 'image' || type === 'document');
   const canSubmit = $derived(
     saving || recording ? false
@@ -308,7 +337,7 @@
     <h2 class="modal-title" id="modal-title">{isEdit ? editLabels[type] : addLabels[type]}</h2>
 
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="form" onkeydown={(e) => { if (e.key === 'Enter' && e.target instanceof HTMLInputElement && e.target.type === 'text' && canSubmit) { e.preventDefault(); handleSubmit(); } }}>
+    <div class="form" onkeydown={(e) => { if (shouldSubmitAddEntryForm(e.key, e.target, canSubmit)) { e.preventDefault(); handleSubmit(); } }}>
       {#if type === 'bookmark'}
         <p class="info-note">Metadata fetching is not yet available in the web app. Use the browser extension to auto-fill bookmark details. Sockethub integration is planned for a future release.</p>
         <label class="field">
@@ -333,13 +362,28 @@
           <div class="field-header">
             <span>Content *</span>
             <div class="editor-tabs">
-              <button type="button" class="tab" class:active={editorMode === 'visual'} onclick={() => editorMode = 'visual'}>Visual</button>
+              <button type="button" class="tab" class:active={editorMode === 'visual'} onclick={() => editorMode = 'visual'} disabled={!!markdownEditorLoadError}>Visual</button>
               <button type="button" class="tab" class:active={editorMode === 'write'} onclick={() => editorMode = 'write'}>Markdown</button>
-              <button type="button" class="tab" class:active={editorMode === 'preview'} onclick={() => editorMode = 'preview'}>Preview</button>
+              <button type="button" class="tab" class:active={editorMode === 'preview'} onclick={() => editorMode = 'preview'} disabled={!!markdownEditorLoadError}>Preview</button>
             </div>
           </div>
-          <MarkdownEditor bind:value={body} bind:mode={editorMode} placeholder="Write your note..." />
+          {#if MarkdownEditorComponent}
+            <MarkdownEditorComponent bind:value={body} bind:mode={editorMode} placeholder="Write your note..." />
+          {:else if markdownEditorLoadError}
+            <textarea
+              use:autofocus
+              class="code-input"
+              bind:value={body}
+              rows="10"
+              placeholder="Write your note in Markdown..."
+            ></textarea>
+          {:else}
+            <div class="editor-loading" aria-live="polite">Loading visual editor…</div>
+          {/if}
         </div>
+        {#if markdownEditorLoadError}
+          <p class="info-note">{markdownEditorLoadError}</p>
+        {/if}
 
       {:else if type === 'image'}
         <label class="field">
@@ -602,6 +646,18 @@
     font-size: 0.8rem;
     line-height: 1.5;
     tab-size: 2;
+  }
+
+  .editor-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 14rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    font-size: 0.85rem;
   }
 
   .actions {

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -3,6 +3,7 @@
   import type { InboxItemType, InboxItem } from '@inbox-rs/rs-module';
   import { storeItem, moveItemToCollection } from '../lib/stores';
   import { transcribeAudio } from '../lib/transcribe';
+  import MarkdownEditor from './MarkdownEditor.svelte';
 
   let { type, editItem = undefined, collectionId = undefined, onclose, ondelete }: {
     type: InboxItemType;
@@ -25,6 +26,9 @@
   let from = $state(editItem && 'from' in editItem ? editItem.from ?? '' : '');
   let notes = $state(editItem && 'notes' in editItem ? editItem.notes ?? '' : '');
   let file = $state<File | null>(null);
+
+  // Markdown editor mode for notes
+  let editorMode = $state<'visual' | 'write' | 'preview'>('visual');
 
   // Voice recording state
   let recording = $state(false);
@@ -300,11 +304,11 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="overlay" onclick={onclose}>
-  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" onclick={(e) => e.stopPropagation()}>
+  <div class="modal" class:modal-note={type === 'note'} role="dialog" aria-modal="true" aria-labelledby="modal-title" onclick={(e) => e.stopPropagation()}>
     <h2 class="modal-title" id="modal-title">{isEdit ? editLabels[type] : addLabels[type]}</h2>
 
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="form" onkeydown={(e) => { if (e.key === 'Enter' && !(e.target instanceof HTMLTextAreaElement) && canSubmit) { e.preventDefault(); handleSubmit(); } }}>
+    <div class="form" onkeydown={(e) => { if (e.key === 'Enter' && !(e.target instanceof HTMLTextAreaElement) && !(e.target as HTMLElement)?.closest?.('.tiptap-editor') && canSubmit) { e.preventDefault(); handleSubmit(); } }}>
       {#if type === 'bookmark'}
         <p class="info-note">Metadata fetching is not yet available in the web app. Use the browser extension to auto-fill bookmark details. Sockethub integration is planned for a future release.</p>
         <label class="field">
@@ -325,10 +329,17 @@
           <span>Title</span>
           <input type="text" bind:value={title} placeholder="Note title" />
         </label>
-        <label class="field">
-          <span>Content *</span>
-          <textarea use:autofocus bind:value={body} rows="6" placeholder="Write your note..."></textarea>
-        </label>
+        <div class="field note-editor-field">
+          <div class="field-header">
+            <span>Content *</span>
+            <div class="editor-tabs">
+              <button type="button" class="tab" class:active={editorMode === 'visual'} onclick={() => editorMode = 'visual'}>Visual</button>
+              <button type="button" class="tab" class:active={editorMode === 'write'} onclick={() => editorMode = 'write'}>Markdown</button>
+              <button type="button" class="tab" class:active={editorMode === 'preview'} onclick={() => editorMode = 'preview'}>Preview</button>
+            </div>
+          </div>
+          <MarkdownEditor bind:value={body} bind:mode={editorMode} placeholder="Write your note..." />
+        </div>
 
       {:else if type === 'image'}
         <label class="field">
@@ -506,6 +517,22 @@
       border: none;
       border-radius: 0;
     }
+  }
+
+  .modal-note {
+    max-width: 720px;
+    height: 85vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .modal-note .form {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
   }
 
   .modal-title {
@@ -769,5 +796,44 @@
     padding: 0.5rem 0.75rem;
     white-space: pre-wrap;
     margin: 0;
+  }
+
+  .field-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .editor-tabs {
+    display: flex;
+    gap: 0.25rem;
+  }
+
+  .tab {
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    padding: 0.15rem 0.5rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.7rem;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+  }
+
+  .tab:hover {
+    color: var(--text);
+    border-color: var(--text-muted);
+  }
+
+  .tab.active {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+
+  .note-editor-field {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
   }
 </style>

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -3,8 +3,9 @@
   import { onDestroy } from 'svelte';
   import type { InboxItemType, InboxItem } from '@inbox-rs/rs-module';
   import { storeItem, moveItemToCollection } from '../lib/stores';
+  import { renderMarkdown } from '../lib/markdown';
   import { transcribeAudio } from '../lib/transcribe';
-  import { loadMarkdownEditorComponent, shouldSubmitAddEntryForm } from '../lib/add-entry-modal';
+  import { loadMarkdownEditorComponent, shouldLoadMarkdownEditor, shouldSubmitAddEntryForm } from '../lib/add-entry-modal';
 
   let { type, editItem = undefined, collectionId = undefined, onclose, ondelete }: {
     type: InboxItemType;
@@ -32,6 +33,7 @@
   let editorMode = $state<'visual' | 'write' | 'preview'>('visual');
   let MarkdownEditorComponent = $state<Component<any> | null>(null);
   let markdownEditorLoadError = $state('');
+  let previewHtml = $state('');
 
   // Voice recording state
   let recording = $state(false);
@@ -293,7 +295,7 @@
   });
 
   $effect(() => {
-    if (type !== 'note' || MarkdownEditorComponent || markdownEditorLoadError) {
+    if (!shouldLoadMarkdownEditor(type, editorMode, !!MarkdownEditorComponent, !!markdownEditorLoadError)) {
       return;
     }
 
@@ -310,6 +312,32 @@
         if (!cancelled) {
           markdownEditorLoadError = 'Visual editor unavailable. Markdown mode is still available.';
           editorMode = 'write';
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  $effect(() => {
+    if (type !== 'note' || editorMode !== 'preview') {
+      previewHtml = '';
+      return;
+    }
+
+    const currentBody = body;
+    let cancelled = false;
+
+    renderMarkdown(currentBody)
+      .then((html) => {
+        if (!cancelled && body === currentBody && editorMode === 'preview') {
+          previewHtml = html;
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          previewHtml = '';
         }
       });
 
@@ -364,12 +392,24 @@
             <div class="editor-tabs">
               <button type="button" class="tab" class:active={editorMode === 'visual'} onclick={() => editorMode = 'visual'} disabled={!!markdownEditorLoadError}>Visual</button>
               <button type="button" class="tab" class:active={editorMode === 'write'} onclick={() => editorMode = 'write'}>Markdown</button>
-              <button type="button" class="tab" class:active={editorMode === 'preview'} onclick={() => editorMode = 'preview'} disabled={!!markdownEditorLoadError}>Preview</button>
+              <button type="button" class="tab" class:active={editorMode === 'preview'} onclick={() => editorMode = 'preview'}>Preview</button>
             </div>
           </div>
-          {#if MarkdownEditorComponent}
-            <MarkdownEditorComponent bind:value={body} bind:mode={editorMode} placeholder="Write your note..." />
-          {:else if markdownEditorLoadError}
+          {#if editorMode === 'visual'}
+            {#if MarkdownEditorComponent}
+              <MarkdownEditorComponent bind:value={body} placeholder="Write your note..." />
+            {:else if markdownEditorLoadError}
+              <textarea
+                use:autofocus
+                class="code-input"
+                bind:value={body}
+                rows="10"
+                placeholder="Write your note in Markdown..."
+              ></textarea>
+            {:else}
+              <div class="editor-loading" aria-live="polite">Loading visual editor…</div>
+            {/if}
+          {:else if editorMode === 'write'}
             <textarea
               use:autofocus
               class="code-input"
@@ -378,7 +418,15 @@
               placeholder="Write your note in Markdown..."
             ></textarea>
           {:else}
-            <div class="editor-loading" aria-live="polite">Loading visual editor…</div>
+            <div class="preview-wrap markdown-body">
+              {#if previewHtml}
+                {@html previewHtml}
+              {:else if body.trim()}
+                <span class="preview-empty">Preview unavailable</span>
+              {:else}
+                <span class="preview-empty">Nothing to preview</span>
+              {/if}
+            </div>
           {/if}
         </div>
         {#if markdownEditorLoadError}
@@ -660,6 +708,22 @@
     font-size: 0.85rem;
   }
 
+  .preview-wrap {
+    flex: 1;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.75rem;
+    overflow-y: auto;
+    min-height: 0;
+  }
+
+  .preview-empty {
+    color: var(--text-muted);
+    font-style: italic;
+    font-size: 0.85rem;
+  }
+
   .actions {
     display: flex;
     justify-content: flex-end;
@@ -892,4 +956,58 @@
     flex-direction: column;
     min-height: 0;
   }
+
+  .markdown-body {
+    font-size: 0.9rem;
+    color: var(--text);
+    line-height: 1.6;
+    word-break: break-word;
+  }
+
+  .markdown-body :global(h1) { font-size: 1.3rem; font-weight: 600; margin: 0.75rem 0 0.4rem; }
+  .markdown-body :global(h2) { font-size: 1.15rem; font-weight: 600; margin: 0.6rem 0 0.35rem; }
+  .markdown-body :global(h3) { font-size: 1.05rem; font-weight: 600; margin: 0.5rem 0 0.3rem; }
+  .markdown-body :global(p) { margin: 0 0 0.5rem; }
+  .markdown-body :global(p:last-child) { margin-bottom: 0; }
+  .markdown-body :global(ul),
+  .markdown-body :global(ol) { padding-left: 1.5rem; margin: 0 0 0.5rem; }
+  .markdown-body :global(ul) { list-style: disc; }
+  .markdown-body :global(ol) { list-style: decimal; }
+  .markdown-body :global(li) { margin-bottom: 0.15rem; }
+  .markdown-body :global(blockquote) {
+    border-left: 3px solid var(--accent);
+    padding-left: 0.75rem;
+    margin: 0 0 0.5rem;
+    color: var(--text-muted);
+  }
+  .markdown-body :global(a) { color: var(--accent); text-decoration: none; }
+  .markdown-body :global(a:hover) { text-decoration: underline; }
+  .markdown-body :global(code) {
+    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+    background: rgba(255, 255, 255, 0.06);
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+    font-size: 0.82rem;
+  }
+  .markdown-body :global(pre) {
+    background: #0d1117;
+    border-radius: var(--radius-sm);
+    padding: 0.75rem;
+    margin: 0 0 0.5rem;
+    overflow-x: auto;
+  }
+  .markdown-body :global(pre code) {
+    background: none;
+    padding: 0;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: #e6edf3;
+  }
+  .markdown-body :global(hr) {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 0.75rem 0;
+  }
+  .markdown-body :global(strong) { font-weight: 600; }
+  .markdown-body :global(em) { font-style: italic; }
 </style>

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -308,7 +308,7 @@
     <h2 class="modal-title" id="modal-title">{isEdit ? editLabels[type] : addLabels[type]}</h2>
 
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="form" onkeydown={(e) => { if (e.key === 'Enter' && !(e.target instanceof HTMLTextAreaElement) && !(e.target as HTMLElement)?.closest?.('.tiptap-editor') && canSubmit) { e.preventDefault(); handleSubmit(); } }}>
+    <div class="form" onkeydown={(e) => { if (e.key === 'Enter' && e.target instanceof HTMLInputElement && e.target.type === 'text' && canSubmit) { e.preventDefault(); handleSubmit(); } }}>
       {#if type === 'bookmark'}
         <p class="info-note">Metadata fetching is not yet available in the web app. Use the browser extension to auto-fill bookmark details. Sockethub integration is planned for a future release.</p>
         <label class="field">

--- a/packages/web/src/components/MarkdownEditor.svelte
+++ b/packages/web/src/components/MarkdownEditor.svelte
@@ -4,22 +4,20 @@
   import StarterKit from '@tiptap/starter-kit';
   import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
   import { Markdown } from 'tiptap-markdown';
+  import Placeholder from '@tiptap/extension-placeholder';
   import { common, createLowlight } from 'lowlight';
   import 'highlight.js/styles/github-dark.min.css';
 
   let {
     value = $bindable(''),
-    mode = $bindable<'visual' | 'write' | 'preview'>('visual'),
     placeholder = 'Write your note...',
   }: {
     value: string;
-    mode: 'visual' | 'write' | 'preview';
     placeholder?: string;
   } = $props();
 
   let editorElement = $state<HTMLDivElement>(undefined!);
   let editor: Editor | null = null;
-  let previewHtml = $state('');
 
   const lowlight = createLowlight(common);
 
@@ -39,6 +37,9 @@
           tightLists: true,
           transformPastedText: true,
         }),
+        Placeholder.configure({
+          placeholder,
+        }),
       ],
       content: value,
       onUpdate: ({ editor: e }) => {
@@ -56,45 +57,21 @@
     editor?.destroy();
   });
 
-  // Sync mode changes - when switching to visual, update editor content
+  // Keep the visual editor in sync with external markdown updates.
   $effect(() => {
-    if (mode === 'visual' && editor) {
-      const currentMd = editor.storage.markdown.getMarkdown();
-      if (currentMd !== value) {
-        editor.commands.setContent(value);
-      }
+    if (!editor) {
+      return;
     }
-    if (mode === 'preview') {
-      import('../lib/markdown')
-        .then(({ renderMarkdown }) => renderMarkdown(value))
-        .then((html) => { previewHtml = html; })
-        .catch(() => { previewHtml = ''; });
+
+    const currentMd = editor.storage.markdown.getMarkdown();
+    if (currentMd !== value) {
+      editor.commands.setContent(value);
     }
   });
-
-  function handleTextareaInput(e: Event) {
-    value = (e.target as HTMLTextAreaElement).value;
-  }
 </script>
 
 <div class="editor-container">
-  <div class="tiptap-wrap" class:hidden={mode !== 'visual'} bind:this={editorElement}></div>
-  {#if mode === 'write'}
-    <textarea
-      class="raw-textarea"
-      {placeholder}
-      oninput={handleTextareaInput}
-      value={value}
-    ></textarea>
-  {:else if mode === 'preview'}
-    <div class="preview-wrap markdown-body">
-      {#if previewHtml}
-        {@html previewHtml}
-      {:else}
-        <span class="preview-empty">Nothing to preview</span>
-      {/if}
-    </div>
-  {/if}
+  <div class="tiptap-wrap" bind:this={editorElement}></div>
 </div>
 
 <style>
@@ -114,10 +91,6 @@
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     overflow-y: auto;
-  }
-
-  .tiptap-wrap.hidden {
-    display: none;
   }
 
   .tiptap-wrap :global(.tiptap-editor) {
@@ -210,94 +183,4 @@
   /* Paragraph spacing */
   .tiptap-wrap :global(p) { margin: 0 0 0.4rem; }
   .tiptap-wrap :global(p:last-child) { margin-bottom: 0; }
-
-  /* Raw textarea mode */
-  .raw-textarea {
-    flex: 1;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    padding: 0.75rem;
-    font-size: 0.85rem;
-    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
-    color: var(--text);
-    resize: none;
-    line-height: 1.6;
-    min-height: 0;
-  }
-  .raw-textarea:focus {
-    outline: none;
-    border-color: var(--accent);
-  }
-
-  /* Preview mode */
-  .preview-wrap {
-    flex: 1;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    padding: 0.75rem;
-    overflow-y: auto;
-    min-height: 0;
-  }
-
-  .preview-empty {
-    color: var(--text-muted);
-    font-style: italic;
-    font-size: 0.85rem;
-  }
-
-  /* Markdown body styles for preview */
-  .markdown-body {
-    font-size: 0.9rem;
-    color: var(--text);
-    line-height: 1.6;
-    word-break: break-word;
-  }
-  .markdown-body :global(h1) { font-size: 1.3rem; font-weight: 600; margin: 0.75rem 0 0.4rem; }
-  .markdown-body :global(h2) { font-size: 1.15rem; font-weight: 600; margin: 0.6rem 0 0.35rem; }
-  .markdown-body :global(h3) { font-size: 1.05rem; font-weight: 600; margin: 0.5rem 0 0.3rem; }
-  .markdown-body :global(p) { margin: 0 0 0.5rem; }
-  .markdown-body :global(p:last-child) { margin-bottom: 0; }
-  .markdown-body :global(ul),
-  .markdown-body :global(ol) { padding-left: 1.5rem; margin: 0 0 0.5rem; }
-  .markdown-body :global(ul) { list-style: disc; }
-  .markdown-body :global(ol) { list-style: decimal; }
-  .markdown-body :global(li) { margin-bottom: 0.15rem; }
-  .markdown-body :global(blockquote) {
-    border-left: 3px solid var(--accent);
-    padding-left: 0.75rem;
-    margin: 0 0 0.5rem;
-    color: var(--text-muted);
-  }
-  .markdown-body :global(a) { color: var(--accent); text-decoration: none; }
-  .markdown-body :global(a:hover) { text-decoration: underline; }
-  .markdown-body :global(code) {
-    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
-    background: rgba(255, 255, 255, 0.06);
-    padding: 0.1rem 0.3rem;
-    border-radius: 3px;
-    font-size: 0.82rem;
-  }
-  .markdown-body :global(pre) {
-    background: #0d1117;
-    border-radius: var(--radius-sm);
-    padding: 0.75rem;
-    margin: 0 0 0.5rem;
-    overflow-x: auto;
-  }
-  .markdown-body :global(pre code) {
-    background: none;
-    padding: 0;
-    font-size: 0.8rem;
-    line-height: 1.5;
-    color: #e6edf3;
-  }
-  .markdown-body :global(hr) {
-    border: none;
-    border-top: 1px solid var(--border);
-    margin: 0.75rem 0;
-  }
-  .markdown-body :global(strong) { font-weight: 600; }
-  .markdown-body :global(em) { font-style: italic; }
 </style>

--- a/packages/web/src/components/MarkdownEditor.svelte
+++ b/packages/web/src/components/MarkdownEditor.svelte
@@ -1,0 +1,336 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { Editor } from '@tiptap/core';
+  import StarterKit from '@tiptap/starter-kit';
+  import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+  import { Markdown } from 'tiptap-markdown';
+  import { createLowlight } from 'lowlight';
+  import 'highlight.js/styles/github-dark.min.css';
+
+  // Import languages for code block highlighting
+  import javascript from 'highlight.js/lib/languages/javascript';
+  import typescript from 'highlight.js/lib/languages/typescript';
+  import python from 'highlight.js/lib/languages/python';
+  import rust from 'highlight.js/lib/languages/rust';
+  import go from 'highlight.js/lib/languages/go';
+  import bash from 'highlight.js/lib/languages/bash';
+  import shell from 'highlight.js/lib/languages/shell';
+  import json from 'highlight.js/lib/languages/json';
+  import xml from 'highlight.js/lib/languages/xml';
+  import css from 'highlight.js/lib/languages/css';
+  import sql from 'highlight.js/lib/languages/sql';
+  import java from 'highlight.js/lib/languages/java';
+  import yaml from 'highlight.js/lib/languages/yaml';
+
+  let {
+    value = $bindable(''),
+    mode = $bindable<'visual' | 'write' | 'preview'>('visual'),
+    placeholder = 'Write your note...',
+  }: {
+    value: string;
+    mode: 'visual' | 'write' | 'preview';
+    placeholder?: string;
+  } = $props();
+
+  let editorElement = $state<HTMLDivElement>(undefined!);
+  let editor: Editor | null = null;
+  let previewHtml = $state('');
+
+  const lowlight = createLowlight();
+  lowlight.register('javascript', javascript);
+  lowlight.register('js', javascript);
+  lowlight.register('typescript', typescript);
+  lowlight.register('ts', typescript);
+  lowlight.register('python', python);
+  lowlight.register('py', python);
+  lowlight.register('rust', rust);
+  lowlight.register('go', go);
+  lowlight.register('bash', bash);
+  lowlight.register('sh', bash);
+  lowlight.register('shell', shell);
+  lowlight.register('json', json);
+  lowlight.register('html', xml);
+  lowlight.register('xml', xml);
+  lowlight.register('css', css);
+  lowlight.register('sql', sql);
+  lowlight.register('java', java);
+  lowlight.register('yaml', yaml);
+  lowlight.register('yml', yaml);
+
+  onMount(() => {
+    editor = new Editor({
+      element: editorElement,
+      extensions: [
+        StarterKit.configure({
+          codeBlock: false,
+        }),
+        CodeBlockLowlight.configure({
+          lowlight,
+        }),
+        Markdown.configure({
+          html: false,
+          breaks: true,
+          tightLists: true,
+          transformPastedText: true,
+        }),
+      ],
+      content: value,
+      onUpdate: ({ editor: e }) => {
+        value = e.storage.markdown.getMarkdown();
+      },
+      editorProps: {
+        attributes: {
+          class: 'tiptap-editor',
+        },
+      },
+    });
+  });
+
+  onDestroy(() => {
+    editor?.destroy();
+  });
+
+  // Sync mode changes - when switching to visual, update editor content
+  $effect(() => {
+    if (mode === 'visual' && editor) {
+      const currentMd = editor.storage.markdown.getMarkdown();
+      if (currentMd !== value) {
+        editor.commands.setContent(value);
+      }
+    }
+    if (mode === 'preview') {
+      import('../lib/markdown').then(({ renderMarkdown }) => {
+        renderMarkdown(value).then((html) => { previewHtml = html; });
+      });
+    }
+  });
+
+  function handleTextareaInput(e: Event) {
+    value = (e.target as HTMLTextAreaElement).value;
+  }
+</script>
+
+<div class="editor-container">
+  <div class="tiptap-wrap" class:hidden={mode !== 'visual'} bind:this={editorElement}></div>
+  {#if mode === 'write'}
+    <textarea
+      class="raw-textarea"
+      {placeholder}
+      oninput={handleTextareaInput}
+      value={value}
+    ></textarea>
+  {:else if mode === 'preview'}
+    <div class="preview-wrap markdown-body">
+      {#if previewHtml}
+        {@html previewHtml}
+      {:else}
+        <span class="preview-empty">Nothing to preview</span>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .editor-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .tiptap-wrap {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    overflow-y: auto;
+  }
+
+  .tiptap-wrap.hidden {
+    display: none;
+  }
+
+  .tiptap-wrap :global(.tiptap-editor) {
+    flex: 1;
+    padding: 0.75rem;
+    outline: none;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: var(--text);
+    min-height: 100%;
+  }
+
+  .tiptap-wrap:focus-within {
+    border-color: var(--accent);
+  }
+
+  .tiptap-wrap :global(.tiptap-editor p.is-editor-empty:first-child::before) {
+    content: attr(data-placeholder);
+    color: var(--text-muted);
+    opacity: 0.5;
+    pointer-events: none;
+    float: left;
+    height: 0;
+  }
+
+  /* Headings */
+  .tiptap-wrap :global(h1) { font-size: 1.3rem; font-weight: 600; margin: 0.75rem 0 0.4rem; }
+  .tiptap-wrap :global(h2) { font-size: 1.15rem; font-weight: 600; margin: 0.6rem 0 0.35rem; }
+  .tiptap-wrap :global(h3) { font-size: 1.05rem; font-weight: 600; margin: 0.5rem 0 0.3rem; }
+  .tiptap-wrap :global(h4),
+  .tiptap-wrap :global(h5),
+  .tiptap-wrap :global(h6) { font-size: 0.95rem; font-weight: 600; margin: 0.4rem 0 0.25rem; }
+
+  /* Lists */
+  .tiptap-wrap :global(ul),
+  .tiptap-wrap :global(ol) {
+    padding-left: 1.5rem;
+    margin: 0.25rem 0;
+  }
+  .tiptap-wrap :global(ul) { list-style: disc; }
+  .tiptap-wrap :global(ol) { list-style: decimal; }
+  .tiptap-wrap :global(li) { margin-bottom: 0.1rem; }
+  .tiptap-wrap :global(li p) { margin: 0; }
+
+  /* Blockquote */
+  .tiptap-wrap :global(blockquote) {
+    border-left: 3px solid var(--accent);
+    padding-left: 0.75rem;
+    margin: 0.4rem 0;
+    color: var(--text-muted);
+  }
+  .tiptap-wrap :global(blockquote p) { margin: 0; }
+
+  /* Inline code */
+  .tiptap-wrap :global(code) {
+    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+    background: rgba(255, 255, 255, 0.06);
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+    font-size: 0.82rem;
+  }
+
+  /* Code blocks */
+  .tiptap-wrap :global(pre) {
+    background: #0d1117;
+    border-radius: var(--radius-sm);
+    padding: 0.75rem;
+    margin: 0.4rem 0;
+    overflow-x: auto;
+  }
+  .tiptap-wrap :global(pre code) {
+    background: none;
+    padding: 0;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: #e6edf3;
+  }
+
+  /* Horizontal rule */
+  .tiptap-wrap :global(hr) {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 0.75rem 0;
+  }
+
+  /* Strong & em */
+  .tiptap-wrap :global(strong) { font-weight: 600; }
+  .tiptap-wrap :global(em) { font-style: italic; }
+
+  /* Paragraph spacing */
+  .tiptap-wrap :global(p) { margin: 0 0 0.4rem; }
+  .tiptap-wrap :global(p:last-child) { margin-bottom: 0; }
+
+  /* Raw textarea mode */
+  .raw-textarea {
+    flex: 1;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.75rem;
+    font-size: 0.85rem;
+    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+    color: var(--text);
+    resize: none;
+    line-height: 1.6;
+    min-height: 0;
+  }
+  .raw-textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+
+  /* Preview mode */
+  .preview-wrap {
+    flex: 1;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.75rem;
+    overflow-y: auto;
+    min-height: 0;
+  }
+
+  .preview-empty {
+    color: var(--text-muted);
+    font-style: italic;
+    font-size: 0.85rem;
+  }
+
+  /* Markdown body styles for preview */
+  .markdown-body {
+    font-size: 0.9rem;
+    color: var(--text);
+    line-height: 1.6;
+    word-break: break-word;
+  }
+  .markdown-body :global(h1) { font-size: 1.3rem; font-weight: 600; margin: 0.75rem 0 0.4rem; }
+  .markdown-body :global(h2) { font-size: 1.15rem; font-weight: 600; margin: 0.6rem 0 0.35rem; }
+  .markdown-body :global(h3) { font-size: 1.05rem; font-weight: 600; margin: 0.5rem 0 0.3rem; }
+  .markdown-body :global(p) { margin: 0 0 0.5rem; }
+  .markdown-body :global(p:last-child) { margin-bottom: 0; }
+  .markdown-body :global(ul),
+  .markdown-body :global(ol) { padding-left: 1.5rem; margin: 0 0 0.5rem; }
+  .markdown-body :global(ul) { list-style: disc; }
+  .markdown-body :global(ol) { list-style: decimal; }
+  .markdown-body :global(li) { margin-bottom: 0.15rem; }
+  .markdown-body :global(blockquote) {
+    border-left: 3px solid var(--accent);
+    padding-left: 0.75rem;
+    margin: 0 0 0.5rem;
+    color: var(--text-muted);
+  }
+  .markdown-body :global(a) { color: var(--accent); text-decoration: none; }
+  .markdown-body :global(a:hover) { text-decoration: underline; }
+  .markdown-body :global(code) {
+    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+    background: rgba(255, 255, 255, 0.06);
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+    font-size: 0.82rem;
+  }
+  .markdown-body :global(pre) {
+    background: #0d1117;
+    border-radius: var(--radius-sm);
+    padding: 0.75rem;
+    margin: 0 0 0.5rem;
+    overflow-x: auto;
+  }
+  .markdown-body :global(pre code) {
+    background: none;
+    padding: 0;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: #e6edf3;
+  }
+  .markdown-body :global(hr) {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 0.75rem 0;
+  }
+  .markdown-body :global(strong) { font-weight: 600; }
+  .markdown-body :global(em) { font-style: italic; }
+</style>

--- a/packages/web/src/components/MarkdownEditor.svelte
+++ b/packages/web/src/components/MarkdownEditor.svelte
@@ -4,23 +4,8 @@
   import StarterKit from '@tiptap/starter-kit';
   import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
   import { Markdown } from 'tiptap-markdown';
-  import { createLowlight } from 'lowlight';
+  import { common, createLowlight } from 'lowlight';
   import 'highlight.js/styles/github-dark.min.css';
-
-  // Import languages for code block highlighting
-  import javascript from 'highlight.js/lib/languages/javascript';
-  import typescript from 'highlight.js/lib/languages/typescript';
-  import python from 'highlight.js/lib/languages/python';
-  import rust from 'highlight.js/lib/languages/rust';
-  import go from 'highlight.js/lib/languages/go';
-  import bash from 'highlight.js/lib/languages/bash';
-  import shell from 'highlight.js/lib/languages/shell';
-  import json from 'highlight.js/lib/languages/json';
-  import xml from 'highlight.js/lib/languages/xml';
-  import css from 'highlight.js/lib/languages/css';
-  import sql from 'highlight.js/lib/languages/sql';
-  import java from 'highlight.js/lib/languages/java';
-  import yaml from 'highlight.js/lib/languages/yaml';
 
   let {
     value = $bindable(''),
@@ -36,26 +21,7 @@
   let editor: Editor | null = null;
   let previewHtml = $state('');
 
-  const lowlight = createLowlight();
-  lowlight.register('javascript', javascript);
-  lowlight.register('js', javascript);
-  lowlight.register('typescript', typescript);
-  lowlight.register('ts', typescript);
-  lowlight.register('python', python);
-  lowlight.register('py', python);
-  lowlight.register('rust', rust);
-  lowlight.register('go', go);
-  lowlight.register('bash', bash);
-  lowlight.register('sh', bash);
-  lowlight.register('shell', shell);
-  lowlight.register('json', json);
-  lowlight.register('html', xml);
-  lowlight.register('xml', xml);
-  lowlight.register('css', css);
-  lowlight.register('sql', sql);
-  lowlight.register('java', java);
-  lowlight.register('yaml', yaml);
-  lowlight.register('yml', yaml);
+  const lowlight = createLowlight(common);
 
   onMount(() => {
     editor = new Editor({
@@ -99,9 +65,10 @@
       }
     }
     if (mode === 'preview') {
-      import('../lib/markdown').then(({ renderMarkdown }) => {
-        renderMarkdown(value).then((html) => { previewHtml = html; });
-      });
+      import('../lib/markdown')
+        .then(({ renderMarkdown }) => renderMarkdown(value))
+        .then((html) => { previewHtml = html; })
+        .catch(() => { previewHtml = ''; });
     }
   });
 

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -8,39 +8,7 @@
   import DeleteConfirm from './DeleteConfirm.svelte';
   import hljs from 'highlight.js/lib/core';
   import 'highlight.js/styles/github-dark.min.css';
-
-  const langModules: Record<string, () => Promise<any>> = {
-    javascript: () => import('highlight.js/lib/languages/javascript'),
-    typescript: () => import('highlight.js/lib/languages/typescript'),
-    python: () => import('highlight.js/lib/languages/python'),
-    rust: () => import('highlight.js/lib/languages/rust'),
-    go: () => import('highlight.js/lib/languages/go'),
-    bash: () => import('highlight.js/lib/languages/bash'),
-    shell: () => import('highlight.js/lib/languages/shell'),
-    json: () => import('highlight.js/lib/languages/json'),
-    html: () => import('highlight.js/lib/languages/xml'),
-    xml: () => import('highlight.js/lib/languages/xml'),
-    css: () => import('highlight.js/lib/languages/css'),
-    sql: () => import('highlight.js/lib/languages/sql'),
-    java: () => import('highlight.js/lib/languages/java'),
-    c: () => import('highlight.js/lib/languages/c'),
-    cpp: () => import('highlight.js/lib/languages/cpp'),
-    csharp: () => import('highlight.js/lib/languages/csharp'),
-    ruby: () => import('highlight.js/lib/languages/ruby'),
-    php: () => import('highlight.js/lib/languages/php'),
-    swift: () => import('highlight.js/lib/languages/swift'),
-    kotlin: () => import('highlight.js/lib/languages/kotlin'),
-    yaml: () => import('highlight.js/lib/languages/yaml'),
-    markdown: () => import('highlight.js/lib/languages/markdown'),
-    dockerfile: () => import('highlight.js/lib/languages/dockerfile'),
-    svelte: () => import('highlight.js/lib/languages/xml'),
-  };
-
-  const langAliases: Record<string, string> = {
-    js: 'javascript', ts: 'typescript', py: 'python', rb: 'ruby',
-    sh: 'bash', zsh: 'bash', yml: 'yaml', 'c++': 'cpp', 'c#': 'csharp',
-    htm: 'html', md: 'markdown',
-  };
+  import { langModules, langAliases, renderMarkdown } from '../lib/markdown';
 
   let { item, onclose, onedit }: {
     item: InboxItem;
@@ -69,6 +37,9 @@
   // Code highlighting
   let highlightedHtml = $state('');
 
+  // Markdown rendering for notes
+  let renderedBody = $state('');
+
   // Document download
   let docBlobUrl = $state<string | null>(null);
   let docLoading = $state(false);
@@ -82,12 +53,18 @@
     transcribing = false;
     transcriptionError = false;
     highlightedHtml = '';
+    renderedBody = '';
     untrack(() => { if (docBlobUrl) URL.revokeObjectURL(docBlobUrl); });
     docBlobUrl = null;
     docLoading = false;
 
     if (currentItem.type === 'code-snippet') {
       highlightCode();
+    }
+    if (currentItem.type === 'note' && (currentItem as any).body) {
+      renderMarkdown((currentItem as any).body).then((html) => {
+        if (item.id === currentItem.id) renderedBody = html;
+      });
     }
   });
 
@@ -425,7 +402,11 @@
     {#if body && item.type !== 'code-snippet'}
       <div class="content-block">
         <span class="content-label">{item.type === 'audio' ? 'Transcription' : 'Body'}</span>
-        <p class="content-text">{body}</p>
+        {#if item.type === 'note' && renderedBody}
+          <div class="markdown-body">{@html renderedBody}</div>
+        {:else}
+          <p class="content-text">{body}</p>
+        {/if}
       </div>
     {/if}
 
@@ -700,6 +681,104 @@
     line-height: 1.6;
     white-space: pre-wrap;
     word-break: break-word;
+  }
+
+  .markdown-body {
+    font-size: 0.9rem;
+    color: var(--text);
+    line-height: 1.6;
+    word-break: break-word;
+  }
+
+  .markdown-body :global(h1) { font-size: 1.1rem; font-weight: 600; margin: 0.75rem 0 0.4rem; }
+  .markdown-body :global(h2) { font-size: 1rem; font-weight: 600; margin: 0.6rem 0 0.35rem; }
+  .markdown-body :global(h3) { font-size: 0.95rem; font-weight: 600; margin: 0.5rem 0 0.3rem; }
+  .markdown-body :global(h4),
+  .markdown-body :global(h5),
+  .markdown-body :global(h6) { font-size: 0.9rem; font-weight: 600; margin: 0.4rem 0 0.25rem; }
+
+  .markdown-body :global(p) { margin: 0 0 0.5rem; }
+  .markdown-body :global(p:last-child) { margin-bottom: 0; }
+
+  .markdown-body :global(ul),
+  .markdown-body :global(ol) {
+    padding-left: 1.5rem;
+    margin: 0 0 0.5rem;
+  }
+  .markdown-body :global(ul) { list-style: disc; }
+  .markdown-body :global(ol) { list-style: decimal; }
+  .markdown-body :global(li) { margin-bottom: 0.15rem; }
+  .markdown-body :global(li > ul),
+  .markdown-body :global(li > ol) { margin-top: 0.15rem; margin-bottom: 0; }
+
+  .markdown-body :global(blockquote) {
+    border-left: 3px solid var(--accent);
+    padding-left: 0.75rem;
+    margin: 0 0 0.5rem;
+    color: var(--text-muted);
+  }
+
+  .markdown-body :global(a) {
+    color: var(--accent);
+    text-decoration: none;
+  }
+  .markdown-body :global(a:hover) { text-decoration: underline; }
+
+  .markdown-body :global(code) {
+    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+    background: rgba(255, 255, 255, 0.06);
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+    font-size: 0.82rem;
+  }
+
+  .markdown-body :global(pre) {
+    background: #0d1117;
+    border-radius: var(--radius-sm);
+    padding: 0.75rem;
+    margin: 0 0 0.5rem;
+    overflow-x: auto;
+    max-height: 400px;
+    overflow-y: auto;
+  }
+
+  .markdown-body :global(pre code) {
+    background: none;
+    padding: 0;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: #e6edf3;
+  }
+
+  .markdown-body :global(pre .hljs) {
+    background: transparent;
+    padding: 0;
+  }
+
+  .markdown-body :global(hr) {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 0.75rem 0;
+  }
+
+  .markdown-body :global(strong) { font-weight: 600; }
+  .markdown-body :global(em) { font-style: italic; }
+
+  .markdown-body :global(table) {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0 0 0.5rem;
+    font-size: 0.85rem;
+  }
+  .markdown-body :global(th),
+  .markdown-body :global(td) {
+    border: 1px solid var(--border);
+    padding: 0.35rem 0.6rem;
+    text-align: left;
+  }
+  .markdown-body :global(th) {
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.03);
   }
 
   .notes-block .content-text {

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -8,6 +8,7 @@
   import Lightbox from './Lightbox.svelte';
   import DeleteConfirm from './DeleteConfirm.svelte';
   import hljs from 'highlight.js/lib/core';
+  import DOMPurify from 'dompurify';
   import 'highlight.js/styles/github-dark.min.css';
   import { langModules, langAliases, renderMarkdown } from '../lib/markdown';
 
@@ -110,9 +111,15 @@
     if (loader && !hljs.getLanguage(resolved)) {
       const mod = await loader();
       hljs.registerLanguage(resolved, mod.default);
-      highlightedHtml = hljs.highlight(item.body, { language: resolved }).value;
+      highlightedHtml = DOMPurify.sanitize(
+        hljs.highlight(item.body, { language: resolved }).value,
+        { USE_PROFILES: { html: true } },
+      );
     } else if (hljs.getLanguage(resolved)) {
-      highlightedHtml = hljs.highlight(item.body, { language: resolved }).value;
+      highlightedHtml = DOMPurify.sanitize(
+        hljs.highlight(item.body, { language: resolved }).value,
+        { USE_PROFILES: { html: true } },
+      );
     }
   }
 

--- a/packages/web/src/lib/add-entry-modal.test.ts
+++ b/packages/web/src/lib/add-entry-modal.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { loadMarkdownEditorComponent, shouldSubmitAddEntryForm } from './add-entry-modal';
+
+describe('shouldSubmitAddEntryForm', () => {
+  it('submits from text-like inputs including bookmark url fields', () => {
+    const urlInput = document.createElement('input');
+    urlInput.type = 'url';
+
+    const textInput = document.createElement('input');
+    textInput.type = 'text';
+
+    expect(shouldSubmitAddEntryForm('Enter', urlInput, true)).toBe(true);
+    expect(shouldSubmitAddEntryForm('Enter', textInput, true)).toBe(true);
+  });
+
+  it('does not submit from textarea or tiptap editor content', () => {
+    const textarea = document.createElement('textarea');
+    const tiptap = document.createElement('div');
+    tiptap.className = 'tiptap-editor';
+    const nested = document.createElement('p');
+    tiptap.appendChild(nested);
+
+    expect(shouldSubmitAddEntryForm('Enter', textarea, true)).toBe(false);
+    expect(shouldSubmitAddEntryForm('Enter', nested, true)).toBe(false);
+  });
+
+  it('does not submit when disabled or for unsupported input types', () => {
+    const fileInput = document.createElement('input');
+    fileInput.type = 'file';
+
+    expect(shouldSubmitAddEntryForm('Enter', fileInput, true)).toBe(false);
+    expect(shouldSubmitAddEntryForm('Escape', fileInput, true)).toBe(false);
+    expect(shouldSubmitAddEntryForm('Enter', fileInput, false)).toBe(false);
+  });
+});
+
+describe('loadMarkdownEditorComponent', () => {
+  it('loads the markdown editor on demand', async () => {
+    const component = await loadMarkdownEditorComponent();
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/web/src/lib/add-entry-modal.test.ts
+++ b/packages/web/src/lib/add-entry-modal.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
-import { loadMarkdownEditorComponent, shouldSubmitAddEntryForm } from './add-entry-modal';
+import { loadMarkdownEditorComponent, shouldLoadMarkdownEditor, shouldSubmitAddEntryForm } from './add-entry-modal';
 
 describe('shouldSubmitAddEntryForm', () => {
   it('submits from text-like inputs including bookmark url fields', () => {
@@ -39,5 +39,19 @@ describe('loadMarkdownEditorComponent', () => {
   it('loads the markdown editor on demand', async () => {
     const component = await loadMarkdownEditorComponent();
     expect(component).toBeTruthy();
+  });
+});
+
+describe('shouldLoadMarkdownEditor', () => {
+  it('loads only for note visual mode', () => {
+    expect(shouldLoadMarkdownEditor('note', 'visual', false, false)).toBe(true);
+    expect(shouldLoadMarkdownEditor('note', 'write', false, false)).toBe(false);
+    expect(shouldLoadMarkdownEditor('note', 'preview', false, false)).toBe(false);
+    expect(shouldLoadMarkdownEditor('bookmark', 'visual', false, false)).toBe(false);
+  });
+
+  it('does not reload after success or failure', () => {
+    expect(shouldLoadMarkdownEditor('note', 'visual', true, false)).toBe(false);
+    expect(shouldLoadMarkdownEditor('note', 'visual', false, true)).toBe(false);
   });
 });

--- a/packages/web/src/lib/add-entry-modal.ts
+++ b/packages/web/src/lib/add-entry-modal.ts
@@ -1,0 +1,24 @@
+import type { Component } from 'svelte';
+
+const SUBMITTABLE_INPUT_TYPES = new Set(['text', 'url', 'email', 'search', 'tel']);
+
+export function shouldSubmitAddEntryForm(
+  key: string,
+  target: EventTarget | null,
+  canSubmit: boolean,
+): boolean {
+  if (!canSubmit || key !== 'Enter' || !(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  if (target.closest('.tiptap-editor') || target instanceof HTMLTextAreaElement) {
+    return false;
+  }
+
+  return target instanceof HTMLInputElement && SUBMITTABLE_INPUT_TYPES.has(target.type);
+}
+
+export async function loadMarkdownEditorComponent(): Promise<Component<any>> {
+  const module = await import('../components/MarkdownEditor.svelte');
+  return module.default;
+}

--- a/packages/web/src/lib/add-entry-modal.ts
+++ b/packages/web/src/lib/add-entry-modal.ts
@@ -1,4 +1,5 @@
 import type { Component } from 'svelte';
+import type { InboxItemType } from '@inbox-rs/rs-module';
 
 const SUBMITTABLE_INPUT_TYPES = new Set(['text', 'url', 'email', 'search', 'tel']);
 
@@ -21,4 +22,13 @@ export function shouldSubmitAddEntryForm(
 export async function loadMarkdownEditorComponent(): Promise<Component<any>> {
   const module = await import('../components/MarkdownEditor.svelte');
   return module.default;
+}
+
+export function shouldLoadMarkdownEditor(
+  type: InboxItemType,
+  mode: 'visual' | 'write' | 'preview',
+  componentLoaded: boolean,
+  loadError: boolean,
+): boolean {
+  return type === 'note' && mode === 'visual' && !componentLoaded && !loadError;
 }

--- a/packages/web/src/lib/markdown.test.ts
+++ b/packages/web/src/lib/markdown.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { renderMarkdown } from './markdown';
+
+describe('renderMarkdown', () => {
+  it('sanitizes raw html, inline handlers, and javascript urls', async () => {
+    const html = await renderMarkdown([
+      '# Title',
+      '<script>alert(1)</script>',
+      '<img src="x" onerror="alert(1)">',
+      '<a href="javascript:alert(1)">bad</a>',
+      '**safe**',
+    ].join('\n\n'));
+
+    expect(html).toContain('<h1>Title</h1>');
+    expect(html).toContain('<strong>safe</strong>');
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('onerror=');
+    expect(html).not.toContain('javascript:alert(1)');
+  });
+
+  it('preserves highlighted code block classes for safe markdown output', async () => {
+    const html = await renderMarkdown('```javascript\nconst value = 1;\n```');
+
+    expect(html).toContain('<pre><code');
+    expect(html).toContain('class="hljs language-javascript"');
+    expect(html).toContain('hljs-keyword');
+    expect(html).toContain('hljs-number');
+  });
+});

--- a/packages/web/src/lib/markdown.test.ts
+++ b/packages/web/src/lib/markdown.test.ts
@@ -19,6 +19,23 @@ describe('renderMarkdown', () => {
     expect(html).not.toContain('javascript:alert(1)');
   });
 
+  it('strips external-resource and active html from markdown output', async () => {
+    const html = await renderMarkdown([
+      '<img src="https://attacker.example/pixel.png" alt="pixel">',
+      '<audio controls src="https://attacker.example/audio.mp3"></audio>',
+      '<form><input value="spoof"></form>',
+      '<p style="position:fixed;inset:0">overlay</p>',
+      '[safe](https://example.com)',
+    ].join('\n\n'));
+
+    expect(html).not.toContain('<img');
+    expect(html).not.toContain('<audio');
+    expect(html).not.toContain('<form');
+    expect(html).not.toContain('<input');
+    expect(html).not.toContain('style=');
+    expect(html).toContain('<a href="https://example.com">safe</a>');
+  });
+
   it('preserves highlighted code block classes for safe markdown output', async () => {
     const html = await renderMarkdown('```javascript\nconst value = 1;\n```');
 
@@ -26,5 +43,14 @@ describe('renderMarkdown', () => {
     expect(html).toContain('class="hljs language-javascript"');
     expect(html).toContain('hljs-keyword');
     expect(html).toContain('hljs-number');
+  });
+
+  it('fully escapes fallback code blocks for unknown languages', async () => {
+    const html = await renderMarkdown('```unknown\nconst s = "<tag> & \'quote\'";\n```');
+
+    expect(html).toContain('&lt;tag&gt;');
+    expect(html).toContain('&amp;');
+    expect(html).not.toContain('<tag>');
+    expect(html).toContain('\'quote\'');
   });
 });

--- a/packages/web/src/lib/markdown.ts
+++ b/packages/web/src/lib/markdown.ts
@@ -1,4 +1,5 @@
 import hljs from 'highlight.js/lib/core';
+import DOMPurify from 'dompurify';
 import { Marked } from 'marked';
 
 export const langModules: Record<string, () => Promise<any>> = {
@@ -45,11 +46,6 @@ async function ensureLanguage(lang: string): Promise<string | null> {
   return resolved;
 }
 
-const marked = new Marked({
-  gfm: true,
-  breaks: true,
-});
-
 export async function renderMarkdown(source: string): Promise<string> {
   // Collect code block languages so we can load them before rendering
   const langsToLoad = new Set<string>();
@@ -82,6 +78,15 @@ export async function renderMarkdown(source: string): Promise<string> {
     },
   };
 
+  const marked = new Marked({
+    gfm: true,
+    breaks: true,
+  });
+
   marked.use({ renderer });
-  return await marked.parse(source);
+  const rendered = await marked.parse(source);
+
+  return DOMPurify.sanitize(rendered, {
+    USE_PROFILES: { html: true },
+  });
 }

--- a/packages/web/src/lib/markdown.ts
+++ b/packages/web/src/lib/markdown.ts
@@ -2,6 +2,35 @@ import hljs from 'highlight.js/lib/core';
 import DOMPurify from 'dompurify';
 import { Marked } from 'marked';
 
+const MARKDOWN_SANITIZE_OPTIONS = {
+  USE_PROFILES: { html: true },
+  FORBID_TAGS: [
+    'img',
+    'picture',
+    'audio',
+    'video',
+    'source',
+    'track',
+    'iframe',
+    'frame',
+    'frameset',
+    'object',
+    'embed',
+    'portal',
+    'form',
+    'input',
+    'button',
+    'textarea',
+    'select',
+    'option',
+    'style',
+    'link',
+    'meta',
+    'base',
+  ],
+  FORBID_ATTR: ['style'],
+} as const;
+
 export const langModules: Record<string, () => Promise<any>> = {
   javascript: () => import('highlight.js/lib/languages/javascript'),
   typescript: () => import('highlight.js/lib/languages/typescript'),
@@ -73,7 +102,12 @@ export async function renderMarkdown(source: string): Promise<string> {
         const highlighted = hljs.highlight(text, { language: resolved }).value;
         return `<pre><code class="hljs language-${resolved}">${highlighted}</code></pre>`;
       }
-      const escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      const escaped = text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
       return `<pre><code>${escaped}</code></pre>`;
     },
   };
@@ -86,7 +120,5 @@ export async function renderMarkdown(source: string): Promise<string> {
   marked.use({ renderer });
   const rendered = await marked.parse(source);
 
-  return DOMPurify.sanitize(rendered, {
-    USE_PROFILES: { html: true },
-  });
+  return DOMPurify.sanitize(rendered, MARKDOWN_SANITIZE_OPTIONS);
 }

--- a/packages/web/src/lib/markdown.ts
+++ b/packages/web/src/lib/markdown.ts
@@ -1,0 +1,87 @@
+import hljs from 'highlight.js/lib/core';
+import { Marked } from 'marked';
+
+export const langModules: Record<string, () => Promise<any>> = {
+  javascript: () => import('highlight.js/lib/languages/javascript'),
+  typescript: () => import('highlight.js/lib/languages/typescript'),
+  python: () => import('highlight.js/lib/languages/python'),
+  rust: () => import('highlight.js/lib/languages/rust'),
+  go: () => import('highlight.js/lib/languages/go'),
+  bash: () => import('highlight.js/lib/languages/bash'),
+  shell: () => import('highlight.js/lib/languages/shell'),
+  json: () => import('highlight.js/lib/languages/json'),
+  html: () => import('highlight.js/lib/languages/xml'),
+  xml: () => import('highlight.js/lib/languages/xml'),
+  css: () => import('highlight.js/lib/languages/css'),
+  sql: () => import('highlight.js/lib/languages/sql'),
+  java: () => import('highlight.js/lib/languages/java'),
+  c: () => import('highlight.js/lib/languages/c'),
+  cpp: () => import('highlight.js/lib/languages/cpp'),
+  csharp: () => import('highlight.js/lib/languages/csharp'),
+  ruby: () => import('highlight.js/lib/languages/ruby'),
+  php: () => import('highlight.js/lib/languages/php'),
+  swift: () => import('highlight.js/lib/languages/swift'),
+  kotlin: () => import('highlight.js/lib/languages/kotlin'),
+  yaml: () => import('highlight.js/lib/languages/yaml'),
+  markdown: () => import('highlight.js/lib/languages/markdown'),
+  dockerfile: () => import('highlight.js/lib/languages/dockerfile'),
+  svelte: () => import('highlight.js/lib/languages/xml'),
+};
+
+export const langAliases: Record<string, string> = {
+  js: 'javascript', ts: 'typescript', py: 'python', rb: 'ruby',
+  sh: 'bash', zsh: 'bash', yml: 'yaml', 'c++': 'cpp', 'c#': 'csharp',
+  htm: 'html', md: 'markdown',
+};
+
+async function ensureLanguage(lang: string): Promise<string | null> {
+  const resolved = langAliases[lang] || lang;
+  const loader = langModules[resolved];
+  if (!loader) return null;
+  if (!hljs.getLanguage(resolved)) {
+    const mod = await loader();
+    hljs.registerLanguage(resolved, mod.default);
+  }
+  return resolved;
+}
+
+const marked = new Marked({
+  gfm: true,
+  breaks: true,
+});
+
+export async function renderMarkdown(source: string): Promise<string> {
+  // Collect code block languages so we can load them before rendering
+  const langsToLoad = new Set<string>();
+  const langPattern = /^```(\w+)/gm;
+  let match;
+  while ((match = langPattern.exec(source)) !== null) {
+    langsToLoad.add(match[1].toLowerCase());
+  }
+
+  // Load all languages in parallel
+  const loaded = new Map<string, string>();
+  await Promise.all(
+    [...langsToLoad].map(async (lang) => {
+      const resolved = await ensureLanguage(lang);
+      if (resolved) loaded.set(lang, resolved);
+    })
+  );
+
+  // Configure renderer with highlight support
+  const renderer = {
+    code({ text, lang }: { text: string; lang?: string }) {
+      const rawLang = (lang || '').toLowerCase();
+      const resolved = loaded.get(rawLang) || (langAliases[rawLang] || rawLang);
+      if (resolved && hljs.getLanguage(resolved)) {
+        const highlighted = hljs.highlight(text, { language: resolved }).value;
+        return `<pre><code class="hljs language-${resolved}">${highlighted}</code></pre>`;
+      }
+      const escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      return `<pre><code>${escaped}</code></pre>`;
+    },
+  };
+
+  marked.use({ renderer });
+  return await marked.parse(source);
+}

--- a/packages/web/src/lib/markdown.ts
+++ b/packages/web/src/lib/markdown.ts
@@ -53,15 +53,15 @@ const marked = new Marked({
 export async function renderMarkdown(source: string): Promise<string> {
   // Collect code block languages so we can load them before rendering
   const langsToLoad = new Set<string>();
-  const langPattern = /^```(\w+)/gm;
+  const langPattern = /^```([\w+#.-]+)/gm;
   let match;
   while ((match = langPattern.exec(source)) !== null) {
     langsToLoad.add(match[1].toLowerCase());
   }
 
-  // Load all languages in parallel
+  // Load all languages in parallel, tolerating individual failures
   const loaded = new Map<string, string>();
-  await Promise.all(
+  await Promise.allSettled(
     [...langsToLoad].map(async (lang) => {
       const resolved = await ensureLanguage(lang);
       if (resolved) loaded.set(lang, resolved);

--- a/packages/web/src/lib/markdown.ts
+++ b/packages/web/src/lib/markdown.ts
@@ -54,7 +54,7 @@ export async function renderMarkdown(source: string): Promise<string> {
   // Collect code block languages so we can load them before rendering
   const langsToLoad = new Set<string>();
   const langPattern = /^```([\w+#.-]+)/gm;
-  let match;
+  let match: RegExpExecArray | null = null;
   while ((match = langPattern.exec(source)) !== null) {
     langsToLoad.add(match[1].toLowerCase());
   }


### PR DESCRIPTION
## Summary

- Adds a tiptap-based WYSIWYG markdown editor for notes with three modes: Visual (rich text), Markdown (raw), and Preview (rendered)
- Note modal is now significantly larger (720px wide, 85vh tall) for a proper writing experience
- View modal renders note body as formatted markdown with syntax-highlighted code blocks via `marked` + `highlight.js`
- Extracts shared highlight.js language maps into `packages/web/src/lib/markdown.ts` for reuse across components
- New dependencies: `@tiptap/core`, `@tiptap/starter-kit`, `@tiptap/extension-code-block-lowlight`, `tiptap-markdown`, `lowlight`, `marked`

## Test plan

- [x] Create a new note and verify the Visual editor renders formatting (headings, bold, lists, code blocks) as you type
- [x] Switch between Visual, Markdown, and Preview modes — content should persist across mode switches
- [x] Verify Enter key creates new lines in the editor (not saving the note)
- [x] Open an existing plain-text note and confirm it renders correctly (backward compatible)
- [x] Verify code blocks in the view modal have syntax highlighting