### PR TITLE
Remove deprecated getFileUrl from web app

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -142,7 +142,7 @@ inbox-rs/
 │   │   └── src/
 │   │       ├── App.svelte          # Main layout
 │   │       ├── lib/
-│   │       │   ├── rs.ts           # RS instance + getFileUrl helper
+│   │       │   ├── rs.ts           # RS instance + fetchFileBlobUrl helper
 │   │       │   └── stores.ts       # Svelte stores (items, connection state)
 │   │       └── components/
 │   │           ├── InboxGrid.svelte      # CSS-column masonry layout

--- a/packages/web/src/lib/rs.ts
+++ b/packages/web/src/lib/rs.ts
@@ -45,13 +45,4 @@ export async function fetchFileBlobUrl(path: string): Promise<string | null> {
   return fetchFileWithAuth(remote.href, remote.token, path);
 }
 
-/**
- * @deprecated Use fetchFileBlobUrl instead — query-param auth doesn't work on all RS servers (e.g. 5apps).
- */
-export function getFileUrl(path: string): string | null {
-  const remote = (rs as any).remote;
-  if (!remote?.href || !remote?.token) return null;
-  return `${remote.href}/inbox/${path}?access_token=${encodeURIComponent(remote.token)}`;
-}
-
 export default rs;

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -30,7 +30,6 @@ vi.mock('./rs', () => {
     default: rs,
     fetchFileBlobUrl: mockFetchFileBlobUrl,
     fetchFileWithAuth: vi.fn(),
-    getFileUrl: vi.fn(),
   };
 });
 


### PR DESCRIPTION
## Summary
- Remove the deprecated `getFileUrl` function from `packages/web/src/lib/rs.ts` (replaced by `fetchFileBlobUrl` in #35)
- Clean up the corresponding mock in `stores.test.ts`
- Update `DEVELOPMENT.md` to reference `fetchFileBlobUrl`

Closes #37

## Test plan
- [x] `npm run build` succeeds
- [x] All 44 tests pass (`npm test`)
- [x] `grep -r getFileUrl` returns zero results