### PR TITLE
feat(web): user menu with theme switcher and light mode logo

### DIFF
--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { InboxItemType, InboxItem, Collection, CollectionGroup } from '@inbox-rs/rs-module';
-  import ConnectWidget from './components/ConnectWidget.svelte';
+  import UserMenu from './components/UserMenu.svelte';
   import InboxGrid from './components/InboxGrid.svelte';
   import TodoList from './components/TodoList.svelte';
   import AddEntryBar from './components/AddEntryBar.svelte';
@@ -14,7 +14,7 @@
   import GroupFormModal from './components/GroupFormModal.svelte';
   import { connected, deleteItem, todoItems, appConfig, updateConfig, pendingMigrationCount, runAllMigrations, storeCollection, sortedGroups, storeGroup, moveCollectionToGroup } from './lib/stores';
   import { pluginArtifactVersion } from './lib/plugin-downloads.generated';
-  import logoShield from './assets/logos/logo-shield.svg';
+  import LogoShield from './components/LogoShield.svelte';
 
   type Route =
     | { page: 'home' }
@@ -158,7 +158,7 @@
     <div class="brand">
       <a class="brand-link" href="#/">
         <h1 class="sr-only">Inbox RS</h1>
-        <img src={logoShield} alt="" aria-hidden="true" class="brand-logo" />
+        <span class="brand-logo" aria-hidden="true"><LogoShield /></span>
       </a>
     </div>
     <nav class="header-nav" aria-label="Primary">
@@ -186,7 +186,7 @@
       {/if}
     </nav>
     <div class="header-right">
-      <ConnectWidget />
+      <UserMenu />
     </div>
   </div>
 </header>
@@ -333,6 +333,12 @@
   }
 
   .brand-logo {
+    display: inline-flex;
+    height: 38px;
+    width: auto;
+  }
+
+  .brand-logo :global(svg) {
     height: 38px;
     width: auto;
   }
@@ -490,6 +496,11 @@
 
     .brand-logo {
       height: 30px;
+    }
+
+    .brand-logo :global(svg) {
+      height: 30px;
+      width: auto;
     }
 
     /* Row 1, right: connection controls */

