### PR TITLE
Convert static Collections into a regular dynamic group

### DIFF
--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { get } from 'svelte/store';
   import type { InboxItemType, InboxItem, Collection, CollectionGroup } from '@inbox-rs/rs-module';
   import UserMenu from './components/UserMenu.svelte';
   import InboxGrid from './components/InboxGrid.svelte';
@@ -33,18 +32,18 @@
     if (typeof window === 'undefined') return { page: 'home' };
     const hash = window.location.hash;
     if (hash === '#/plugins') return { page: 'plugins' };
-    if (hash === '#/collections') {
-      const groups = get(sortedGroups);
-      if (groups.length > 0) {
-        window.location.hash = `#/group/${groups[0].id}`;
-        return { page: 'group', groupId: groups[0].id };
-      }
-      return { page: 'home' };
-    }
+    if (hash === '#/collections') return { page: 'home' };
     const groupMatch = hash.match(/^#\/group\/(.+)$/);
     if (groupMatch) return { page: 'group', groupId: groupMatch[1] };
     return { page: 'home' };
   }
+
+  // Legacy #/collections redirect: wait for groups to load, then redirect
+  $effect(() => {
+    if (window.location.hash === '#/collections' && $sortedGroups.length > 0) {
+      window.location.hash = `#/group/${$sortedGroups[0].id}`;
+    }
+  });
 
   let route = $state<Route>(getRouteFromHash());
   let userToggledTodos = false;

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
   import type { InboxItemType, InboxItem, Collection, CollectionGroup } from '@inbox-rs/rs-module';
   import UserMenu from './components/UserMenu.svelte';
   import InboxGrid from './components/InboxGrid.svelte';
@@ -19,7 +20,6 @@
   type Route =
     | { page: 'home' }
     | { page: 'plugins' }
-    | { page: 'collections' }
     | { page: 'group'; groupId: string };
 
   let activeModal = $state<InboxItemType | null>(null);
@@ -33,7 +33,14 @@
     if (typeof window === 'undefined') return { page: 'home' };
     const hash = window.location.hash;
     if (hash === '#/plugins') return { page: 'plugins' };
