### PR TITLE
feat: surface active collection todos in main todo list

### DIFF
--- a/packages/rs-module/src/schemas.ts
+++ b/packages/rs-module/src/schemas.ts
@@ -202,6 +202,7 @@ export const collectionSchema = {
     createdAt: { type: 'string' },
     color: { type: 'string' },
     groupId: { type: 'string' },
+    active: { type: 'boolean' },
   },
   required: ['id', 'name', 'itemIds', 'createdAt']
 };

--- a/packages/rs-module/src/types.ts
+++ b/packages/rs-module/src/types.ts
@@ -99,6 +99,7 @@ export interface Collection {
   createdAt: string;       // ISO 8601
   color?: string;          // optional accent color
   groupId?: string;        // optional group membership
+  active?: boolean;        // when true, top todos surface in main todo list
 }
 
 export interface CollectionGroup {

--- a/packages/web/src/components/CollectionFormModal.svelte
+++ b/packages/web/src/components/CollectionFormModal.svelte
@@ -13,6 +13,7 @@
   let name = $state(collection?.name ?? '');
   let description = $state(collection?.description ?? '');
   let color = $state(collection?.color ?? '#6366f1');
+  let active = $state(collection?.active ?? false);
 
   function handleSubmit() {
     if (!name.trim()) return;
@@ -24,6 +25,7 @@
       createdAt: collection?.createdAt ?? new Date().toISOString(),
       color,
       groupId: collection?.groupId ?? groupId,
+      active,
     });
   }
 </script>
@@ -35,6 +37,8 @@
   bind:color
   showDescription
   bind:description
+  showActive
+  bind:active
   namePlaceholder="e.g. Sockethub Bugs"
   descriptionPlaceholder="What's this collection for?"
   maxWidth="440px"

--- a/packages/web/src/components/CollectionView.svelte
+++ b/packages/web/src/components/CollectionView.svelte
@@ -61,7 +61,7 @@
     onclick={ontoggle}
     onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); ontoggle(); } }}
     aria-expanded={expanded}