--- a/packages/web/src/components/LogoShield.svelte
+++ b/packages/web/src/components/LogoShield.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  let isLight = $state(false);
+
+  function checkLight() {
+    const dt = document.documentElement.getAttribute('data-theme');
+    if (dt === 'light') { isLight = true; return; }
+    if (dt === 'dark') { isLight = false; return; }
+    // system
+    isLight = window.matchMedia('(prefers-color-scheme: light)').matches;
+  }
+
+  onMount(() => {
+    checkLight();
+    const mq = window.matchMedia('(prefers-color-scheme: light)');
+    const onMq = () => checkLight();
+    mq.addEventListener('change', onMq);
+
+    const observer = new MutationObserver(() => checkLight());
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+
+    return () => {
+      mq.removeEventListener('change', onMq);
+      observer.disconnect();
+    };
+  });
+</script>
+
+<svg viewBox="0 0 155 40" xmlns="http://www.w3.org/2000/svg" class="logo-shield">
+  <!-- Icon -->
+  <g transform="translate(4, 2) scale(1.15)">
+    <path d="M16 2 L28 7 L28 16 Q28 26 16 30 Q4 26 4 16 L4 7 Z" fill="#6366f1"/>
+    <path d="M8 15 L10.5 23 L13 23 L13 20 Q13 19 14.5 19 L17.5 19 Q19 19 19 20 L19 23 L21.5 23 L24 15 Z" fill="#818cf8"/>
+    <rect x="14.8" y="7" width="2.4" height="7" rx="1.2" fill="#e4e6eb"/>
+    <polygon points="16,16 12,12 13.5,10.8 16,13.5 18.5,10.8 20,12" fill="#e4e6eb"/>
+  </g>
+  <!-- Wordmark -->
+  <text x="44" y="27" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-weight="700" font-size="22" letter-spacing="-0.02em"
+    fill={isLight ? '#1a1d27' : '#e4e6eb'}>Inbox <tspan fill={isLight ? '#4f46e5' : '#6366f1'}>RS</tspan></text>
+</svg>
+
+<style>
+  .logo-shield {
+    display: block;
+  }
+</style>

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -1,0 +1,438 @@
+<script lang="ts">
+  import rs from '../lib/rs';
+  import { connected, syncing } from '../lib/stores';
+
+  let open = $state(false);
+  let userAddress = $state('');
+  let connecting = $state(false);
+  let theme = $state<'system' | 'light' | 'dark'>(getStoredTheme());
+
+  function getStoredTheme(): 'system' | 'light' | 'dark' {
+    if (typeof localStorage === 'undefined') return 'system';
+    return (localStorage.getItem('inbox-rs-theme') as 'system' | 'light' | 'dark') || 'system';
+  }
+
+  function applyTheme(t: 'system' | 'light' | 'dark') {
+    theme = t;
+    localStorage.setItem('inbox-rs-theme', t);
+    const root = document.documentElement;
+    if (t === 'system') {
+      root.removeAttribute('data-theme');
+      root.style.colorScheme = '';
+    } else {
+      root.setAttribute('data-theme', t);
+      root.style.colorScheme = t;
+    }
+  }
+
+  // Apply stored theme on mount
+  $effect(() => {
+    applyTheme(theme);
+  });
+
+  function toggle() {
+    open = !open;
+  }
+
+  function closeMenu(e: MouseEvent) {
+    const target = e.target as HTMLElement;
+    if (!target.closest('.user-menu')) {
+      open = false;
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') open = false;
+  }
+
+  $effect(() => {
+    if (open) {
+      document.addEventListener('click', closeMenu, true);
+      document.addEventListener('keydown', handleKeydown, true);
+    }
+    return () => {
+      document.removeEventListener('click', closeMenu, true);
+      document.removeEventListener('keydown', handleKeydown, true);
+    };
+  });
+
+  async function handleConnect() {
+    if (!userAddress.trim()) return;
+    connecting = true;
+    try {
+      rs.connect(userAddress.trim());
+    } catch {
+      connecting = false;
+    }
+  }
+
+  function handleDisconnect() {
+    rs.disconnect();
+    open = false;
+  }
+
+  $effect(() => {
+    if ($connected) connecting = false;
+  });
+</script>
+
+<div class="user-menu">
+  <button
+    class="trigger"
+    onclick={toggle}
+    aria-expanded={open}
+    aria-haspopup="true"
+    aria-label={$connected ? 'User menu — connected' : 'User menu — disconnected'}
+  >
+    <svg class="trigger-sync" class:spinning={$syncing} width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="23 4 23 10 17 10"></polyline>
+      <polyline points="1 20 1 14 7 14"></polyline>
+      <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10"></path>
+      <path d="M20.49 15a9 9 0 0 1-14.85 3.36L1 14"></path>
+    </svg>
+    <span class="trigger-dot" class:connected={$connected}></span>
+    <svg class="trigger-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
+      <circle cx="12" cy="7" r="4"></circle>
+    </svg>
+  </button>
+
+  {#if open}
+    <div class="dropdown" role="menu">
+      <!-- Connection status -->
+      <div class="section-label">Connection</div>
+      {#if $connected}
+        <div class="status-row">
+          <span class="status-dot connected"></span>
+          <span class="status-label">Connected</span>
+        </div>
+        <button class="menu-item danger" role="menuitem" onclick={handleDisconnect}>
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path>
+            <polyline points="16 17 21 12 16 7"></polyline>
+            <line x1="21" y1="12" x2="9" y2="12"></line>
+          </svg>
+          Disconnect
+        </button>
+      {:else}
+        <div class="status-row">
+          <span class="status-dot"></span>
+          <span class="status-label">Not connected</span>
+        </div>
+        <form class="connect-form" onsubmit={(e) => { e.preventDefault(); handleConnect(); }}>
+          <input
+            type="text"
+            bind:value={userAddress}
+            placeholder="user@storage.example"
+            disabled={connecting}
+          />
+          <button type="submit" class="btn-connect" disabled={connecting || !userAddress.trim()}>
+            {connecting ? 'Connecting…' : 'Connect'}
+          </button>
+        </form>
+      {/if}
+
+      <div class="divider"></div>
+
+      <!-- Theme -->
+      <div class="section-label">Theme</div>
+      <div class="theme-switcher" role="radiogroup" aria-label="Theme">
+        <button
+          class="theme-option"
+          class:active={theme === 'system'}
+          role="radio"
+          aria-checked={theme === 'system'}
+          onclick={() => applyTheme('system')}
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
+            <line x1="8" y1="21" x2="16" y2="21"></line>
+            <line x1="12" y1="17" x2="12" y2="21"></line>
+          </svg>
+          System
+        </button>
+        <button
+          class="theme-option"
+          class:active={theme === 'light'}
+          role="radio"
+          aria-checked={theme === 'light'}
+          onclick={() => applyTheme('light')}
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="5"></circle>
+            <line x1="12" y1="1" x2="12" y2="3"></line>
+            <line x1="12" y1="21" x2="12" y2="23"></line>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+            <line x1="1" y1="12" x2="3" y2="12"></line>
+            <line x1="21" y1="12" x2="23" y2="12"></line>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+          </svg>
+          Light
+        </button>
+        <button
+          class="theme-option"
+          class:active={theme === 'dark'}
+          role="radio"
+          aria-checked={theme === 'dark'}
+          onclick={() => applyTheme('dark')}
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+          </svg>
+          Dark
+        </button>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .user-menu {
+    position: relative;
+  }
+
+  /* ── Trigger button ──────────────────────── */
+  .trigger {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.55rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    transition: border-color 150ms, background 150ms;
+  }
+
+  .trigger:hover {
+    border-color: var(--accent);
+    background: var(--surface-hover);
+  }
+
+  .trigger-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--text-muted);
+    opacity: 0.4;
+    flex-shrink: 0;
+    transition: background 200ms, opacity 200ms;
+  }
+
+  .trigger-dot.connected {
+    background: #22c55e;
+    opacity: 1;
+  }
+
+  .trigger-icon {
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .trigger-sync {
+    color: var(--accent);
+    flex-shrink: 0;
+    opacity: 0;
+    transition: opacity 150ms;
+  }
+
+  .trigger-sync.spinning {
+    opacity: 1;
+    animation: spin 1s linear infinite;
+  }
+
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+
+  /* ── Dropdown ────────────────────────────── */
+  .dropdown {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    width: 260px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.5rem;
+    box-shadow: 0 8px 24px var(--shadow), 0 2px 8px var(--shadow);
+    z-index: 200;
+    animation: dropdown-in 120ms ease-out;
+  }
+
+  @keyframes dropdown-in {
+    from {
+      opacity: 0;
+      transform: translateY(-4px) scale(0.97);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  .section-label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    padding: 0.35rem 0.5rem 0.2rem;
+  }
+
+  .divider {
+    height: 1px;
+    background: var(--border);
+    margin: 0.4rem 0;
+  }
+
+  /* ── Status row ──────────────────────────── */
+  .status-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.5rem;
+  }
+
+  .status-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--text-muted);
+    opacity: 0.35;
+    flex-shrink: 0;
+  }
+
+  .status-dot.connected {
+    background: #22c55e;
+    opacity: 1;
+  }
+
+  .status-label {
+    font-size: 0.82rem;
+    color: var(--text-muted);
+  }
+
+  /* ── Menu items ──────────────────────────── */
+  .menu-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.45rem 0.5rem;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: none;
+    color: var(--text);
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 120ms;
+  }
+
+  .menu-item:hover {
+    background: var(--surface-hover);
+  }
+
+  .menu-item.danger {
+    color: var(--danger);
+  }
+
+  .menu-item.danger:hover {
+    background: color-mix(in srgb, var(--danger) 10%, var(--surface) 90%);
+  }
+
+  /* ── Connect form ────────────────────────── */
+  .connect-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding: 0.25rem 0.5rem 0.35rem;
+  }
+
+  .connect-form input {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.4rem 0.6rem;
+    color: var(--text);
+    font-size: 0.82rem;
+    outline: none;
+    transition: border-color 150ms;
+    width: 100%;
+  }
+
+  .connect-form input:focus {
+    border-color: var(--accent);
+  }
+
+  .connect-form input::placeholder {
+    color: var(--text-muted);
+  }
+
+  .btn-connect {
+    background: var(--accent);
+    color: white;
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: 0.4rem 0.75rem;
+    font-size: 0.82rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 150ms;
+  }
+
+  .btn-connect:hover:not(:disabled) {
+    background: var(--accent-hover);
+  }
+
+  .btn-connect:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* ── Theme switcher ──────────────────────── */
+  .theme-switcher {
+    display: flex;
+    gap: 2px;
+    padding: 0.25rem 0.5rem 0.35rem;
+  }
+
+  .theme-option {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.3rem;
+    padding: 0.35rem 0.4rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: none;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 150ms;
+  }
+
+  .theme-option:hover {
+    color: var(--text);
+    border-color: var(--text-muted);
+  }
+
+  .theme-option.active {
+    color: var(--accent);
+    border-color: var(--accent);
+    background: var(--accent-subtle);
+  }
+
+  /* ── Mobile ──────────────────────────────── */
+  @media (max-width: 768px) {
+    .dropdown {
+      width: 240px;
+    }
+  }
+</style>

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -21,7 +21,7 @@
 }
 
 @media (prefers-color-scheme: light) {
-  :root {
+  :root:not([data-theme="dark"]) {
     --bg: #f8f9fb;
     --surface: #ffffff;
     --surface-hover: #f0f1f4;
@@ -40,6 +40,26 @@
     --surface-tint: rgba(0, 0, 0, 0.04);
     --surface-tint-hover: rgba(0, 0, 0, 0.07);
   }
+}
+
+:root[data-theme="light"] {
+  --bg: #f8f9fb;
+  --surface: #ffffff;
+  --surface-hover: #f0f1f4;
+  --border: #d8dbe3;
+  --text: #1a1d27;
+  --text-muted: #6b7084;
+  --accent: #4f46e5;
+  --accent-hover: #4338ca;
+  --danger: #dc2626;
+  --danger-hover: #b91c1c;
+  --overlay: rgba(0, 0, 0, 0.4);
+  --shadow: rgba(0, 0, 0, 0.1);
+  --accent-subtle: rgba(79, 70, 229, 0.1);
+  --accent-subtler: rgba(79, 70, 229, 0.06);
+  --accent-subtle-strong: rgba(79, 70, 229, 0.18);
+  --surface-tint: rgba(0, 0, 0, 0.04);
+  --surface-tint-hover: rgba(0, 0, 0, 0.07);
 }
 
 * {


### PR DESCRIPTION
## Summary

Replaces the `ConnectWidget` with a compact **UserMenu** dropdown and adds manual **theme switching** (System / Light / Dark).

### Changes

#### New: `UserMenu.svelte`
- **Collapsed**: Pill button with status dot (green when connected, dim when not), sync animation, and user icon
- **Expanded dropdown**: Connection section (status + disconnect/connect form) and theme switcher
- Theme preference persisted to `localStorage`
- Sync icon always reserves space (opacity toggle) to prevent layout shift

#### New: `LogoShield.svelte`
- Inline SVG component replacing the static `<img>` import
- "Inbox" text reactively adapts to light/dark — including manual `data-theme` overrides (via MutationObserver)
- Shield icon stays purple in all themes

#### Updated: `global.css`
- `prefers-color-scheme: light` now excludes `[data-theme="dark"]`
- Added `[data-theme="light"]` rule for manual light mode on dark-OS systems

#### Updated: `App.svelte`
- Swapped `ConnectWidget` → `UserMenu`
- Swapped static logo `<img>` → inline `<LogoShield />` component