### PR TITLE
Fix header title layout and mobile responsiveness

### DIFF
--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -133,19 +133,21 @@
         <h1 class="sr-only">Inbox RS</h1>
         <img src={logoShield} alt="Inbox RS" class="brand-logo" />
       </a>
-      <span class="version">v{__APP_VERSION__}</span>
+      <div class="brand-meta">
+        <span class="version">v{__APP_VERSION__}</span>
+        <a class="extras-link" class:active={route.page === 'plugins'} href="#/plugins">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+            <polyline points="7 10 12 15 17 10"></polyline>
+            <line x1="12" y1="15" x2="12" y2="3"></line>
+          </svg>
+          <span class="extras-label">Downloads</span>
+        </a>
+      </div>
     </div>
     <nav class="header-nav" aria-label="Primary">
       <a class:active={route.page === 'home'} aria-current={route.page === 'home' ? 'page' : undefined} href="#/">Inbox</a>
       <a class:active={route.page === 'collections'} aria-current={route.page === 'collections' ? 'page' : undefined} href="#/collections">Collections</a>
-      <a class="downloads-nav-link" class:active={route.page === 'plugins'} aria-current={route.page === 'plugins' ? 'page' : undefined} href="#/plugins">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-          <polyline points="7 10 12 15 17 10"></polyline>
-          <line x1="12" y1="15" x2="12" y2="3"></line>
-        </svg>
-        <span class="downloads-label">Downloads</span>
-      </a>
       {#if $connected}
         {#each $sortedGroups as group (group.id)}
           <a
@@ -302,11 +304,42 @@
     width: auto;
   }
 
+  .brand-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-left: 0.2rem;
+  }
+
   .version {
     font-size: 0.6rem;
     font-weight: 400;
     opacity: 0.4;
-    margin-left: 0.2rem;
+  }
+
+  .extras-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    font-size: 0.6rem;
+    font-weight: 500;
+    color: var(--text-muted);
+    opacity: 0.5;
+    transition: opacity 150ms, color 150ms;
+  }
+
+  .extras-link:hover {
+    opacity: 1;
+    color: var(--accent);
+  }
+
+  .extras-link.active {
+    opacity: 1;
+    color: var(--accent);
+  }
+
+  .extras-link svg {
+    flex-shrink: 0;
   }
 
   /* ── Navigation (zone 2) ───────────────────── */
@@ -344,15 +377,6 @@
   .header-nav a.active {
     color: var(--text);
     background: color-mix(in srgb, var(--accent) 18%, var(--surface) 82%);
-  }
-
-  /* Downloads inside nav */
-  .downloads-nav-link {
-    gap: 0.3rem;
-  }
-
-  .downloads-nav-link svg {
-    flex-shrink: 0;
   }
 
   /* Group links — truncate long names */
@@ -458,16 +482,26 @@
     .brand {
       grid-column: 1;
       grid-row: 1;
-      flex-direction: row;
-      align-items: center;
-      gap: 0.4rem;
     }
 
     .brand-logo {
       height: 22px;
     }
 
+    .brand-meta {
+      gap: 0.3rem;
+      margin-left: 0.1rem;
+    }
+
     .version {
+      font-size: 0.55rem;
+    }
+
+    .extras-label {
+      display: none;
+    }
+
+    .extras-link {
       font-size: 0.55rem;
     }
 