-    aria-label="{expanded ? 'Collapse' : 'Expand'} {collection.name}"
+    aria-label="{expanded ? 'Collapse' : 'Expand'} {collection.name}{collection.active ? ' (active)' : ''}"
   >
     <span class="color-indicator"></span>
     {#if collection.active}

--- a/packages/web/src/components/CollectionView.svelte
+++ b/packages/web/src/components/CollectionView.svelte
@@ -64,6 +64,9 @@
     aria-label="{expanded ? 'Collapse' : 'Expand'} {collection.name}"
   >
     <span class="color-indicator"></span>
+    {#if collection.active}
+      <span class="active-dot" title="Active — todos surfaced in main list"></span>
+    {/if}
     <svg class="chevron" class:open={expanded} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="6 9 12 15 18 9"></polyline>
     </svg>
@@ -352,6 +355,21 @@
     border-radius: 2px;
     background: var(--_col);
     flex-shrink: 0;
+  }
+
+  .active-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--_col);
+    flex-shrink: 0;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--_col) 30%, transparent 70%);
+    animation: pulse-active 2s ease-in-out infinite;
+  }
+
+  @keyframes pulse-active {
+    0%, 100% { box-shadow: 0 0 0 2px color-mix(in srgb, var(--_col) 30%, transparent 70%); }
+    50% { box-shadow: 0 0 0 4px color-mix(in srgb, var(--_col) 15%, transparent 85%); }
   }
 
   .chevron {

--- a/packages/web/src/components/EntityFormModal.svelte
+++ b/packages/web/src/components/EntityFormModal.svelte
@@ -9,6 +9,8 @@
     color = $bindable('#6366f1'),
     showDescription = false,
     description = $bindable(''),
+    showActive = false,
+    active = $bindable(false),
     namePlaceholder = '',
     descriptionPlaceholder = '',
     maxWidth = '440px',
@@ -23,6 +25,8 @@
     color: string;
     showDescription?: boolean;
     description?: string;
+    showActive?: boolean;
+    active?: boolean;
     namePlaceholder?: string;
     descriptionPlaceholder?: string;
     maxWidth?: string;
@@ -70,6 +74,25 @@
           {/each}
         </div>
       </fieldset>
+
+      {#if showActive}
+        <label class="field field-toggle">
+          <span class="toggle-text">
+            <span class="label">Active</span>
+            <span class="toggle-hint">Surface top todos in the main todo list</span>
+          </span>
+          <button
+            type="button"
+            class="toggle-switch"
+            class:on={active}
+            onclick={() => active = !active}
+            role="switch"
+            aria-checked={active}
+          >
+            <span class="toggle-knob"></span>
+          </button>
+        </label>
+      {/if}
 
       <div class="actions">
         {#if isEdit && ondelete}
@@ -266,5 +289,62 @@
 
   .actions-spacer {
     flex: 1;
+  }
+
+  .field-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    cursor: pointer;
+  }
+
+  .toggle-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+
+  .toggle-text .label {
+    margin-bottom: 0;
+  }
+
+  .toggle-hint {
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    opacity: 0.7;
+  }
+
+  .toggle-switch {
+    position: relative;
+    width: 40px;
+    height: 22px;
+    border-radius: 999px;
+    border: none;
+    background: color-mix(in srgb, var(--text-muted) 25%, var(--bg) 75%);
+    cursor: pointer;
+    transition: background 200ms;
+    flex-shrink: 0;
+    padding: 0;
+  }
+
+  .toggle-switch.on {
+    background: var(--accent);
+  }
+
+  .toggle-knob {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: white;
+    transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  }
+
+  .toggle-switch.on .toggle-knob {
+    transform: translateX(18px);
   }
 </style>

--- a/packages/web/src/components/TodoList.svelte
+++ b/packages/web/src/components/TodoList.svelte
@@ -96,7 +96,7 @@
           </li>
         {/each}
       </ul>
-    {:else if todos.length === 0}
+    {:else if todos.length === 0 && collectionTodos.length === 0}
       <p class="empty">No todos yet.</p>
     {/if}
 
@@ -129,7 +129,7 @@
               <div class="todo-meta">
                 <span
                   class="origin-pill"
-                  title="{ct.groupColor ? 'Group' : ''} › {ct.collectionName}"
+                  title={ct.groupName ? `${ct.groupName} › ${ct.collectionName}` : ct.collectionName}
                   style="--pill-left: {ct.groupColor || ct.collectionColor}; --pill-right: {ct.collectionColor}"
                 >
                   <span class="pill-half pill-left"></span><span class="pill-half pill-right"></span>

--- a/packages/web/src/components/TodoList.svelte
+++ b/packages/web/src/components/TodoList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { InboxItem } from '@inbox-rs/rs-module';
-  import { todoItems, storeItem } from '../lib/stores';
+  import { todoItems, storeItem, activeCollectionTodos } from '../lib/stores';
   import { cleanForStorage } from '../lib/clean-for-storage';
   import { typeBadge } from '../lib/item-utils';
 
@@ -13,6 +13,8 @@
   const todos = $derived($todoItems);
   const openTodos = $derived(todos.filter(t => !t.completed));
   const completedTodos = $derived(todos.filter(t => t.completed));
+  const collectionTodos = $derived($activeCollectionTodos);
+  const totalOpenCount = $derived(openTodos.length + collectionTodos.length);
   let expanded = $state(!inline);
   let showCompleted = $state(false);
   async function toggleCompleted(e: Event, todo: InboxItem) {
@@ -40,8 +42,8 @@
         <polyline points="6 9 12 15 18 9"></polyline>
       </svg>
       <h2 class="todo-heading">Todos</h2>
-      {#if openTodos.length > 0}
-        <span class="todo-badge">{openTodos.length}</span>
+      {#if totalOpenCount > 0}
+        <span class="todo-badge">{totalOpenCount}</span>
       {:else if expanded && todos.length > 0}
         <span class="todo-count">0/{todos.length}</span>
       {/if}
@@ -96,6 +98,54 @@
       </ul>
     {:else if todos.length === 0}
       <p class="empty">No todos yet.</p>
+    {/if}
+
+    {#if collectionTodos.length > 0}
+      <ul role="list" class="collection-todos-list">
+        {#each collectionTodos as ct (ct.item.id)}
+          {@const badge = typeBadge(ct.item)}
+          {@const note = todoNote(ct.item)}
+          <li class="todo-item" role="button" tabindex="0"
+            onclick={(e) => {
+              const target = e.target as HTMLElement;
+              if (target.closest('input, button')) return;
+              onselect(ct.item);
+            }}
+            onkeydown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onselect(ct.item); }
+            }}>
+            <input
+              type="checkbox"
+              class="checkbox"
+              checked={false}
+              onclick={(e) => e.stopPropagation()}
+              onchange={(e) => toggleCompleted(e, ct.item)}
+              aria-label="Mark {ct.item.title} as complete"
+            />
+            <div class="todo-content">
+              <div class="todo-title-row">
+                <span class="todo-title">{ct.item.title}</span>
+              </div>
+              <div class="todo-meta">
+                <span
+                  class="origin-pill"
+                  title="{ct.groupColor ? 'Group' : ''} › {ct.collectionName}"
+                  style="--pill-left: {ct.groupColor || ct.collectionColor}; --pill-right: {ct.collectionColor}"
+                >
+                  <span class="pill-half pill-left"></span><span class="pill-half pill-right"></span>
+                  <span class="pill-label">{ct.collectionName}</span>
+                </span>
+                {#if badge}
+                  <span class="type-badge">{badge}</span>
+                {/if}
+                {#if note}
+                  <span class="todo-note">{note}</span>
+                {/if}
+              </div>
+            </div>
+          </li>
+        {/each}
+      </ul>
     {/if}
 
     {#if completedTodos.length > 0}
@@ -396,5 +446,50 @@
 
   .chevron-sm.collapsed {
     transform: rotate(-90deg);
+  }
+
+  /* ---- Active collection todos ---- */
+  .collection-todos-list {
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent 40%);
+  }
+
+  .origin-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    height: 18px;
+    border-radius: 999px;
+    overflow: hidden;
+    flex-shrink: 0;
+    position: relative;
+  }
+
+  .pill-half {
+    width: 7px;
+    height: 100%;
+  }
+
+  .pill-left {
+    background: var(--pill-left);
+    border-radius: 999px 0 0 999px;
+  }
+
+  .pill-right {
+    background: var(--pill-right);
+    border-radius: 0 999px 999px 0;
+  }
+
+  .pill-label {
+    font-size: 0.6rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--text-muted);
+    padding-right: 0.4rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 10rem;
   }
 </style>

--- a/packages/web/src/components/TodoList.svelte
+++ b/packages/web/src/components/TodoList.svelte
@@ -132,7 +132,7 @@
                   title={ct.groupName ? `${ct.groupName} › ${ct.collectionName}` : ct.collectionName}
                   style="--pill-left: {ct.groupColor || ct.collectionColor}; --pill-right: {ct.collectionColor}"
                 >
-                  <span class="pill-half pill-left"></span><span class="pill-half pill-right"></span>
+                  <span class="pill-swatch"></span>
                   <span class="pill-label">{ct.collectionName}</span>
                 </span>
                 {#if badge}
@@ -458,27 +458,16 @@
   .origin-pill {
     display: inline-flex;
     align-items: center;
-    gap: 0.3rem;
-    height: 18px;
-    border-radius: 999px;
-    overflow: hidden;
+    gap: 0.35rem;
     flex-shrink: 0;
-    position: relative;
   }
 
-  .pill-half {
-    width: 7px;
-    height: 100%;
-  }
-
-  .pill-left {
-    background: var(--pill-left);
-    border-radius: 999px 0 0 999px;
-  }
-
-  .pill-right {
-    background: var(--pill-right);
-    border-radius: 0 999px 999px 0;
+  .pill-swatch {
+    width: 20px;
+    height: 10px;
+    border-radius: 999px;
+    background: linear-gradient(to right, var(--pill-left) 50%, var(--pill-right) 50%);
+    flex-shrink: 0;
   }
 
   .pill-label {
@@ -486,7 +475,6 @@
     font-weight: 600;
     letter-spacing: 0.02em;
     color: var(--text-muted);
-    padding-right: 0.4rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -259,21 +259,24 @@ export interface ActiveCollectionTodo {
   collectionId: string;
   collectionName: string;
   collectionColor: string;
+  groupName: string | undefined;
   groupColor: string | undefined;
 }
 
 export const activeCollectionTodos = derived(
-  [items, collections, groups],
-  ([$items, $collections, $groups]): ActiveCollectionTodo[] => {
+  [items, sortedCollections, groups],
+  ([$items, $sortedCollections, $groups]): ActiveCollectionTodo[] => {
     const MAX_PER_COLLECTION = 5;
     const result: ActiveCollectionTodo[] = [];
     const itemMap = new Map(Object.values($items).map(i => [i.id, i]));
 
-    for (const col of Object.values($collections)) {
+    for (const col of $sortedCollections) {
       if (!col.active) continue;
 
       // Resolve group color if the collection belongs to a group
-      const groupColor = col.groupId ? ($groups[col.groupId]?.color || undefined) : undefined;
+      const group = col.groupId ? $groups[col.groupId] : undefined;
+      const groupColor = group?.color || undefined;
+      const groupName = group?.name || undefined;
 
       // Get todos from this collection, open ones only
       const colTodos = col.itemIds
@@ -286,6 +289,7 @@ export const activeCollectionTodos = derived(
           collectionId: col.id,
           collectionName: col.name,
           collectionColor: col.color || '#6366f1',
+          groupName,
           groupColor,
         });
       }

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -278,12 +278,12 @@ export const activeCollectionTodos = derived(
       const groupColor = group?.color || undefined;
       const groupName = group?.name || undefined;
 
-      // Get todos from this collection, open ones only
-      const colTodos = col.itemIds
-        .map(id => itemMap.get(id))
-        .filter((i): i is InboxItem => i !== undefined && (i.isTodo || i.type === 'todo') && !i.completed);
-
-      for (const item of colTodos.slice(0, MAX_PER_COLLECTION)) {
+      // Collect open todos from this collection, stopping at MAX_PER_COLLECTION
+      let count = 0;
+      for (const id of col.itemIds) {
+        if (count >= MAX_PER_COLLECTION) break;
+        const item = itemMap.get(id);
+        if (!item || !(item.isTodo || item.type === 'todo') || item.completed) continue;
         result.push({
           item,
           collectionId: col.id,
@@ -292,6 +292,7 @@ export const activeCollectionTodos = derived(
           groupName,
           groupColor,
         });
+        count++;
       }
     }
 

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -252,6 +252,49 @@ export const todoItems = derived(items, ($items) => {
 
 export const sortedCollections = orderedDerived<Collection>(collections, 'collectionsOrder');
 
+/** Todos from active collections, surfaced for the main todo list.
+ *  Each todo is annotated with its source collection info. */
+export interface ActiveCollectionTodo {
+  item: InboxItem;
+  collectionId: string;
+  collectionName: string;
+  collectionColor: string;
+  groupColor: string | undefined;
+}
+
+export const activeCollectionTodos = derived(
+  [items, collections, groups],
+  ([$items, $collections, $groups]): ActiveCollectionTodo[] => {
+    const MAX_PER_COLLECTION = 5;
+    const result: ActiveCollectionTodo[] = [];
+    const itemMap = new Map(Object.values($items).map(i => [i.id, i]));
+
+    for (const col of Object.values($collections)) {
+      if (!col.active) continue;
+
+      // Resolve group color if the collection belongs to a group
+      const groupColor = col.groupId ? ($groups[col.groupId]?.color || undefined) : undefined;
+
+      // Get todos from this collection, open ones only
+      const colTodos = col.itemIds
+        .map(id => itemMap.get(id))
+        .filter((i): i is InboxItem => i !== undefined && (i.isTodo || i.type === 'todo') && !i.completed);
+
+      for (const item of colTodos.slice(0, MAX_PER_COLLECTION)) {
+        result.push({
+          item,
+          collectionId: col.id,
+          collectionName: col.name,
+          collectionColor: col.color || '#6366f1',
+          groupColor,
+        });
+      }
+    }
+
+    return result;
+  }
+);
+
 export const collectionItems = derived([items, collections], ([$items, $collections]) => {
   const result: Record<string, InboxItem[]> = {};
   const itemMap = new Map(Object.values($items).map(i => [i.id, i]));


### PR DESCRIPTION
## What

When a collection is marked **active**, its top open todos (up to 5) are surfaced in the main page's todo list. Each surfaced todo has a **dual-color origin pill** — the left half shows the group color, the right half shows the collection color — making it easy to identify where each todo originates.

## Changes

- **`Collection.active`** — new optional boolean on the `Collection` type
- **Active toggle** in the collection create/edit form (EntityFormModal + CollectionFormModal)
- **`activeCollectionTodos` derived store** — pulls open todos from active collections with their collection/group color metadata
- **TodoList** — renders collection todos below inbox todos with the origin pill indicator; badge count includes both sources
- **CollectionView** — pulsing dot indicator on active collections

## Visual Design

The origin pill uses a split-color approach:
```
┌──────────────────────────┐
│ ██ ██ Collection Name    │  ← left = group color, right = collection color
└──────────────────────────┘
```
When a collection has no group, both halves show the collection color.