-    if (hash === '#/collections') return { page: 'collections' };
+    if (hash === '#/collections') {
+      const groups = get(sortedGroups);
+      if (groups.length > 0) {
+        window.location.hash = `#/group/${groups[0].id}`;
+        return { page: 'group', groupId: groups[0].id };
+      }
+      return { page: 'home' };
+    }
     const groupMatch = hash.match(/^#\/group\/(.+)$/);
     if (groupMatch) return { page: 'group', groupId: groupMatch[1] };
     return { page: 'home' };
@@ -163,7 +170,6 @@
     </div>
     <nav class="header-nav" aria-label="Primary">
       <a class:active={route.page === 'home'} aria-current={route.page === 'home' ? 'page' : undefined} href="#/">Inbox</a>
-      <a class:active={route.page === 'collections'} aria-current={route.page === 'collections' ? 'page' : undefined} href="#/collections">Collections</a>
       {#if $connected}
         {#each $sortedGroups as group (group.id)}
           <a
@@ -194,16 +200,6 @@
 <main>
   {#if route.page === 'plugins'}
     <PluginsPage />
-  {:else if route.page === 'collections'}
-    {#if $connected}
-      <CollectionsPage onselect={openView} oncreate={() => showCollectionForm = true} />
-    {:else}
-      <div class="empty-state">
-        <div class="empty-icon">📥</div>
-        <h2>Connect your storage</h2>
-        <p>Enter your remoteStorage address above to view your collections.</p>
-      </div>
-    {/if}
   {:else if route.page === 'group'}
     {#if $connected}
       <CollectionsPage onselect={openView} oncreate={() => showCollectionForm = true} groupId={route.groupId} />

--- a/packages/web/src/components/CollectionsPage.svelte
+++ b/packages/web/src/components/CollectionsPage.svelte
@@ -3,18 +3,18 @@
   import { get } from 'svelte/store';
   import { dndzone } from 'svelte-dnd-action';
   import {
-    sortedCollections, storeCollection, deleteCollection, reorderCollections,
-    groups, groupCollections, ungroupedCollections, storeGroup, deleteGroup, moveCollectionToGroup,
+    storeCollection, deleteCollection,
+    groups, groupCollections, sortedGroups, storeGroup, deleteGroup, moveCollectionToGroup,
     appConfig, updateConfig, reorderGroupCollections
   } from '../lib/stores';
   import CollectionView from './CollectionView.svelte';
   import CollectionFormModal from './CollectionFormModal.svelte';
   import GroupFormModal from './GroupFormModal.svelte';
 
-  let { onselect, oncreate, groupId = undefined }: {
+  let { onselect, oncreate, groupId }: {
     onselect: (item: InboxItem) => void;
     oncreate: () => void;
-    groupId?: string;
+    groupId: string;
   } = $props();
 
   let expandedIds = $state<Set<string>>(new Set($appConfig.expandedCollections ?? []));
@@ -42,13 +42,7 @@
 
   const currentGroup = $derived(groupId ? $groups[groupId] : undefined);
 
-  const filteredCollections = $derived.by(() => {
-    if (groupId) {
-      const grpCols = $groupCollections[groupId];
-      return grpCols ?? [];
-    }
-    return $ungroupedCollections;
-  });
+  const filteredCollections = $derived($groupCollections[groupId] ?? []);
 
   // DnD: local mutable copy of filtered collections
   let dndCollections = $state<Array<Collection & { id: string }>>([]);
@@ -65,17 +59,7 @@
     dndCollections = e.detail.items;
     const newIds = dndCollections.map(c => c.id);
     try {
-      if (groupId) {
-        await reorderGroupCollections(groupId, newIds);
-      } else {
-        // Merge reordered subset into full order, preserving grouped collections' positions
-        let currentOrder: string[] = [];
-        currentOrder = get(appConfig).collectionsOrder ?? [];
-        const reorderedSet = new Set(newIds);
-        const merged = currentOrder.filter(id => !reorderedSet.has(id));
-        merged.push(...newIds);
-        await reorderCollections(merged);
-      }
+      await reorderGroupCollections(groupId, newIds);
     } catch (error) {
       console.error('Failed to reorder collections', error);
       dndCollections = previous;
@@ -115,7 +99,8 @@
     if (!groupId) return;
     editingGroup = null;
     await deleteGroup(groupId);
-    window.location.hash = '#/collections';
+    const remaining = get(sortedGroups);
+    window.location.hash = remaining.length > 0 ? `#/group/${remaining[0].id}` : '#/';
   }
 </script>
 
@@ -134,8 +119,6 @@
           </button>
         </div>
       </div>
-    {:else}
-      <h2>Collections</h2>
     {/if}
     <button class="btn-new" onclick={oncreate}>
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -192,7 +175,7 @@
     group={editingGroup}
     onclose={() => editingGroup = null}
     onsave={handleEditGroup}
-    ondelete={groupId ? handleDeleteGroup : undefined}
+    ondelete={filteredCollections.length === 0 ? handleDeleteGroup : undefined}
   />
 {/if}
 

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { untrack, onDestroy } from 'svelte';
   import type { InboxItem } from '@inbox-rs/rs-module';
-  import { deleteItem, storeItem, blobUrls, connected, ungroupedCollections, sortedGroups, groupCollections, moveItemToCollection, loadFileBlobUrl } from '../lib/stores';
+  import { deleteItem, storeItem, blobUrls, connected, sortedGroups, groupCollections, moveItemToCollection, loadFileBlobUrl } from '../lib/stores';
   import rs from '../lib/rs';
   import { transcribeAudio } from '../lib/transcribe';
   import ShareButton from './ShareButton.svelte';
@@ -488,14 +488,6 @@
           </button>
           <div class="move-divider"></div>
         {/if}
-        {#each $ungroupedCollections as col (col.id)}
-          {#if col.id !== item.collectionId}
-            <button class="move-option" onclick={() => { moveItemToCollection(item.id, col.id).catch(e => console.error('Move failed:', e)); closeMoveMenu(); onclose(); }}>
-              <span class="move-dot" style="background: {col.color || '#6366f1'}"></span>
-              {col.name}
-            </button>
-          {/if}
-        {/each}
         {#each $sortedGroups as group (group.id)}
           {#each ($groupCollections[group.id] ?? []) as col (col.id)}
             {#if col.id !== item.collectionId}
@@ -506,7 +498,7 @@
             {/if}
           {/each}
         {/each}
-        {#if $ungroupedCollections.length === 0 && $sortedGroups.length === 0}
+        {#if $sortedGroups.length === 0}
           <div class="move-empty">No collections</div>
         {/if}
       </div>

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -149,6 +149,39 @@ async function loadGroups() {
   await loadEntities<CollectionGroup>(() => inbox.getAllGroups(), groups, 'collectionIds');
 }
 
+const DEFAULT_GROUP_COLOR = '#6b7280';
+
+async function ensureDefaultGroup() {
+  const currentGroups = get(groups);
+  let targetGroupId: string | undefined;
+
+  // If no groups exist, create a default "Collections" group
+  if (Object.keys(currentGroups).length === 0) {
+    const defaultGroup: CollectionGroup = {
+      id: crypto.randomUUID(),
+      name: 'Collections',
+      collectionIds: [],
+      createdAt: new Date().toISOString(),
+      color: DEFAULT_GROUP_COLOR,
+    };
+    await storeGroup(defaultGroup);
+    targetGroupId = defaultGroup.id;
+  }
+
+  // Migrate any ungrouped collections into the first group
+  const allCollections = get(collections);
+  const allGroups = get(groups);
+  const firstGroupId = targetGroupId || Object.values(allGroups)[0]?.id;
+  if (!firstGroupId) return;
+
+  const groupIds = new Set(Object.keys(allGroups));
+  for (const col of Object.values(allCollections)) {
+    if (!col.groupId || !groupIds.has(col.groupId)) {
+      await moveCollectionToGroup(col.id, firstGroupId);
+    }
+  }
+}
+
 // Debounced sync indicator: stays visible for at least 1 second to avoid flicker
 let syncTimeout: ReturnType<typeof setTimeout> | null = null;
 let syncVisibleUntil = 0;
@@ -264,11 +297,10 @@ export async function updateUserSettings(patch: Partial<UserSettings>) {
 const inboxRef = getInbox();
 function scheduleReload() {
   if (reloadTimeout) clearTimeout(reloadTimeout);
-  reloadTimeout = setTimeout(() => {
+  reloadTimeout = setTimeout(async () => {
     reloadTimeout = undefined;
-    void loadItems();
-    void loadCollections();
-    void loadGroups();
+    await Promise.all([loadItems(), loadCollections(), loadGroups()]);
+    await ensureDefaultGroup();
   }, 100);
 }
 if (inboxRef) {
@@ -587,15 +619,6 @@ export const groupCollections = derived([collections, groups, appConfig], ([$col
   return result;
 });
 
-/** Collections that don't belong to any group */
-export const ungroupedCollections = derived([sortedCollections, groups], ([$sortedCollections, $groups]) => {
-  const grouped = new Set<string>();
-  for (const group of Object.values($groups)) {
-    for (const cid of group.collectionIds) grouped.add(cid);
-  }
-  return $sortedCollections.filter(c => !grouped.has(c.id));
-});
-
 export async function storeGroup(group: CollectionGroup) {
   const inbox = getInbox();
   const clean = cleanForStorage(group);
@@ -605,28 +628,17 @@ export async function storeGroup(group: CollectionGroup) {
 
 export async function deleteGroup(id: string) {
   const inbox = getInbox();
-  const prevCollections = get(collections);
+  const currentGroups = get(groups);
+  const group = currentGroups[id];
+
+  // Refuse to delete a group that still has collections
+  if (group && group.collectionIds.length > 0) {
+    console.warn('[inbox] cannot delete group with collections — remove them first');
+    return;
+  }
+
   const prevGroups = get(groups);
-
-  // Unset groupId on orphaned collections
-  let orphanedCols: Collection[] = [];
-  collections.update(current => {
-    const next = { ...current };
-    for (const key of Object.keys(next)) {
-      if (next[key].groupId === id) {
-        const updated = { ...next[key] };
-        delete (updated as any).groupId;
-        next[key] = updated as Collection;
-        orphanedCols.push(updated as Collection);
-      }
-    }
-    return next;
-  });
-
   try {
-    for (const col of orphanedCols) {
-      await inbox.storeCollection(cleanForStorage(col));
-    }
     await inbox.removeGroup(id);
     groups.update(current => {
       const next = { ...current };
@@ -635,7 +647,6 @@ export async function deleteGroup(id: string) {
     });
     await removeFromOrderConfig(id, 'groupsOrder');
   } catch (e) {
-    collections.set(prevCollections);
     groups.set(prevGroups);
     console.error('[inbox] deleteGroup failed, rolling back:', e);
     throw e;

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -223,18 +223,15 @@ rs.on('wire-done', () => console.log('[inbox] wire-done'));
 
 let reloadTimeout: ReturnType<typeof setTimeout> | undefined;
 
-rs.on('connected', () => {
+rs.on('connected', async () => {
   connected.set(true);
   const addr =
     (rs as any).remote?.userAddress ||
     localStorage.getItem('inbox-rs:userAddress') ||
     '';
   userAddress.set(addr);
-  void loadItems();
-  void loadConfig();
-  void loadUserSettings();
-  void loadCollections();
-  void loadGroups();
+  await Promise.all([loadItems(), loadConfig(), loadUserSettings(), loadCollections(), loadGroups()]);
+  await ensureDefaultGroup();
 });
 
 rs.on('disconnected', () => {


### PR DESCRIPTION
## Summary
- Removes the hardcoded "Collections" nav link and `#/collections` route
- Auto-creates a default "Collections" group (grey color) on first connection when no groups exist
- Migrates existing ungrouped collections into the first available group after each sync
- Groups cannot be deleted while they still contain collections (delete button hidden, store guard)
- Legacy `#/collections` URLs redirect to the first group

## Test plan
- [x] Fresh login: verify a grey "Collections" group is auto-created in the nav
- [ ] Existing account with ungrouped collections: verify they migrate into the default group
- [ ] Rename/recolor/delete the Collections group (after removing its collections)
- [ ] Visit `#/collections` URL directly — should redirect to first group
- [ ] Verify move-to-collection dropdown in item view shows all collections under their groups
- [ ] Verify delete button is hidden on groups that still have collections