### PR TITLE
feat: show default collections group as move destination

### DIFF
--- a/packages/web/src/components/CollectionView.svelte
+++ b/packages/web/src/components/CollectionView.svelte
@@ -101,7 +101,7 @@
       </button>
       {#if availableGroups.length > 0}
         <div class="move-menu-wrapper">
-          <button class="btn-header" onclick={(e) => { e.stopPropagation(); showMoveMenu = !showMoveMenu; }} aria-label="Move to group" title="Move to group">
+          <button class="btn-header" aria-label="Move to group" aria-haspopup="menu" aria-expanded={showMoveMenu} title="Move to group" onclick={(e) => { e.stopPropagation(); showMoveMenu = !showMoveMenu; }}>
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
               <line x1="12" y1="11" x2="12" y2="17"></line>

--- a/packages/web/src/components/CollectionView.svelte
+++ b/packages/web/src/components/CollectionView.svelte
@@ -114,6 +114,21 @@
             <div class="move-menu-backdrop" onclick={(e) => { e.stopPropagation(); showMoveMenu = false; }}></div>
             <div class="move-menu" onclick={(e) => e.stopPropagation()}>
               <div class="move-menu-label">Move to group</div>
+              <button
+                class="move-menu-item"
+                class:current={!collection.groupId}
+                onclick={() => handleMoveToGroup(undefined)}
+                disabled={!collection.groupId}
+              >
+                <span class="move-dot" style="background: var(--text-muted)"></span>
+                Collections
+                {#if !collection.groupId}
+                  <svg class="check-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="20 6 9 17 4 12"></polyline>
+                  </svg>
+                {/if}
+              </button>
+              <div class="move-menu-divider"></div>
               {#each availableGroups as group (group.id)}
                 <button
                   class="move-menu-item"
@@ -130,12 +145,6 @@
                   {/if}
                 </button>
               {/each}
-              {#if collection.groupId}
-                <div class="move-menu-divider"></div>
-                <button class="move-menu-item move-menu-ungrouped" onclick={() => handleMoveToGroup(undefined)}>
-                  Remove from group
-                </button>
-              {/if}
             </div>
           {/if}
         </div>
@@ -563,11 +572,6 @@
     height: 1px;
     background: var(--border);
     margin: 0.25rem 0;
-  }
-
-  .move-menu-ungrouped {
-    color: var(--text-muted);
-    font-size: 0.78rem;
   }
 
   /* ================================================================

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { untrack, onDestroy } from 'svelte';
   import type { InboxItem } from '@inbox-rs/rs-module';
-  import { deleteItem, storeItem, blobUrls, connected, sortedCollections, moveItemToCollection, loadFileBlobUrl } from '../lib/stores';
+  import { deleteItem, storeItem, blobUrls, connected, ungroupedCollections, sortedGroups, groupCollections, moveItemToCollection, loadFileBlobUrl } from '../lib/stores';
   import rs from '../lib/rs';
   import { transcribeAudio } from '../lib/transcribe';
   import ShareButton from './ShareButton.svelte';
@@ -488,7 +488,7 @@
           </button>
           <div class="move-divider"></div>
         {/if}
-        {#each $sortedCollections as col (col.id)}
+        {#each $ungroupedCollections as col (col.id)}
           {#if col.id !== item.collectionId}
             <button class="move-option" onclick={() => { moveItemToCollection(item.id, col.id).catch(e => console.error('Move failed:', e)); closeMoveMenu(); onclose(); }}>
               <span class="move-dot" style="background: {col.color || '#6366f1'}"></span>
@@ -496,7 +496,17 @@
             </button>
           {/if}
         {/each}
-        {#if $sortedCollections.length === 0}
+        {#each $sortedGroups as group (group.id)}
+          {#each ($groupCollections[group.id] ?? []) as col (col.id)}
+            {#if col.id !== item.collectionId}
+              <button class="move-option" onclick={() => { moveItemToCollection(item.id, col.id).catch(e => console.error('Move failed:', e)); closeMoveMenu(); onclose(); }}>
+                <span class="move-dot" style="background: {col.color || '#6366f1'}"></span>
+                <span class="move-group-prefix" style="color: {group.color || 'var(--accent)'}">{group.name}</span> : {col.name}
+              </button>
+            {/if}
+          {/each}
+        {/each}
+        {#if $ungroupedCollections.length === 0 && $sortedGroups.length === 0}
           <div class="move-empty">No collections</div>
         {/if}
       </div>
@@ -889,6 +899,11 @@
     height: 8px;
     border-radius: 50%;
     flex-shrink: 0;
+  }
+
+  .move-group-prefix {
+    font-weight: 600;
+    font-size: 0.78rem;
   }
 
   .move-divider {


### PR DESCRIPTION
Replace the 'Remove from group' option in the collection move menu with a proper **Collections** entry, making the default/ungrouped area a first-class destination alongside named groups.

### Changes

- Added a "Collections" entry at the top of the move-to-group menu representing the default (ungrouped) area
- Shows a check mark when the collection is currently ungrouped, disabled to prevent no-op moves
- Divider separates the default entry from named groups
- Removed the old "Remove from group" link and its `.move-menu-ungrouped` style