### PR TITLE
fix(web): fix collections migration race condition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inbox-rs",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inbox-rs",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "workspaces": [
         "packages/*"
       ]
@@ -3214,7 +3214,7 @@
     },
     "packages/extension": {
       "name": "@inbox-rs/extension",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "remotestoragejs": "^2.0.0-beta.8",
@@ -3231,7 +3231,7 @@
     },
     "packages/rs-module": {
       "name": "@inbox-rs/rs-module",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "remotestoragejs": "^2.0.0-beta.8",
         "rs-migrate": "^1.0.0"
@@ -3242,7 +3242,7 @@
     },
     "packages/thunderbird": {
       "name": "@inbox-rs/thunderbird",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@inbox-rs/rs-module": "*"
       },
@@ -3255,7 +3255,7 @@
     },
     "packages/web": {
       "name": "@inbox-rs/web",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "@xenova/transformers": "^2.17.2",

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -22,8 +22,10 @@ vi.mock('./rs', () => {
       getAllCollections: vi.fn().mockResolvedValue({}),
       getAllGroups: vi.fn().mockResolvedValue({}),
       onChange: vi.fn(),
-      store: vi.fn(),
-      remove: vi.fn(),
+      store: vi.fn().mockResolvedValue(undefined),
+      remove: vi.fn().mockResolvedValue(undefined),
+      storeCollection: vi.fn().mockResolvedValue(undefined),
+      storeGroup: vi.fn().mockResolvedValue(undefined),
     },
   };
   return {
@@ -38,7 +40,11 @@ vi.mock('./clean-for-storage', () => ({
   cleanForStorage: (x: any) => x,
 }));
 
-import { blobUrls, connected, loadFileBlobUrl } from './stores';
+import {
+  blobUrls, connected, loadFileBlobUrl,
+  collections, groups, groupCollections, moveCollectionToGroup,
+} from './stores';
+import type { Collection, CollectionGroup } from '@inbox-rs/rs-module';
 
 describe('loadFileBlobUrl', () => {
   beforeEach(() => {
@@ -152,5 +158,140 @@ describe('loadFileBlobUrl', () => {
     });
 
     expect(mockFetchFileBlobUrl).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---- Helpers for collection/group tests ----
+
+function makeCollection(id: string, groupId?: string): Collection {
+  return {
+    id,
+    name: `Collection ${id}`,
+    itemIds: [],
+    createdAt: new Date().toISOString(),
+    ...(groupId ? { groupId } : {}),
+  };
+}
+
+function makeGroup(id: string, collectionIds: string[] = []): CollectionGroup {
+  return {
+    id,
+    name: `Group ${id}`,
+    collectionIds,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+describe('groupCollections', () => {
+  beforeEach(() => {
+    collections.set({});
+    groups.set({});
+  });
+
+  it('shows collections listed in group.collectionIds', () => {
+    const col1 = makeCollection('c1', 'g1');
+    const col2 = makeCollection('c2', 'g1');
+    const group = makeGroup('g1', ['c1', 'c2']);
+
+    collections.set({ c1: col1, c2: col2 });
+    groups.set({ g1: group });
+
+    const result = get(groupCollections);
+    expect(result['g1']).toHaveLength(2);
+    expect(result['g1'][0].id).toBe('c1');
+    expect(result['g1'][1].id).toBe('c2');
+  });
+
+  it('shows collections with groupId but missing from collectionIds', () => {
+    const col1 = makeCollection('c1', 'g1');
+    const col2 = makeCollection('c2', 'g1');
+    // Group only knows about c1, but c2 also has groupId pointing here
+    const group = makeGroup('g1', ['c1']);
+
+    collections.set({ c1: col1, c2: col2 });
+    groups.set({ g1: group });
+
+    const result = get(groupCollections);
+    expect(result['g1']).toHaveLength(2);
+    expect(result['g1'][0].id).toBe('c1');
+    expect(result['g1'][1].id).toBe('c2');
+  });
+
+  it('preserves collectionIds order and appends orphans after', () => {
+    const col1 = makeCollection('c1', 'g1');
+    const col2 = makeCollection('c2', 'g1');
+    const col3 = makeCollection('c3', 'g1');
+    // Group has c2 then c1 in order; c3 is orphaned
+    const group = makeGroup('g1', ['c2', 'c1']);
+
+    collections.set({ c1: col1, c2: col2, c3: col3 });
+    groups.set({ g1: group });
+
+    const result = get(groupCollections);
+    expect(result['g1'].map(c => c.id)).toEqual(['c2', 'c1', 'c3']);
+  });
+
+  it('filters out stale collectionIds entries', () => {
+    const col1 = makeCollection('c1', 'g1');
+    // Group references c1 and c_deleted, but c_deleted doesn't exist
+    const group = makeGroup('g1', ['c1', 'c_deleted']);
+
+    collections.set({ c1: col1 });
+    groups.set({ g1: group });
+
+    const result = get(groupCollections);
+    expect(result['g1']).toHaveLength(1);
+    expect(result['g1'][0].id).toBe('c1');
+  });
+
+  it('returns empty array for group with no collections', () => {
+    const group = makeGroup('g1', []);
+    groups.set({ g1: group });
+
+    const result = get(groupCollections);
+    expect(result['g1']).toEqual([]);
+  });
+});
+
+describe('moveCollectionToGroup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    collections.set({});
+    groups.set({});
+  });
+
+  it('updates collection groupId and group collectionIds', async () => {
+    const col = makeCollection('c1');
+    const group = makeGroup('g1', []);
+
+    collections.set({ c1: col });
+    groups.set({ g1: group });
+
+    await moveCollectionToGroup('c1', 'g1');
+
+    const updatedCol = get(collections)['c1'];
+    expect(updatedCol.groupId).toBe('g1');
+
+    const updatedGroup = get(groups)['g1'];
+    expect(updatedGroup.collectionIds).toContain('c1');
+  });
+
+  it('removes collection from old group when moving to new group', async () => {
+    const col = makeCollection('c1', 'g1');
+    const oldGroup = makeGroup('g1', ['c1']);
+    const newGroup = makeGroup('g2', []);
+
+    collections.set({ c1: col });
+    groups.set({ g1: oldGroup, g2: newGroup });
+
+    await moveCollectionToGroup('c1', 'g2');
+
+    const updatedOldGroup = get(groups)['g1'];
+    expect(updatedOldGroup.collectionIds).not.toContain('c1');
+
+    const updatedNewGroup = get(groups)['g2'];
+    expect(updatedNewGroup.collectionIds).toContain('c1');
+
+    expect(get(collections)['c1'].groupId).toBe('g2');
   });
 });

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -244,6 +244,22 @@ describe('groupCollections', () => {
     expect(result['g1'][0].id).toBe('c1');
   });
 
+  it('does not show collection in stale group after move', () => {
+    // Partial write: collection moved to g2 but g1.collectionIds still references it
+    const col1 = makeCollection('c1', 'g2');
+    const oldGroup = makeGroup('g1', ['c1']);
+    const newGroup = makeGroup('g2', []);
+
+    collections.set({ c1: col1 });
+    groups.set({ g1: oldGroup, g2: newGroup });
+
+    const result = get(groupCollections);
+    // c1 should only appear in g2 (its actual groupId), not g1
+    expect(result['g1']).toHaveLength(0);
+    expect(result['g2']).toHaveLength(1);
+    expect(result['g2'][0].id).toBe('c1');
+  });
+
   it('returns empty array for group with no collections', () => {
     const group = makeGroup('g1', []);
     groups.set({ g1: group });

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -150,35 +150,62 @@ async function loadGroups() {
 }
 
 const DEFAULT_GROUP_COLOR = '#6b7280';
+let ensureDefaultGroupRunning = false;
 
 async function ensureDefaultGroup() {
-  const currentGroups = get(groups);
-  let targetGroupId: string | undefined;
+  if (ensureDefaultGroupRunning) return;
+  ensureDefaultGroupRunning = true;
+  try {
+    const currentGroups = get(groups);
+    let targetGroupId: string | undefined;
 
-  // If no groups exist, create a default "Collections" group
-  if (Object.keys(currentGroups).length === 0) {
-    const defaultGroup: CollectionGroup = {
-      id: crypto.randomUUID(),
-      name: 'Collections',
-      collectionIds: [],
-      createdAt: new Date().toISOString(),
-      color: DEFAULT_GROUP_COLOR,
-    };
-    await storeGroup(defaultGroup);
-    targetGroupId = defaultGroup.id;
-  }
-
-  // Migrate any ungrouped collections into the first group
-  const allCollections = get(collections);
-  const allGroups = get(groups);
-  const firstGroupId = targetGroupId || Object.values(allGroups)[0]?.id;
-  if (!firstGroupId) return;
-
-  const groupIds = new Set(Object.keys(allGroups));
-  for (const col of Object.values(allCollections)) {
-    if (!col.groupId || !groupIds.has(col.groupId)) {
-      await moveCollectionToGroup(col.id, firstGroupId);
+    // If no groups exist, create a default "Collections" group
+    if (Object.keys(currentGroups).length === 0) {
+      const defaultGroup: CollectionGroup = {
+        id: crypto.randomUUID(),
+        name: 'Collections',
+        collectionIds: [],
+        createdAt: new Date().toISOString(),
+        color: DEFAULT_GROUP_COLOR,
+      };
+      await storeGroup(defaultGroup);
+      targetGroupId = defaultGroup.id;
     }
+
+    // Migrate any ungrouped collections into the first group
+    const allCollections = get(collections);
+    const allGroups = get(groups);
+    const firstGroupId = targetGroupId || Object.values(allGroups)[0]?.id;
+    if (!firstGroupId) return;
+
+    const groupIds = new Set(Object.keys(allGroups));
+    for (const col of Object.values(allCollections)) {
+      if (!col.groupId || !groupIds.has(col.groupId)) {
+        await moveCollectionToGroup(col.id, firstGroupId);
+      }
+    }
+
+    // Reconcile: ensure group.collectionIds includes all collections that reference it
+    const reconciledGroups = get(groups);
+    for (const [gid, group] of Object.entries(reconciledGroups)) {
+      const colIdSet = new Set(group.collectionIds);
+      const missing: string[] = [];
+      for (const col of Object.values(get(collections))) {
+        if (col.groupId === gid && !colIdSet.has(col.id)) {
+          missing.push(col.id);
+        }
+      }
+      if (missing.length > 0) {
+        console.warn(`[inbox] reconciling group "${group.name}": adding ${missing.length} missing collection(s)`);
+        const updated: CollectionGroup = {
+          ...group,
+          collectionIds: [...group.collectionIds, ...missing],
+        };
+        await storeGroup(updated);
+      }
+    }
+  } finally {
+    ensureDefaultGroupRunning = false;
   }
 }
 
@@ -606,12 +633,20 @@ export async function reorderCollections(newOrder: string[]) {
 
 export const sortedGroups = orderedDerived<CollectionGroup>(groups, 'groupsOrder');
 
-export const groupCollections = derived([collections, groups, appConfig], ([$collections, $groups, $config]) => {
+export const groupCollections = derived([collections, groups, appConfig], ([$collections, $groups]) => {
   const result: Record<string, Collection[]> = {};
   for (const [gid, group] of Object.entries($groups)) {
-    result[gid] = group.collectionIds
-      .map(cid => $collections[cid])
-      .filter((c): c is Collection => c !== undefined);
+    const orderedIds = group.collectionIds.filter(cid => $collections[cid] !== undefined);
+    const orderedSet = new Set(orderedIds);
+    // Start with ordered collections
+    const cols: Collection[] = orderedIds.map(cid => $collections[cid]);
+    // Append any collections whose groupId points here but missing from collectionIds
+    for (const col of Object.values($collections)) {
+      if (col.groupId === gid && !orderedSet.has(col.id)) {
+        cols.push(col);
+      }
+    }
+    result[gid] = cols;
   }
   return result;
 });

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -636,9 +636,12 @@ export const sortedGroups = orderedDerived<CollectionGroup>(groups, 'groupsOrder
 export const groupCollections = derived([collections, groups, appConfig], ([$collections, $groups]) => {
   const result: Record<string, Collection[]> = {};
   for (const [gid, group] of Object.entries($groups)) {
-    const orderedIds = group.collectionIds.filter(cid => $collections[cid] !== undefined);
+    const orderedIds = group.collectionIds.filter(cid => {
+      const col = $collections[cid];
+      return col !== undefined && col.groupId === gid;
+    });
     const orderedSet = new Set(orderedIds);
-    // Start with ordered collections
+    // Start with ordered collections whose groupId matches
     const cols: Collection[] = orderedIds.map(cid => $collections[cid]);
     // Append any collections whose groupId points here but missing from collectionIds
     for (const col of Object.values($collections)) {


### PR DESCRIPTION
## Summary

- **Root cause**: `ensureDefaultGroup()` could run concurrently from both the connect handler and `scheduleReload`, corrupting the group's `collectionIds` array. Collections still existed in remoteStorage but were invisible because `groupCollections` derived only from `collectionIds`.
- **Fix**: Add re-entry guard to prevent concurrent runs, make `groupCollections` use `collection.groupId` as source of truth (with `collectionIds` only for ordering), and add a reconciliation step to repair incomplete `collectionIds` on connect.
- No data was deleted — collections are recovered automatically on next load.

## Test plan

- [x] All 21 unit tests pass (`npm test --workspace=packages/web`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual: load app, verify existing collections appear in their group
- [ ] Manual: check browser console for `[inbox] reconciling group` messages confirming data repair