### PR TITLE
ci: add npm test step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,4 @@ jobs:
       - run: npm install @rollup/rollup-linux-x64-gnu --no-save
 
       - run: npm run build
+      - run: npm test


### PR DESCRIPTION
## Summary
- Adds `npm test` step to `.github/workflows/ci.yml` after the build step
- Runs the 44 vitest tests (30 extension + 14 web) on every PR to catch regressions

Closes #36

## Test plan
- [x] Verified `npm test` passes locally after build (44 tests pass)
- [ ] Confirm CI workflow runs tests on this PR