@@ -496,15 +530,6 @@
 
     .header-nav .group-link {
       max-width: 7rem;
-    }
-
-    /* Downloads: icon-only on mobile */
-    .downloads-label {
-      display: none;
-    }
-
-    .downloads-nav-link {
-      gap: 0;
     }
 
     .content-layout {

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -131,11 +131,11 @@
     <div class="brand">
       <a class="brand-link" href="#/">
         <h1 class="sr-only">Inbox RS</h1>
-        <img src={logoShield} alt="Inbox RS" class="brand-logo" />
+        <img src={logoShield} alt="" aria-hidden="true" class="brand-logo" />
       </a>
       <div class="brand-meta">
         <span class="version">v{__APP_VERSION__}</span>
-        <a class="extras-link" class:active={route.page === 'plugins'} href="#/plugins">
+        <a class="extras-link" class:active={route.page === 'plugins'} href="#/plugins" aria-label="Downloads">
           <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
             <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
             <polyline points="7 10 12 15 17 10"></polyline>

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -13,7 +13,7 @@
   import CollectionFormModal from './components/CollectionFormModal.svelte';
   import GroupFormModal from './components/GroupFormModal.svelte';
   import { connected, deleteItem, todoItems, appConfig, updateConfig, pendingMigrationCount, runAllMigrations, storeCollection, sortedGroups, storeGroup, moveCollectionToGroup } from './lib/stores';
-  import shieldIcon from './assets/logos/favicon-shield.svg';
+  import logoShield from './assets/logos/logo-shield.svg';
 
   type Route =
     | { page: 'home' }
@@ -128,48 +128,44 @@
 
 <header>
   <div class="header-inner">
-    <div class="header-left">
-      <div class="brand-row">
-        <div class="brand">
-          <a class="brand-link" href="#/">
-            <img src={shieldIcon} alt="" class="brand-icon" />
-            <h1>Inbox <span class="accent">RS</span> <span class="version">v{__APP_VERSION__}</span></h1>
-          </a>
-        </div>
-        <a class="downloads-link" class:active={route.page === 'plugins'} href="#/plugins">
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-            <polyline points="7 10 12 15 17 10"></polyline>
-            <line x1="12" y1="15" x2="12" y2="3"></line>
-          </svg>
-          Downloads
-        </a>
-      </div>
-      <nav class="header-nav" aria-label="Primary">
-        <a class:active={route.page === 'home'} aria-current={route.page === 'home' ? 'page' : undefined} href="#/">Inbox</a>
-        <a class:active={route.page === 'collections'} aria-current={route.page === 'collections' ? 'page' : undefined} href="#/collections">Collections</a>
-        {#if $connected}
-          {#each $sortedGroups as group (group.id)}
-            <a
-              class="group-link"
-              class:active={route.page === 'group' && route.groupId === group.id}
-              aria-current={route.page === 'group' && route.groupId === group.id ? 'page' : undefined}
-              href="#/group/{group.id}"
-              style="--group-color: {group.color || 'var(--accent)'}"
-            >
-              <span class="group-dot"></span>
-              {group.name}
-            </a>
-          {/each}
-          <button class="nav-add-group" onclick={() => showGroupForm = true} title="New group" aria-label="Create new group">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-              <line x1="12" y1="5" x2="12" y2="19"></line>
-              <line x1="5" y1="12" x2="19" y2="12"></line>
-            </svg>
-          </button>
-        {/if}
-      </nav>
+    <div class="brand">
+      <a class="brand-link" href="#/">
+        <img src={logoShield} alt="Inbox RS" class="brand-logo" />
+      </a>
+      <span class="version">v{__APP_VERSION__}</span>
+      <a class="downloads-link" class:active={route.page === 'plugins'} href="#/plugins">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+          <polyline points="7 10 12 15 17 10"></polyline>
+          <line x1="12" y1="15" x2="12" y2="3"></line>
+        </svg>
+        Downloads
+      </a>
     </div>
+    <nav class="header-nav" aria-label="Primary">
+      <a class:active={route.page === 'home'} aria-current={route.page === 'home' ? 'page' : undefined} href="#/">Inbox</a>
+      <a class:active={route.page === 'collections'} aria-current={route.page === 'collections' ? 'page' : undefined} href="#/collections">Collections</a>
+      {#if $connected}
+        {#each $sortedGroups as group (group.id)}
+          <a
+            class="group-link"
+            class:active={route.page === 'group' && route.groupId === group.id}
+            aria-current={route.page === 'group' && route.groupId === group.id ? 'page' : undefined}
+            href="#/group/{group.id}"
+            style="--group-color: {group.color || 'var(--accent)'}"
+          >
+            <span class="group-dot"></span>
+            {group.name}
+          </a>
+        {/each}
+        <button class="nav-add-group" onclick={() => showGroupForm = true} title="New group" aria-label="Create new group">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="12" y1="5" x2="12" y2="19"></line>
+            <line x1="5" y1="12" x2="19" y2="12"></line>
+          </svg>
+        </button>
+      {/if}
+    </nav>
     <div class="header-right">
       <ConnectWidget />
     </div>
@@ -267,60 +263,47 @@
     justify-content: space-between;
   }
 
-  .header-left {
-    display: flex;
-    align-items: flex-end;
-    gap: 1rem;
-    min-width: 0;
-  }
-
-  .brand-row {
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
-  }
-
   .brand {
     display: flex;
-    align-items: center;
-    line-height: 1;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.15rem;
+    flex-shrink: 0;
   }
 
   .brand-link {
+    display: flex;
+    align-items: center;
     color: inherit;
-  }
-
-  .brand-icon {
-    width: 24px;
-    height: 24px;
   }
 
   .brand-link:hover {
     color: inherit;
   }
 
-  h1 {
-    font-size: 1.25rem;
-    font-weight: 700;
-    letter-spacing: -0.02em;
+  .brand-logo {
+    height: 28px;
+    width: auto;
   }
 
   .version {
-    font-size: 0.65rem;
+    font-size: 0.6rem;
     font-weight: 400;
     opacity: 0.4;
-    vertical-align: middle;
-    margin-left: 0.15rem;
+    margin-left: 0.2rem;
   }
 
   .header-nav {
     display: flex;
     align-items: center;
-    gap: 0.4rem;
+    flex-wrap: wrap;
+    gap: 0.3rem;
     padding: 0.25rem;
     border: 1px solid var(--border);
-    border-radius: 999px;
+    border-radius: 1rem;
     background: color-mix(in srgb, var(--surface) 88%, black 12%);
+    min-width: 0;
+    flex-shrink: 1;
   }
 
   .header-nav a {
@@ -332,6 +315,8 @@
     color: var(--text-muted);
     font-size: 0.92rem;
     font-weight: 600;
+    white-space: nowrap;
+    flex-shrink: 0;
     transition: background 180ms ease, color 180ms ease;
   }
 
@@ -386,6 +371,7 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
+    flex-shrink: 0;
   }
 
   .downloads-link {
@@ -411,10 +397,6 @@
 
   .downloads-link svg {
     flex-shrink: 0;
-  }
-
-  .accent {
-    color: var(--accent);
   }
 
   main {
@@ -453,27 +435,43 @@
     .header-inner {
       flex-wrap: wrap;
       gap: 0.5rem;
+      padding: 0.75rem 1rem;
     }
 
-    .header-left {
-      align-items: flex-start;
-      flex-direction: column;
-      width: 100%;
+    .brand {
+      flex-direction: row;
+      align-items: center;
+      gap: 0.5rem;
     }
 
-    .brand-row {
-      width: 100%;
-      justify-content: space-between;
+    .brand-logo {
+      height: 24px;
+    }
+
+    .version {
+      font-size: 0.55rem;
+    }
+
+    .downloads-link {
+      font-size: 0.7rem;
+      padding: 0.05rem 0.3rem;
     }
 
     .header-nav {
+      order: 3;
       width: 100%;
-      justify-content: space-between;
+      border-radius: 0.75rem;
+      gap: 0.25rem;
+    }
+
+    .header-nav a {
+      min-height: 1.75rem;
+      padding: 0 0.6rem;
+      font-size: 0.82rem;
     }
 
     .header-right {
-      width: 100%;
-      justify-content: flex-end;
+      margin-left: auto;
     }
 
     .content-layout {

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -130,21 +130,22 @@
   <div class="header-inner">
     <div class="brand">
       <a class="brand-link" href="#/">
+        <h1 class="sr-only">Inbox RS</h1>
         <img src={logoShield} alt="Inbox RS" class="brand-logo" />
       </a>
       <span class="version">v{__APP_VERSION__}</span>
-      <a class="downloads-link" class:active={route.page === 'plugins'} href="#/plugins">
+    </div>
+    <nav class="header-nav" aria-label="Primary">
+      <a class:active={route.page === 'home'} aria-current={route.page === 'home' ? 'page' : undefined} href="#/">Inbox</a>
+      <a class:active={route.page === 'collections'} aria-current={route.page === 'collections' ? 'page' : undefined} href="#/collections">Collections</a>
+      <a class="downloads-nav-link" class:active={route.page === 'plugins'} aria-current={route.page === 'plugins' ? 'page' : undefined} href="#/plugins">
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
           <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
           <polyline points="7 10 12 15 17 10"></polyline>
           <line x1="12" y1="15" x2="12" y2="3"></line>
         </svg>
-        Downloads
+        <span class="downloads-label">Downloads</span>
       </a>
-    </div>
-    <nav class="header-nav" aria-label="Primary">
-      <a class:active={route.page === 'home'} aria-current={route.page === 'home' ? 'page' : undefined} href="#/">Inbox</a>
-      <a class:active={route.page === 'collections'} aria-current={route.page === 'collections' ? 'page' : undefined} href="#/collections">Collections</a>
       {#if $connected}
         {#each $sortedGroups as group (group.id)}
           <a
@@ -155,7 +156,7 @@
             style="--group-color: {group.color || 'var(--accent)'}"
           >
             <span class="group-dot"></span>
-            {group.name}
+            <span class="group-name">{group.name}</span>
           </a>
         {/each}
         <button class="nav-add-group" onclick={() => showGroupForm = true} title="New group" aria-label="Create new group">
@@ -244,6 +245,20 @@
 {/if}
 
 <style>
+  /* ── Accessibility ─────────────────────────── */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* ── Header shell ──────────────────────────── */
   header {
     position: sticky;
     top: 0;
@@ -263,6 +278,7 @@
     justify-content: space-between;
   }
 
+  /* ── Brand (zone 1) ────────────────────────── */
   .brand {
     display: flex;
     flex-direction: column;
@@ -293,6 +309,7 @@
     margin-left: 0.2rem;
   }
 
+  /* ── Navigation (zone 2) ───────────────────── */
   .header-nav {
     display: flex;
     align-items: center;
@@ -329,8 +346,27 @@
     background: color-mix(in srgb, var(--accent) 18%, var(--surface) 82%);
   }
 
+  /* Downloads inside nav */
+  .downloads-nav-link {
+    gap: 0.3rem;
+  }
+
+  .downloads-nav-link svg {
+    flex-shrink: 0;
+  }
+
+  /* Group links — truncate long names */
   .header-nav .group-link {
     gap: 0.35rem;
+    max-width: 10rem;
+    flex-shrink: 1;
+    min-width: 0;
+  }
+
+  .group-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .header-nav .group-link.active {
@@ -367,6 +403,7 @@
     opacity: 1;
   }
 
+  /* ── Connection controls (zone 3) ──────────── */
   .header-right {
     display: flex;
     align-items: center;
@@ -374,31 +411,7 @@
     flex-shrink: 0;
   }
 
-  .downloads-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--text-muted);
-    padding: 0.1rem 0.4rem;
-    border-radius: var(--radius-sm, 6px);
-    transition: color 150ms, background 150ms;
-  }
-
-  .downloads-link:hover {
-    color: var(--accent);
-    background: rgba(99, 102, 241, 0.1);
-  }
-
-  .downloads-link.active {
-    color: var(--accent);
-  }
-
-  .downloads-link svg {
-    flex-shrink: 0;
-  }
-
+  /* ── Main content ──────────────────────────── */
   main {
     max-width: 1200px;
     margin: 0 auto;
@@ -431,37 +444,48 @@
     min-width: 0;
   }
 
+  /* ── Mobile ────────────────────────────────── */
   @media (max-width: 768px) {
     .header-inner {
-      flex-wrap: wrap;
+      display: grid;
+      grid-template-columns: 1fr auto;
+      grid-template-rows: auto auto;
       gap: 0.5rem;
       padding: 0.75rem 1rem;
     }
 
+    /* Row 1, left: brand */
     .brand {
+      grid-column: 1;
+      grid-row: 1;
       flex-direction: row;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4rem;
     }
 
     .brand-logo {
-      height: 24px;
+      height: 22px;
     }
 
     .version {
       font-size: 0.55rem;
     }
 
-    .downloads-link {
-      font-size: 0.7rem;
-      padding: 0.05rem 0.3rem;
+    /* Row 1, right: connection controls */
+    .header-right {
+      grid-column: 2;
+      grid-row: 1;
+      align-items: flex-start;
+      justify-content: flex-end;
     }
 
+    /* Row 2, full width: navigation */
     .header-nav {
-      order: 3;
-      width: 100%;
+      grid-column: 1 / -1;
+      grid-row: 2;
       border-radius: 0.75rem;
       gap: 0.25rem;
+      padding: 0.2rem;
     }
 
     .header-nav a {
@@ -470,8 +494,17 @@
       font-size: 0.82rem;
     }
 
-    .header-right {
-      margin-left: auto;
+    .header-nav .group-link {
+      max-width: 7rem;
+    }
+
+    /* Downloads: icon-only on mobile */
+    .downloads-label {
+      display: none;
+    }
+
+    .downloads-nav-link {
+      gap: 0;
     }
 
     .content-layout {

--- a/packages/web/src/components/ConnectWidget.svelte
+++ b/packages/web/src/components/ConnectWidget.svelte
@@ -26,16 +26,18 @@
 
 {#if $connected}
   <div class="widget connected">
-    {#if $syncing}
-      <svg class="sync-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-        <polyline points="23 4 23 10 17 10"></polyline>
-        <polyline points="1 20 1 14 7 14"></polyline>
-        <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10"></path>
-        <path d="M20.49 15a9 9 0 0 1-14.85 3.36L1 14"></path>
-      </svg>
-    {/if}
-    <span class="status-dot"></span>
-    <span class="status-text">Connected</span>
+    <span class="status-row">
+      {#if $syncing}
+        <svg class="sync-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="23 4 23 10 17 10"></polyline>
+          <polyline points="1 20 1 14 7 14"></polyline>
+          <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10"></path>
+          <path d="M20.49 15a9 9 0 0 1-14.85 3.36L1 14"></path>
+        </svg>
+      {/if}
+      <span class="status-dot"></span>
+      <span class="status-text">Connected</span>
+    </span>
     <button class="btn-disconnect" onclick={handleDisconnect}>Disconnect</button>
   </div>
 {:else}
@@ -80,6 +82,12 @@
   @keyframes spin {
     from { transform: rotate(0deg); }
     to { transform: rotate(360deg); }
+  }
+
+  .status-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
   }
 
   .status-text {
@@ -139,5 +147,38 @@
   .btn-disconnect:hover {
     color: var(--danger);
     border-color: var(--danger);
+  }
+
+  @media (max-width: 768px) {
+    .widget {
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 0.25rem;
+    }
+
+    .connected {
+      font-size: 0.8rem;
+    }
+
+    .status-text {
+      font-size: 0.75rem;
+    }
+
+    .btn-disconnect {
+      font-size: 0.7rem;
+      padding: 0.2rem 0.5rem;
+    }
+
+    input {
+      width: 100%;
+      font-size: 0.8rem;
+      padding: 0.4rem 0.6rem;
+    }
+
+    .btn-connect {
+      width: 100%;
+      font-size: 0.8rem;
+      padding: 0.4rem 0.75rem;
+    }
   }
 </style>

--- a/packages/web/src/components/ConnectWidget.svelte
+++ b/packages/web/src/components/ConnectWidget.svelte
@@ -150,34 +150,49 @@
   }
 
   @media (max-width: 768px) {
-    .widget {
+    /* Connected: status stacks above disconnect, right-aligned */
+    .widget.connected {
       flex-direction: column;
       align-items: flex-end;
-      gap: 0.25rem;
-    }
-
-    .connected {
+      gap: 0.2rem;
       font-size: 0.8rem;
     }
 
-    .status-text {
+    .widget.connected .status-text {
       font-size: 0.75rem;
     }
 
-    .btn-disconnect {
+    .widget.connected .btn-disconnect {
       font-size: 0.7rem;
-      padding: 0.2rem 0.5rem;
+      padding: 0.15rem 0.5rem;
+      border: none;
+      background: none;
+      color: var(--text-muted);
+      opacity: 0.7;
     }
 
-    input {
+    .widget.connected .btn-disconnect:hover {
+      opacity: 1;
+      color: var(--danger);
+    }
+
+    /* Disconnected: full-width stacked form */
+    form.widget {
+      flex-direction: column;
+      align-items: stretch;
       width: 100%;
-      font-size: 0.8rem;
+      gap: 0.35rem;
+    }
+
+    form.widget input {
+      width: 100%;
+      font-size: 0.82rem;
       padding: 0.4rem 0.6rem;
     }
 
-    .btn-connect {
+    form.widget .btn-connect {
       width: 100%;
-      font-size: 0.8rem;
+      font-size: 0.82rem;
       padding: 0.4rem 0.75rem;
     }
   }

--- a/packages/web/src/components/ConnectWidget.svelte
+++ b/packages/web/src/components/ConnectWidget.svelte
@@ -27,14 +27,12 @@
 {#if $connected}
   <div class="widget connected">
     <span class="status-row">
-      {#if $syncing}
-        <svg class="sync-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-          <polyline points="23 4 23 10 17 10"></polyline>
-          <polyline points="1 20 1 14 7 14"></polyline>
-          <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10"></path>
-          <path d="M20.49 15a9 9 0 0 1-14.85 3.36L1 14"></path>
-        </svg>
-      {/if}
+      <svg class="sync-icon" class:spinning={$syncing} width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="23 4 23 10 17 10"></polyline>
+        <polyline points="1 20 1 14 7 14"></polyline>
+        <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10"></path>
+        <path d="M20.49 15a9 9 0 0 1-14.85 3.36L1 14"></path>
+      </svg>
       <span class="status-dot"></span>
       <span class="status-text">Connected</span>
     </span>
@@ -76,6 +74,12 @@
   .sync-icon {
     color: var(--accent);
     flex-shrink: 0;
+    opacity: 0;
+    transition: opacity 0.15s;
+  }
+
+  .sync-icon.spinning {
+    opacity: 1;
     animation: spin 1s linear infinite;
   }
 


### PR DESCRIPTION
Use the combined logo-shield SVG so the icon and wordmark never separate or wrap independently. Restructure the header into three non-overlapping flex zones (brand, nav, connection controls) that respect each other's space at all viewport widths. Nav items wrap gracefully instead of requiring horizontal scroll when groups are added. ConnectWidget stacks status above disconnect button on mobile for a compact layout, and the connect form stacks input above button at full width.