### PR TITLE
fix: stabilize PWA layout and fix collect dropdown clipping

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Inbox RS</title>
     <link rel="icon" href="/src/assets/logos/favicon-shield.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -267,7 +267,7 @@
     z-index: 100;
     background: var(--bg);
     border-bottom: 1px solid var(--border);
-    backdrop-filter: blur(12px);
+    width: 100%;
   }
 
   .header-inner {
@@ -354,6 +354,14 @@
     background: color-mix(in srgb, var(--surface) 88%, black 12%);
     min-width: 0;
     flex-shrink: 1;
+    overflow-x: auto;
+    max-width: 100%;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  .header-nav::-webkit-scrollbar {
+    display: none;
   }
 
   .header-nav a {
@@ -440,6 +448,7 @@
     max-width: 1200px;
     margin: 0 auto;
     padding: 1.5rem;
+    width: 100%;
   }
 
   .content-layout {

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -79,14 +79,25 @@
     void updateConfig({ todosCollapsed: !v });
   }
 
-  // Lock body scroll when any modal is open
+  // Lock body scroll when any modal is open (including iOS Safari)
   const anyModalOpen = $derived(!!viewingItem || !!activeModal || showCollectionForm || showGroupForm);
+  let savedScrollY = 0;
 
   $effect(() => {
     if (anyModalOpen) {
+      savedScrollY = window.scrollY;
+      document.body.style.position = 'fixed';
+      document.body.style.top = `-${savedScrollY}px`;
+      document.body.style.left = '0';
+      document.body.style.right = '0';
       document.body.style.overflow = 'hidden';
     } else {
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.left = '';
+      document.body.style.right = '';
       document.body.style.overflow = '';
+      window.scrollTo(0, savedScrollY);
     }
   });
 

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -79,6 +79,17 @@
     void updateConfig({ todosCollapsed: !v });
   }
 
