### PR TITLE
ci: add GitHub Release creation to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,8 @@ jobs:
         run: |
           git tag "v${{ steps.version.outputs.version }}"
           git push origin HEAD:master --tags
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "v${{ steps.version.outputs.version }}" --generate-notes


### PR DESCRIPTION
Adds a final step to the release workflow that creates a GitHub Release entry with auto-generated release notes, matching the pattern used in setlist-roller.