### PR TITLE
feat(web): expand color palette from 16 to 32 preset colors

### DIFF
--- a/packages/web/src/lib/constants.ts
+++ b/packages/web/src/lib/constants.ts
@@ -1,6 +1,10 @@
 export const PRESET_COLORS = [
-  '#6366f1', '#8b5cf6', '#a855f7', '#ec4899',
-  '#f43f5e', '#ef4444', '#f97316', '#eab308',
-  '#84cc16', '#22c55e', '#14b8a6', '#06b6d4',
-  '#0ea5e9', '#3b82f6', '#6474a8', '#a1a1aa',
+  // violet → pink → red → orange
+  '#6366f1', '#8b5cf6', '#a855f7', '#d946ef', '#ec4899', '#f43f5e', '#ef4444', '#f97316',
+  // yellow → green → teal → blue
+  '#eab308', '#84cc16', '#22c55e', '#14b8a6', '#06b6d4', '#0ea5e9', '#3b82f6', '#6474a8',
+  // deeper / richer shades
+  '#4f46e5', '#7c3aed', '#db2777', '#dc2626', '#ea580c', '#d97706', '#65a30d', '#15803d',
+  // lighter / neutral
+  '#0f766e', '#0284c7', '#2563eb', '#fca5a5', '#fbcfe8', '#bfdbfe', '#a1a1aa', '#6b7280',
 ];


### PR DESCRIPTION
## Summary

Doubles the number of available color swatches in the collection and group color pickers from **16 → 32**.

## Changes

- **`packages/web/src/lib/constants.ts`** — expanded `PRESET_COLORS` array, organized into four logical rows:

| Row | Description | Notable additions |
|-----|-------------|-------------------|
| 1 | Violet → pink → red → orange | `#d946ef` fuchsia |
| 2 | Yellow → green → teal → blue | *(all existing)* |
| 3 | Deeper / richer shades | deep indigo, violet, pink, red, orange, amber, lime, forest green |
| 4 | Lighter / neutral | deep teal, sky, royal blue, blush, soft pink, powder blue, grays |

## Backwards Compatibility

All 16 original colors are preserved — existing collections and groups keep their assigned colors without any data migration needed.