+  // Lock body scroll when any modal is open
+  const anyModalOpen = $derived(!!viewingItem || !!activeModal || showCollectionForm || showGroupForm);
+
+  $effect(() => {
+    if (anyModalOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+  });
+
   function openAdd(type: InboxItemType) {
     editingItem = undefined;
     activeModal = type;

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -82,16 +82,19 @@
   // Lock body scroll when any modal is open (including iOS Safari)
   const anyModalOpen = $derived(!!viewingItem || !!activeModal || showCollectionForm || showGroupForm);
   let savedScrollY = 0;
+  let wasModalOpen = false;
 
   $effect(() => {
-    if (anyModalOpen) {
+    if (anyModalOpen && !wasModalOpen) {
+      // false→true: capture scroll position and lock
       savedScrollY = window.scrollY;
       document.body.style.position = 'fixed';
       document.body.style.top = `-${savedScrollY}px`;
       document.body.style.left = '0';
       document.body.style.right = '0';
       document.body.style.overflow = 'hidden';
-    } else {
+    } else if (!anyModalOpen && wasModalOpen) {
+      // true→false: unlock and restore scroll position
       document.body.style.position = '';
       document.body.style.top = '';
       document.body.style.left = '';
@@ -99,6 +102,7 @@
       document.body.style.overflow = '';
       window.scrollTo(0, savedScrollY);
     }
+    wasModalOpen = anyModalOpen;
   });
 
   function openAdd(type: InboxItemType) {
@@ -368,7 +372,7 @@
   .header-nav {
     display: flex;
     align-items: center;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: 0.3rem;
     padding: 0.25rem;
     border: 1px solid var(--border);

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -478,6 +478,7 @@
     align-items: center;
     justify-content: center;
     padding: 1rem;
+    overscroll-behavior: contain;
   }
 
   .modal {

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -475,9 +475,10 @@
     z-index: 200;
     background: var(--overlay);
     display: flex;
-    align-items: center;
+    align-items: safe center;
     justify-content: center;
     padding: 1rem;
+    overflow-y: auto;
     overscroll-behavior: contain;
   }
 
@@ -487,9 +488,8 @@
     border-radius: var(--radius);
     width: 100%;
     max-width: 480px;
-    max-height: 90vh;
-    overflow-y: auto;
     padding: 1.5rem;
+    margin: auto;
   }
 
   .modal-title {

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -490,6 +490,20 @@
     margin-right: auto;
   }
 
+  @media (max-width: 600px), (display-mode: standalone) {
+    .overlay {
+      padding: 0;
+      background: var(--bg);
+    }
+
+    .modal {
+      max-width: none;
+      min-height: 100%;
+      border: none;
+      border-radius: 0;
+    }
+  }
+
   .modal-title {
     font-size: 1.1rem;
     font-weight: 600;

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -475,9 +475,17 @@
     z-index: 200;
     background: var(--overlay);
     display: flex;
+    flex-direction: column;
+    align-items: center;
     padding: 1rem;
     overflow-y: auto;
     overscroll-behavior: contain;
+  }
+
+  .overlay::before,
+  .overlay::after {
+    content: '';
+    flex: 1;
   }
 
   .modal {
@@ -487,7 +495,7 @@
     width: 100%;
     max-width: 480px;
     padding: 1.5rem;
-    margin: auto;
+    flex-shrink: 0;
   }
 
   .modal-title {

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -474,18 +474,9 @@
     inset: 0;
     z-index: 200;
     background: var(--overlay);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 1rem;
     overflow-y: auto;
     overscroll-behavior: contain;
-  }
-
-  .overlay::before,
-  .overlay::after {
-    content: '';
-    flex: 1;
+    padding: 3rem 1rem;
   }
 
   .modal {
@@ -495,7 +486,8 @@
     width: 100%;
     max-width: 480px;
     padding: 1.5rem;
-    flex-shrink: 0;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   .modal-title {

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -492,7 +492,7 @@
 
   @media (max-width: 600px), (display-mode: standalone) {
     .overlay {
-      padding: 0;
+      padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
       background: var(--bg);
     }
 

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -475,8 +475,6 @@
     z-index: 200;
     background: var(--overlay);
     display: flex;
-    align-items: safe center;
-    justify-content: center;
     padding: 1rem;
     overflow-y: auto;
     overscroll-behavior: contain;

--- a/packages/web/src/components/CollectionItemPicker.svelte
+++ b/packages/web/src/components/CollectionItemPicker.svelte
@@ -66,9 +66,10 @@
     z-index: 200;
     background: var(--overlay);
     display: flex;
-    align-items: center;
+    align-items: safe center;
     justify-content: center;
     padding: 1rem;
+    overflow-y: auto;
     overscroll-behavior: contain;
   }
 
@@ -81,6 +82,7 @@
     max-height: 80vh;
     display: flex;
     flex-direction: column;
+    margin: auto;
     padding: 1.5rem;
   }
 

--- a/packages/web/src/components/CollectionItemPicker.svelte
+++ b/packages/web/src/components/CollectionItemPicker.svelte
@@ -66,9 +66,17 @@
     z-index: 200;
     background: var(--overlay);
     display: flex;
+    flex-direction: column;
+    align-items: center;
     padding: 1rem;
     overflow-y: auto;
     overscroll-behavior: contain;
+  }
+
+  .overlay::before,
+  .overlay::after {
+    content: '';
+    flex: 1;
   }
 
   .modal {
@@ -80,7 +88,7 @@
     max-height: 80vh;
     display: flex;
     flex-direction: column;
-    margin: auto;
+    flex-shrink: 0;
     padding: 1.5rem;
   }
 

--- a/packages/web/src/components/CollectionItemPicker.svelte
+++ b/packages/web/src/components/CollectionItemPicker.svelte
@@ -84,6 +84,21 @@
     margin-right: auto;
   }
 
+  @media (max-width: 600px), (display-mode: standalone) {
+    .overlay {
+      padding: 0;
+      background: var(--bg);
+    }
+
+    .modal {
+      max-width: none;
+      max-height: none;
+      min-height: 100%;
+      border: none;
+      border-radius: 0;
+    }
+  }
+
   h2 {
     font-size: 1.1rem;
     font-weight: 600;

--- a/packages/web/src/components/CollectionItemPicker.svelte
+++ b/packages/web/src/components/CollectionItemPicker.svelte
@@ -69,6 +69,7 @@
     align-items: center;
     justify-content: center;
     padding: 1rem;
+    overscroll-behavior: contain;
   }
 
   .modal {

--- a/packages/web/src/components/CollectionItemPicker.svelte
+++ b/packages/web/src/components/CollectionItemPicker.svelte
@@ -65,18 +65,9 @@
     inset: 0;
     z-index: 200;
     background: var(--overlay);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 1rem;
     overflow-y: auto;
     overscroll-behavior: contain;
-  }
-
-  .overlay::before,
-  .overlay::after {
-    content: '';
-    flex: 1;
+    padding: 3rem 1rem;
   }
 
   .modal {
@@ -88,8 +79,9 @@
     max-height: 80vh;
     display: flex;
     flex-direction: column;
-    flex-shrink: 0;
     padding: 1.5rem;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   h2 {

--- a/packages/web/src/components/CollectionItemPicker.svelte
+++ b/packages/web/src/components/CollectionItemPicker.svelte
@@ -86,7 +86,7 @@
 
   @media (max-width: 600px), (display-mode: standalone) {
     .overlay {
-      padding: 0;
+      padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
       background: var(--bg);
     }
 

--- a/packages/web/src/components/CollectionItemPicker.svelte
+++ b/packages/web/src/components/CollectionItemPicker.svelte
@@ -66,8 +66,6 @@
     z-index: 200;
     background: var(--overlay);
     display: flex;
-    align-items: safe center;
-    justify-content: center;
     padding: 1rem;
     overflow-y: auto;
     overscroll-behavior: contain;

--- a/packages/web/src/components/DeleteConfirm.svelte
+++ b/packages/web/src/components/DeleteConfirm.svelte
@@ -29,7 +29,10 @@
     overflow-y: auto;
     overscroll-behavior: contain;
     z-index: 200;
-    padding: 3rem 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
   }
 
   .dialog {
@@ -41,8 +44,6 @@
     max-width: 340px;
     width: 100%;
     box-shadow: 0 12px 40px var(--shadow);
-    margin-left: auto;
-    margin-right: auto;
   }
 
   p {

--- a/packages/web/src/components/DeleteConfirm.svelte
+++ b/packages/web/src/components/DeleteConfirm.svelte
@@ -27,9 +27,17 @@
     inset: 0;
     background: var(--overlay);
     display: flex;
+    flex-direction: column;
+    align-items: center;
     z-index: 200;
     overflow-y: auto;
     overscroll-behavior: contain;
+  }
+
+  .overlay::before,
+  .overlay::after {
+    content: '';
+    flex: 1;
   }
 
   .dialog {
@@ -41,7 +49,7 @@
     max-width: 340px;
     width: 100%;
     box-shadow: 0 12px 40px var(--shadow);
-    margin: auto;
+    flex-shrink: 0;
   }
 
   p {

--- a/packages/web/src/components/DeleteConfirm.svelte
+++ b/packages/web/src/components/DeleteConfirm.svelte
@@ -27,8 +27,6 @@
     inset: 0;
     background: var(--overlay);
     display: flex;
-    align-items: safe center;
-    justify-content: center;
     z-index: 200;
     overflow-y: auto;
     overscroll-behavior: contain;
@@ -43,6 +41,7 @@
     max-width: 340px;
     width: 100%;
     box-shadow: 0 12px 40px var(--shadow);
+    margin: auto;
   }
 
   p {

--- a/packages/web/src/components/DeleteConfirm.svelte
+++ b/packages/web/src/components/DeleteConfirm.svelte
@@ -26,18 +26,10 @@
     position: fixed;
     inset: 0;
     background: var(--overlay);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    z-index: 200;
     overflow-y: auto;
     overscroll-behavior: contain;
-  }
-
-  .overlay::before,
-  .overlay::after {
-    content: '';
-    flex: 1;
+    z-index: 200;
+    padding: 3rem 1rem;
   }
 
   .dialog {
@@ -49,7 +41,8 @@
     max-width: 340px;
     width: 100%;
     box-shadow: 0 12px 40px var(--shadow);
-    flex-shrink: 0;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   p {

--- a/packages/web/src/components/DeleteConfirm.svelte
+++ b/packages/web/src/components/DeleteConfirm.svelte
@@ -27,9 +27,10 @@
     inset: 0;
     background: var(--overlay);
     display: flex;
-    align-items: center;
+    align-items: safe center;
     justify-content: center;
     z-index: 200;
+    overflow-y: auto;
     overscroll-behavior: contain;
   }
 

--- a/packages/web/src/components/DeleteConfirm.svelte
+++ b/packages/web/src/components/DeleteConfirm.svelte
@@ -30,6 +30,7 @@
     align-items: center;
     justify-content: center;
     z-index: 200;
+    overscroll-behavior: contain;
   }
 
   .dialog {

--- a/packages/web/src/components/EntityFormModal.svelte
+++ b/packages/web/src/components/EntityFormModal.svelte
@@ -101,8 +101,6 @@
     z-index: 200;
     background: var(--overlay);
     display: flex;
-    align-items: safe center;
-    justify-content: center;
     padding: 1rem;
     overflow-y: auto;
     overscroll-behavior: contain;

--- a/packages/web/src/components/EntityFormModal.svelte
+++ b/packages/web/src/components/EntityFormModal.svelte
@@ -117,7 +117,7 @@
 
   @media (max-width: 600px), (display-mode: standalone) {
     .overlay {
-      padding: 0;
+      padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
       background: var(--bg);
     }
 

--- a/packages/web/src/components/EntityFormModal.svelte
+++ b/packages/web/src/components/EntityFormModal.svelte
@@ -100,18 +100,9 @@
     inset: 0;
     z-index: 200;
     background: var(--overlay);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 1rem;
     overflow-y: auto;
     overscroll-behavior: contain;
-  }
-
-  .overlay::before,
-  .overlay::after {
-    content: '';
-    flex: 1;
+    padding: 3rem 1rem;
   }
 
   .modal {
@@ -120,7 +111,8 @@
     border-radius: var(--radius);
     width: 100%;
     padding: 1.5rem;
-    flex-shrink: 0;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   h2 {

--- a/packages/web/src/components/EntityFormModal.svelte
+++ b/packages/web/src/components/EntityFormModal.svelte
@@ -101,9 +101,10 @@
     z-index: 200;
     background: var(--overlay);
     display: flex;
-    align-items: center;
+    align-items: safe center;
     justify-content: center;
     padding: 1rem;
+    overflow-y: auto;
     overscroll-behavior: contain;
   }
 
@@ -113,6 +114,7 @@
     border-radius: var(--radius);
     width: 100%;
     padding: 1.5rem;
+    margin: auto;
   }
 
   h2 {

--- a/packages/web/src/components/EntityFormModal.svelte
+++ b/packages/web/src/components/EntityFormModal.svelte
@@ -101,9 +101,17 @@
     z-index: 200;
     background: var(--overlay);
     display: flex;
+    flex-direction: column;
+    align-items: center;
     padding: 1rem;
     overflow-y: auto;
     overscroll-behavior: contain;
+  }
+
+  .overlay::before,
+  .overlay::after {
+    content: '';
+    flex: 1;
   }
 
   .modal {
@@ -112,7 +120,7 @@
     border-radius: var(--radius);
     width: 100%;
     padding: 1.5rem;
-    margin: auto;
+    flex-shrink: 0;
   }
 
   h2 {

--- a/packages/web/src/components/EntityFormModal.svelte
+++ b/packages/web/src/components/EntityFormModal.svelte
@@ -115,6 +115,20 @@
     margin-right: auto;
   }
 
+  @media (max-width: 600px), (display-mode: standalone) {
+    .overlay {
+      padding: 0;
+      background: var(--bg);
+    }
+
+    .modal {
+      max-width: none;
+      min-height: 100%;
+      border: none;
+      border-radius: 0;
+    }
+  }
+
   h2 {
     font-size: 1.1rem;
     font-weight: 600;

--- a/packages/web/src/components/EntityFormModal.svelte
+++ b/packages/web/src/components/EntityFormModal.svelte
@@ -104,6 +104,7 @@
     align-items: center;
     justify-content: center;
     padding: 1rem;
+    overscroll-behavior: contain;
   }
 
   .modal {

--- a/packages/web/src/components/Lightbox.svelte
+++ b/packages/web/src/components/Lightbox.svelte
@@ -202,6 +202,7 @@
     justify-content: center;
     padding: 2rem;
     cursor: zoom-out;
+    overscroll-behavior: contain;
   }
 
   .lightbox-img {

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -498,18 +498,9 @@
     inset: 0;
     z-index: 200;
     background: var(--overlay);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 1rem;
     overflow-y: auto;
     overscroll-behavior: contain;
-  }
-
-  .overlay::before,
-  .overlay::after {
-    content: '';
-    flex: 1;
+    padding: 3rem 1rem;
   }
 
   .modal {
@@ -519,7 +510,8 @@
     width: 100%;
     max-width: 560px;
     padding: 1.5rem;
-    flex-shrink: 0;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   .modal-header {

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -51,6 +51,8 @@
   let showDelete = $state(false);
   let deleting = $state(false);
   let showMoveMenu = $state(false);
+  let moveButtonEl = $state<HTMLButtonElement | null>(null);
+  let dropdownStyle = $state('');
 
   // Audio playback
   const audioSrc = $derived(
@@ -181,6 +183,22 @@
 
   const canMakeTodo = $derived(item.type !== 'todo' && !item.isTodo);
   const canMakeRef = $derived(item.isTodo || item.type === 'todo');
+
+  function toggleMoveMenu() {
+    showMoveMenu = !showMoveMenu;
+    if (showMoveMenu && moveButtonEl) {
+      const rect = moveButtonEl.getBoundingClientRect();
+      const spaceAbove = rect.top;
+      const spaceBelow = window.innerHeight - rect.bottom;
+      const dropdownMaxHeight = 240;
+
+      if (spaceAbove > spaceBelow && spaceAbove > dropdownMaxHeight) {
+        dropdownStyle = `bottom: ${window.innerHeight - rect.top + 4}px; left: ${rect.left}px; max-height: ${Math.min(spaceAbove - 16, dropdownMaxHeight)}px;`;
+      } else {
+        dropdownStyle = `top: ${rect.bottom + 4}px; left: ${rect.left}px; max-height: ${Math.min(spaceBelow - 16, dropdownMaxHeight)}px;`;
+      }
+    }
+  }
 
   let convertingRef = $state(false);
 
@@ -391,7 +409,7 @@
         Delete
       </button>
       <div class="move-container">
-        <button class="btn-move" onclick={() => showMoveMenu = !showMoveMenu}>
+        <button class="btn-move" bind:this={moveButtonEl} onclick={toggleMoveMenu}>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <rect x="3" y="3" width="7" height="7"></rect>
             <rect x="14" y="3" width="7" height="7"></rect>
@@ -400,27 +418,6 @@
           </svg>
           {item.collectionId ? 'Move' : 'Collect'}
         </button>
-        {#if showMoveMenu}
-          <div class="move-dropdown">
-            {#if item.collectionId}
-              <button class="move-option" onclick={() => { moveItemToCollection(item.id, undefined).catch(e => console.error('Move failed:', e)); showMoveMenu = false; onclose(); }}>
-                Return to Inbox
-              </button>
-              <div class="move-divider"></div>
-            {/if}
-            {#each $sortedCollections as col (col.id)}
-              {#if col.id !== item.collectionId}
-                <button class="move-option" onclick={() => { moveItemToCollection(item.id, col.id).catch(e => console.error('Move failed:', e)); showMoveMenu = false; onclose(); }}>
-                  <span class="move-dot" style="background: {col.color || '#6366f1'}"></span>
-                  {col.name}
-                </button>
-              {/if}
-            {/each}
-            {#if $sortedCollections.length === 0}
-              <div class="move-empty">No collections</div>
-            {/if}
-          </div>
-        {/if}
       </div>
       <button class="btn-cancel" onclick={onclose}>Close</button>
       <button class="btn-edit" onclick={() => onedit(item)}>Edit</button>
@@ -435,6 +432,31 @@
     {/if}
   </div>
 </div>
+
+{#if showMoveMenu}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="move-backdrop" onclick={() => showMoveMenu = false}></div>
+  <div class="move-dropdown" style={dropdownStyle}>
+    {#if item.collectionId}
+      <button class="move-option" onclick={() => { moveItemToCollection(item.id, undefined).catch(e => console.error('Move failed:', e)); showMoveMenu = false; onclose(); }}>
+        Return to Inbox
+      </button>
+      <div class="move-divider"></div>
+    {/if}
+    {#each $sortedCollections as col (col.id)}
+      {#if col.id !== item.collectionId}
+        <button class="move-option" onclick={() => { moveItemToCollection(item.id, col.id).catch(e => console.error('Move failed:', e)); showMoveMenu = false; onclose(); }}>
+          <span class="move-dot" style="background: {col.color || '#6366f1'}"></span>
+          {col.name}
+        </button>
+      {/if}
+    {/each}
+    {#if $sortedCollections.length === 0}
+      <div class="move-empty">No collections</div>
+    {/if}
+  </div>
+{/if}
 
 <style>
   .overlay {
@@ -762,16 +784,22 @@
   }
 
   .move-dropdown {
-    position: absolute;
-    bottom: calc(100% + 0.35rem);
-    left: 0;
-    min-width: 180px;
+    position: fixed;
+    min-width: 200px;
+    max-width: 280px;
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     padding: 0.3rem;
-    z-index: 10;
-    box-shadow: 0 4px 16px var(--shadow);
+    z-index: 300;
+    box-shadow: 0 8px 24px var(--shadow);
+    overflow-y: auto;
+  }
+
+  .move-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 250;
   }
 
   .move-option {

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -499,8 +499,6 @@
     z-index: 200;
     background: var(--overlay);
     display: flex;
-    align-items: safe center;
-    justify-content: center;
     padding: 1rem;
     overflow-y: auto;
     overscroll-behavior: contain;

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -502,6 +502,7 @@
     align-items: center;
     justify-content: center;
     padding: 1rem;
+    overscroll-behavior: contain;
   }
 
   .modal {

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -499,9 +499,17 @@
     z-index: 200;
     background: var(--overlay);
     display: flex;
+    flex-direction: column;
+    align-items: center;
     padding: 1rem;
     overflow-y: auto;
     overscroll-behavior: contain;
+  }
+
+  .overlay::before,
+  .overlay::after {
+    content: '';
+    flex: 1;
   }
 
   .modal {
@@ -511,7 +519,7 @@
     width: 100%;
     max-width: 560px;
     padding: 1.5rem;
-    margin: auto;
+    flex-shrink: 0;
   }
 
   .modal-header {

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -472,36 +472,37 @@
         {deleting}
       />
     {/if}
+
+    {#if showMoveMenu}
+      <button
+        type="button"
+        class="move-backdrop"
+        tabindex="-1"
+        aria-label="Close move menu"
+        onclick={() => closeMoveMenu()}
+      ></button>
+      <div class="move-dropdown" style={dropdownStyle}>
+        {#if item.collectionId}
+          <button class="move-option" onclick={() => { moveItemToCollection(item.id, undefined).catch(e => console.error('Move failed:', e)); showMoveMenu = false; onclose(); }}>
+            Return to Inbox
+          </button>
+          <div class="move-divider"></div>
+        {/if}
+        {#each $sortedCollections as col (col.id)}
+          {#if col.id !== item.collectionId}
+            <button class="move-option" onclick={() => { moveItemToCollection(item.id, col.id).catch(e => console.error('Move failed:', e)); showMoveMenu = false; onclose(); }}>
+              <span class="move-dot" style="background: {col.color || '#6366f1'}"></span>
+              {col.name}
+            </button>
+          {/if}
+        {/each}
+        {#if $sortedCollections.length === 0}
+          <div class="move-empty">No collections</div>
+        {/if}
+      </div>
+    {/if}
   </div>
 </div>
-
-{#if showMoveMenu}
-  <button
-    type="button"
-    class="move-backdrop"
-    aria-label="Close move menu"
-    onclick={() => closeMoveMenu()}
-  ></button>
-  <div class="move-dropdown" style={dropdownStyle}>
-    {#if item.collectionId}
-      <button class="move-option" onclick={() => { moveItemToCollection(item.id, undefined).catch(e => console.error('Move failed:', e)); showMoveMenu = false; onclose(); }}>
-        Return to Inbox
-      </button>
-      <div class="move-divider"></div>
-    {/if}
-    {#each $sortedCollections as col (col.id)}
-      {#if col.id !== item.collectionId}
-        <button class="move-option" onclick={() => { moveItemToCollection(item.id, col.id).catch(e => console.error('Move failed:', e)); showMoveMenu = false; onclose(); }}>
-          <span class="move-dot" style="background: {col.color || '#6366f1'}"></span>
-          {col.name}
-        </button>
-      {/if}
-    {/each}
-    {#if $sortedCollections.length === 0}
-      <div class="move-empty">No collections</div>
-    {/if}
-  </div>
-{/if}
 
 <style>
   .overlay {
@@ -527,7 +528,7 @@
 
   @media (max-width: 600px), (display-mode: standalone) {
     .overlay {
-      padding: 0;
+      padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
       background: var(--bg);
     }
 

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -499,9 +499,10 @@
     z-index: 200;
     background: var(--overlay);
     display: flex;
-    align-items: center;
+    align-items: safe center;
     justify-content: center;
     padding: 1rem;
+    overflow-y: auto;
     overscroll-behavior: contain;
   }
 
@@ -511,9 +512,8 @@
     border-radius: var(--radius);
     width: 100%;
     max-width: 560px;
-    max-height: 90vh;
-    overflow-y: auto;
     padding: 1.5rem;
+    margin: auto;
   }
 
   .modal-header {

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -514,6 +514,20 @@
     margin-right: auto;
   }
 
+  @media (max-width: 600px), (display-mode: standalone) {
+    .overlay {
+      padding: 0;
+      background: var(--bg);
+    }
+
+    .modal {
+      max-width: none;
+      min-height: 100%;
+      border: none;
+      border-radius: 0;
+    }
+  }
+
   .modal-header {
     display: flex;
     align-items: center;

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -93,6 +93,7 @@
 
   onDestroy(() => {
     if (docBlobUrl) URL.revokeObjectURL(docBlobUrl);
+    removeMoveMenuListeners();
   });
 
   async function handleTranscribe() {
@@ -186,17 +187,46 @@
 
   function toggleMoveMenu() {
     showMoveMenu = !showMoveMenu;
-    if (showMoveMenu && moveButtonEl) {
-      const rect = moveButtonEl.getBoundingClientRect();
-      const spaceAbove = rect.top;
-      const spaceBelow = window.innerHeight - rect.bottom;
-      const dropdownMaxHeight = 240;
+    if (showMoveMenu) {
+      updateDropdownPosition();
+      window.addEventListener('scroll', closeMoveMenu, true);
+      window.addEventListener('resize', closeMoveMenu);
+    } else {
+      removeMoveMenuListeners();
+    }
+  }
 
-      if (spaceAbove > spaceBelow && spaceAbove > dropdownMaxHeight) {
-        dropdownStyle = `bottom: ${window.innerHeight - rect.top + 4}px; left: ${rect.left}px; max-height: ${Math.min(spaceAbove - 16, dropdownMaxHeight)}px;`;
-      } else {
-        dropdownStyle = `top: ${rect.bottom + 4}px; left: ${rect.left}px; max-height: ${Math.min(spaceBelow - 16, dropdownMaxHeight)}px;`;
-      }
+  function closeMoveMenu() {
+    showMoveMenu = false;
+    removeMoveMenuListeners();
+  }
+
+  function removeMoveMenuListeners() {
+    window.removeEventListener('scroll', closeMoveMenu, true);
+    window.removeEventListener('resize', closeMoveMenu);
+  }
+
+  function updateDropdownPosition() {
+    if (!moveButtonEl) return;
+    const rect = moveButtonEl.getBoundingClientRect();
+    const spaceAbove = rect.top;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const dropdownMaxHeight = 240;
+    const viewportPadding = 16;
+    const gap = 4;
+
+    const openUpward = spaceAbove > spaceBelow;
+    const available = openUpward ? spaceAbove : spaceBelow;
+    const maxHeight = Math.max(80, Math.min(available - viewportPadding, dropdownMaxHeight));
+
+    // Clamp horizontal position to keep dropdown on-screen
+    const dropdownWidth = 200; // min-width from CSS
+    const left = Math.max(viewportPadding, Math.min(rect.left, window.innerWidth - dropdownWidth - viewportPadding));
+
+    if (openUpward) {
+      dropdownStyle = `bottom: ${window.innerHeight - rect.top + gap}px; left: ${left}px; max-height: ${maxHeight}px;`;
+    } else {
+      dropdownStyle = `top: ${rect.bottom + gap}px; left: ${left}px; max-height: ${maxHeight}px;`;
     }
   }
 
@@ -434,10 +464,14 @@
 </div>
 
 {#if showMoveMenu}
-  <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="move-backdrop" onclick={() => showMoveMenu = false}></div>
-  <div class="move-dropdown" style={dropdownStyle}>
+  <button
+    type="button"
+    class="move-backdrop"
+    aria-label="Close move menu"
+    onclick={() => closeMoveMenu()}
+    onkeydown={(e) => { if (e.key === 'Escape') closeMoveMenu(); }}
+  ></button>
+  <div class="move-dropdown" role="listbox" style={dropdownStyle}>
     {#if item.collectionId}
       <button class="move-option" onclick={() => { moveItemToCollection(item.id, undefined).catch(e => console.error('Move failed:', e)); showMoveMenu = false; onclose(); }}>
         Return to Inbox
@@ -800,6 +834,10 @@
     position: fixed;
     inset: 0;
     z-index: 250;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: default;
   }
 
   .move-option {

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -483,14 +483,14 @@
       ></button>
       <div class="move-dropdown" style={dropdownStyle}>
         {#if item.collectionId}
-          <button class="move-option" onclick={() => { moveItemToCollection(item.id, undefined).catch(e => console.error('Move failed:', e)); showMoveMenu = false; onclose(); }}>
+          <button class="move-option" onclick={() => { moveItemToCollection(item.id, undefined).catch(e => console.error('Move failed:', e)); closeMoveMenu(); onclose(); }}>
             Return to Inbox
           </button>
           <div class="move-divider"></div>
         {/if}
         {#each $sortedCollections as col (col.id)}
           {#if col.id !== item.collectionId}
-            <button class="move-option" onclick={() => { moveItemToCollection(item.id, col.id).catch(e => console.error('Move failed:', e)); showMoveMenu = false; onclose(); }}>
+            <button class="move-option" onclick={() => { moveItemToCollection(item.id, col.id).catch(e => console.error('Move failed:', e)); closeMoveMenu(); onclose(); }}>
               <span class="move-dot" style="background: {col.color || '#6366f1'}"></span>
               {col.name}
             </button>

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -189,11 +189,22 @@
     showMoveMenu = !showMoveMenu;
     if (showMoveMenu) {
       updateDropdownPosition();
-      window.addEventListener('scroll', closeMoveMenu, true);
+      window.addEventListener('scroll', handleMoveMenuScroll, true);
       window.addEventListener('resize', closeMoveMenu);
+      window.addEventListener('keydown', handleMoveMenuKeydown);
     } else {
       removeMoveMenuListeners();
     }
+  }
+
+  function handleMoveMenuScroll(event: Event) {
+    const target = event.target;
+    if (target instanceof Element && target.closest('.move-dropdown')) return;
+    closeMoveMenu();
+  }
+
+  function handleMoveMenuKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') closeMoveMenu();
   }
 
   function closeMoveMenu() {
@@ -202,8 +213,9 @@
   }
 
   function removeMoveMenuListeners() {
-    window.removeEventListener('scroll', closeMoveMenu, true);
+    window.removeEventListener('scroll', handleMoveMenuScroll, true);
     window.removeEventListener('resize', closeMoveMenu);
+    window.removeEventListener('keydown', handleMoveMenuKeydown);
   }
 
   function updateDropdownPosition() {
@@ -217,10 +229,10 @@
 
     const openUpward = spaceAbove > spaceBelow;
     const available = openUpward ? spaceAbove : spaceBelow;
-    const maxHeight = Math.max(80, Math.min(available - viewportPadding, dropdownMaxHeight));
+    const maxHeight = Math.max(0, Math.min(available - viewportPadding, dropdownMaxHeight));
 
-    // Clamp horizontal position to keep dropdown on-screen
-    const dropdownWidth = 200; // min-width from CSS
+    // Clamp horizontal position using max possible rendered width
+    const dropdownWidth = Math.min(280, window.innerWidth - viewportPadding * 2);
     const left = Math.max(viewportPadding, Math.min(rect.left, window.innerWidth - dropdownWidth - viewportPadding));
 
     if (openUpward) {
@@ -469,9 +481,8 @@
     class="move-backdrop"
     aria-label="Close move menu"
     onclick={() => closeMoveMenu()}
-    onkeydown={(e) => { if (e.key === 'Escape') closeMoveMenu(); }}
   ></button>
-  <div class="move-dropdown" role="listbox" style={dropdownStyle}>
+  <div class="move-dropdown" style={dropdownStyle}>
     {#if item.collectionId}
       <button class="move-option" onclick={() => { moveItemToCollection(item.id, undefined).catch(e => console.error('Move failed:', e)); showMoveMenu = false; onclose(); }}>
         Return to Inbox

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -48,12 +48,28 @@
   box-sizing: border-box;
 }
 
+html {
+  overflow-x: hidden;
+  height: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   background: var(--bg);
   color: var(--text);
   line-height: 1.5;
   min-height: 100vh;
+  min-height: 100dvh;
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+
+#app {
+  width: 100%;
+  overflow-x: hidden;
+  position: relative;
 }
 
 button {


### PR DESCRIPTION
## Problem

1. **Content shifts side-to-side when scrolling** — the app feels like a zoomed-in webpage rather than a native PWA. Horizontal overflow isn't constrained, and backdrop-filter blur on the sticky header causes sub-pixel rendering jitter.

2. **Collect button dropdown gets cut off** — the dropdown opens inside the modal which has `overflow-y: auto`, clipping collections that extend beyond the modal boundary.

## Changes

### Layout stability
- Added `overflow-x: hidden` on `html`, `body`, and `#app` to prevent any horizontal scrolling
- Added `min-height: 100dvh` and `env(safe-area-inset-*)` padding for proper PWA sizing on notched devices
- Removed `backdrop-filter: blur(12px)` on header — the background is already opaque so blur did nothing visible but added GPU compositing overhead causing scroll jitter
- Made `.header-nav` horizontally scrollable with hidden scrollbar instead of overflowing the viewport
- Added `viewport-fit=cover` to viewport meta tag

### Collect dropdown fix
- Moved dropdown outside the modal using `position: fixed` with `z-index: 300`
- Added dynamic positioning that measures space above/below the button and opens in the direction with more room
- Added transparent backdrop for outside-click dismissal
- Dropdown now has `overflow-y: auto` with viewport-aware `max-height` so all collections are always reachable