### PR TITLE
feat(web): add import/export for all user data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inbox-rs",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inbox-rs",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "workspaces": [
         "packages/*"
       ]
@@ -1761,6 +1761,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/flatbuffers": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
@@ -3136,7 +3142,7 @@
     },
     "packages/extension": {
       "name": "@inbox-rs/extension",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "remotestoragejs": "^2.0.0-beta.8",
@@ -3310,7 +3316,7 @@
     },
     "packages/rs-module": {
       "name": "@inbox-rs/rs-module",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "remotestoragejs": "^2.0.0-beta.8",
         "rs-migrate": "^1.0.0"
@@ -3321,7 +3327,7 @@
     },
     "packages/thunderbird": {
       "name": "@inbox-rs/thunderbird",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@inbox-rs/rs-module": "*"
       },
@@ -3491,10 +3497,11 @@
     },
     "packages/web": {
       "name": "@inbox-rs/web",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "@xenova/transformers": "^2.17.2",
+        "fflate": "^0.8.2",
         "highlight.js": "^11.11.1",
         "onnxruntime-web": "^1.14.0",
         "remotestorage-module-shares": "^2.1.4",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@inbox-rs/rs-module": "*",
     "@xenova/transformers": "^2.17.2",
+    "fflate": "^0.8.2",
     "highlight.js": "^11.11.1",
     "onnxruntime-web": "^1.14.0",
     "remotestorage-module-shares": "^2.1.4",

--- a/packages/web/src/components/ImportExportModal.svelte
+++ b/packages/web/src/components/ImportExportModal.svelte
@@ -1,0 +1,243 @@
+<script lang="ts">
+  import { exportAllData, importAllData, triggerDownload } from '../lib/import-export';
+  import type { ExportProgress, ImportProgress } from '../lib/import-export';
+
+  let { open = $bindable(false) }: { open: boolean } = $props();
+
+  type ModalState =
+    | { kind: 'confirm-import'; file: File }
+    | { kind: 'exporting'; progress: ExportProgress }
+    | { kind: 'importing'; progress: ImportProgress }
+    | { kind: 'done'; message: string }
+    | { kind: 'error'; message: string };
+
+  let state = $state<ModalState | null>(null);
+
+  function close() {
+    if (state?.kind === 'exporting' || state?.kind === 'importing') return;
+    open = false;
+    state = null;
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') close();
+  }
+
+  function onBackdropClick(e: MouseEvent) {
+    if (e.target === e.currentTarget) close();
+  }
+
+  export async function startExport() {
+    open = true;
+    state = { kind: 'exporting', progress: { phase: 'metadata', current: 0, total: 1 } };
+    try {
+      const blob = await exportAllData((progress) => {
+        state = { kind: 'exporting', progress };
+      });
+      const date = new Date().toISOString().slice(0, 10);
+      triggerDownload(blob, `inbox-rs-export-${date}.zip`);
+      state = { kind: 'done', message: 'Export complete! Your download should start automatically.' };
+    } catch (e) {
+      state = { kind: 'error', message: `Export failed: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  }
+
+  export function promptImport(file: File) {
+    open = true;
+    state = { kind: 'confirm-import', file };
+  }
+
+  async function confirmImport() {
+    if (state?.kind !== 'confirm-import') return;
+    const file = state.file;
+    state = { kind: 'importing', progress: { phase: 'reading', current: 0, total: 1 } };
+    try {
+      await importAllData(file, (progress) => {
+        state = { kind: 'importing', progress };
+      });
+      state = { kind: 'done', message: 'Import complete! All data has been restored.' };
+    } catch (e) {
+      state = { kind: 'error', message: `Import failed: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  }
+
+  function progressLabel(s: ModalState): string {
+    if (s.kind === 'exporting') {
+      const p = s.progress;
+      if (p.phase === 'metadata') return 'Loading data...';
+      if (p.phase === 'files') return `Exporting files... ${p.current}/${p.total}`;
+      return 'Creating archive...';
+    }
+    if (s.kind === 'importing') {
+      const p = s.progress;
+      if (p.phase === 'reading') return 'Reading archive...';
+      if (p.phase === 'clearing') return `Clearing existing data... ${p.current}/${p.total}`;
+      return `Restoring data... ${p.current}/${p.total}`;
+    }
+    return '';
+  }
+
+  function progressPercent(s: ModalState): number {
+    if (s.kind === 'exporting' || s.kind === 'importing') {
+      const p = 'progress' in s ? s.progress : null;
+      if (p && p.total > 0) return Math.round((p.current / p.total) * 100);
+    }
+    return 0;
+  }
+</script>
+
+{#if open && state}
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <div class="backdrop" role="dialog" aria-modal="true" onkeydown={onKeydown} onclick={onBackdropClick}>
+    <div class="modal">
+      {#if state.kind === 'confirm-import'}
+        <h3>Import Data</h3>
+        <p>Select a <strong>.zip</strong> file previously created with <strong>Export Data</strong>. This archive contains your items, collections, settings, and any attached files.</p>
+        <p class="warning">This will <strong>replace all existing data</strong> with the contents of the import file. This cannot be undone.</p>
+        <p class="file-name">{state.file.name}</p>
+        <div class="actions">
+          <button class="btn btn-secondary" onclick={close}>Cancel</button>
+          <button class="btn btn-danger" onclick={confirmImport}>Replace All Data</button>
+        </div>
+
+      {:else if state.kind === 'exporting' || state.kind === 'importing'}
+        <h3>{state.kind === 'exporting' ? 'Exporting' : 'Importing'}...</h3>
+        <p class="progress-label">{progressLabel(state)}</p>
+        <div class="progress-bar">
+          <div class="progress-fill" style="width: {progressPercent(state)}%"></div>
+        </div>
+
+      {:else if state.kind === 'done'}
+        <h3>Done</h3>
+        <p>{state.message}</p>
+        <div class="actions">
+          <button class="btn btn-primary" onclick={close}>Close</button>
+        </div>
+
+      {:else if state.kind === 'error'}
+        <h3>Error</h3>
+        <p class="error-message">{state.message}</p>
+        <div class="actions">
+          <button class="btn btn-secondary" onclick={close}>Close</button>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+
+  .modal {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.5rem;
+    max-width: 420px;
+    width: 90%;
+  }
+
+  h3 {
+    margin: 0 0 0.75rem;
+    font-size: 1.1rem;
+    color: var(--text);
+  }
+
+  p {
+    margin: 0 0 1rem;
+    color: var(--text);
+    opacity: 0.85;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  .warning {
+    color: var(--danger);
+    opacity: 1;
+  }
+
+  .file-name {
+    font-family: monospace;
+    font-size: 0.85rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--bg);
+    border-radius: var(--radius-sm);
+    word-break: break-all;
+  }
+
+  .error-message {
+    color: var(--danger);
+    opacity: 1;
+  }
+
+  .progress-label {
+    opacity: 0.7;
+  }
+
+  .progress-bar {
+    height: 6px;
+    background: var(--bg);
+    border-radius: 3px;
+    overflow: hidden;
+    margin-bottom: 1rem;
+  }
+
+  .progress-fill {
+    height: 100%;
+    background: var(--accent);
+    border-radius: 3px;
+    transition: width 0.2s ease;
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+  }
+
+  .btn {
+    padding: 0.5rem 1rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    font-size: 0.85rem;
+    cursor: pointer;
+    font-weight: 500;
+  }
+
+  .btn-secondary {
+    background: var(--surface);
+    color: var(--text);
+  }
+
+  .btn-secondary:hover {
+    background: var(--bg);
+  }
+
+  .btn-primary {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+  }
+
+  .btn-primary:hover {
+    opacity: 0.9;
+  }
+
+  .btn-danger {
+    background: var(--danger);
+    color: white;
+    border-color: var(--danger);
+  }
+
+  .btn-danger:hover {
+    opacity: 0.9;
+  }
+</style>

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -2,6 +2,7 @@
   import { tick } from 'svelte';
   import rs from '../lib/rs';
   import { connected, syncing, userAddress, userSettings, updateUserSettings } from '../lib/stores';
+  import ImportExportModal from './ImportExportModal.svelte';
 
   let open = $state(false);
   let inputAddress = $state('');
@@ -9,6 +10,9 @@
   let editingAbbrev = $state(false);
   let abbrevInput = $state('');
   let abbrevInputEl = $state<HTMLInputElement | null>(null);
+  let importExportModal = $state<ReturnType<typeof ImportExportModal>>();
+  let importExportOpen = $state(false);
+  let fileInputEl = $state<HTMLInputElement | null>(null);
 
   // Theme: synced settings take priority, localStorage is the offline fallback
   let localTheme = $state<'system' | 'light' | 'dark'>(
@@ -117,6 +121,25 @@
   function cancelEditAbbrev() {
     editingAbbrev = false;
   }
+
+  function handleExport() {
+    open = false;
+    importExportModal?.startExport();
+  }
+
+  function handleImportClick() {
+    fileInputEl?.click();
+  }
+
+  function handleFileSelected(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (file) {
+      open = false;
+      importExportModal?.promptImport(file);
+    }
+    input.value = '';
+  }
 </script>
 
 <div class="user-menu">
@@ -220,6 +243,37 @@
         </form>
       {/if}
 
+      {#if $connected}
+        <div class="divider"></div>
+
+        <!-- Data -->
+        <div class="section-label">Data</div>
+        <button class="menu-item" role="menuitem" onclick={handleExport}>
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+            <polyline points="7 10 12 15 17 10"></polyline>
+            <line x1="12" y1="15" x2="12" y2="3"></line>
+          </svg>
+          Export Data
+        </button>
+        <button class="menu-item" role="menuitem" onclick={handleImportClick}>
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+            <polyline points="17 8 12 3 7 8"></polyline>
+            <line x1="12" y1="3" x2="12" y2="15"></line>
+          </svg>
+          Import Data
+          <span class="menu-hint">.zip</span>
+        </button>
+        <input
+          bind:this={fileInputEl}
+          type="file"
+          accept=".zip"
+          style="display: none"
+          onchange={handleFileSelected}
+        />
+      {/if}
+
       <div class="divider"></div>
 
       <!-- Theme -->
@@ -275,6 +329,8 @@
     </div>
   {/if}
 </div>
+
+<ImportExportModal bind:this={importExportModal} bind:open={importExportOpen} />
 
 <style>
   .user-menu {
@@ -617,6 +673,13 @@
 
   .menu-item.danger:hover {
     background: color-mix(in srgb, var(--danger) 10%, var(--surface) 90%);
+  }
+
+  .menu-hint {
+    margin-left: auto;
+    font-size: 0.7rem;
+    opacity: 0.45;
+    font-weight: 400;
   }
 
   /* ── Connect form ────────────────────────── */

--- a/packages/web/src/lib/import-export.test.ts
+++ b/packages/web/src/lib/import-export.test.ts
@@ -157,7 +157,7 @@ describe('exportToZipBytes', () => {
     expect(manifest.files['images/img1.jpg']).toEqual({ mimeType: 'image/jpeg' });
   });
 
-  it('skips missing files gracefully', async () => {
+  it('fails when a file cannot be retrieved', async () => {
     const img = makeImage('img1', 'Missing');
     mockInbox.getAll.mockResolvedValue({ img1: img });
     mockInbox.getAllCollections.mockResolvedValue({});
@@ -166,13 +166,19 @@ describe('exportToZipBytes', () => {
     mockInbox.getUserSettings.mockResolvedValue({});
     mockInbox.getFile.mockResolvedValue(undefined);
 
-    await exportToZipBytes();
+    await expect(exportToZipBytes()).rejects.toThrow('could not be retrieved');
+  });
 
-    const zipInput = mockZipSync.mock.calls[0][0];
-    expect(zipInput['files/images/img1.jpg']).toBeUndefined();
+  it('fails when a file fetch throws', async () => {
+    const img = makeImage('img1', 'Error');
+    mockInbox.getAll.mockResolvedValue({ img1: img });
+    mockInbox.getAllCollections.mockResolvedValue({});
+    mockInbox.getAllGroups.mockResolvedValue({});
+    mockInbox.getConfig.mockResolvedValue({});
+    mockInbox.getUserSettings.mockResolvedValue({});
+    mockInbox.getFile.mockRejectedValue(new Error('network error'));
 
-    const manifest: ExportManifest = JSON.parse(decoder.decode(zipInput['manifest.json']));
-    expect(manifest.files['images/img1.jpg']).toBeUndefined();
+    await expect(exportToZipBytes()).rejects.toThrow('images/img1.jpg');
   });
 
   it('calls onProgress callback', async () => {
@@ -335,7 +341,7 @@ describe('importFromZipBytes', () => {
     expect(progress).toHaveBeenCalledWith(expect.objectContaining({ phase: 'restoring' }));
   });
 
-  it('does not call setConfig for empty appConfig', async () => {
+  it('clears config and settings when archive has empty objects', async () => {
     const manifest: ExportManifest = {
       version: 1,
       exportedAt: '2026-01-01T00:00:00Z',
@@ -351,8 +357,8 @@ describe('importFromZipBytes', () => {
 
     await importFromZipBytes(new Uint8Array([1, 2, 3]));
 
-    expect(mockInbox.setConfig).not.toHaveBeenCalled();
-    expect(mockInbox.setUserSettings).not.toHaveBeenCalled();
+    expect(mockInbox.setConfig).toHaveBeenCalledWith({});
+    expect(mockInbox.setUserSettings).toHaveBeenCalledWith({});
   });
 });
 

--- a/packages/web/src/lib/import-export.test.ts
+++ b/packages/web/src/lib/import-export.test.ts
@@ -1,0 +1,450 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+
+const mockInbox = vi.hoisted(() => ({
+  getAll: vi.fn().mockResolvedValue({}),
+  getAllCollections: vi.fn().mockResolvedValue({}),
+  getAllGroups: vi.fn().mockResolvedValue({}),
+  getConfig: vi.fn().mockResolvedValue({}),
+  getUserSettings: vi.fn().mockResolvedValue({}),
+  getFile: vi.fn().mockResolvedValue(undefined),
+  store: vi.fn().mockResolvedValue(undefined),
+  remove: vi.fn().mockResolvedValue(undefined),
+  storeCollection: vi.fn().mockResolvedValue(undefined),
+  removeCollection: vi.fn().mockResolvedValue(undefined),
+  storeGroup: vi.fn().mockResolvedValue(undefined),
+  removeGroup: vi.fn().mockResolvedValue(undefined),
+  setConfig: vi.fn().mockResolvedValue(undefined),
+  setUserSettings: vi.fn().mockResolvedValue(undefined),
+  onChange: vi.fn(),
+}));
+
+// Capture what zipSync receives and control what unzipSync returns
+const { mockZipSync, mockUnzipSync } = vi.hoisted(() => {
+  const mockZipSync = vi.fn();
+  const mockUnzipSync = vi.fn();
+  return { mockZipSync, mockUnzipSync };
+});
+
+vi.mock('fflate', () => {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  return {
+    zipSync: mockZipSync,
+    unzipSync: mockUnzipSync,
+    strToU8: (s: string) => encoder.encode(s),
+    strFromU8: (b: Uint8Array) => decoder.decode(b),
+  };
+});
+
+vi.mock('./rs', () => {
+  const rs = {
+    access: { claim: vi.fn() },
+    caching: { enable: vi.fn() },
+    setSyncInterval: vi.fn(),
+    on: vi.fn(),
+    remote: {},
+    startSync: vi.fn(),
+    inbox: mockInbox,
+  };
+  return {
+    default: rs,
+    fetchFileBlobUrl: vi.fn(),
+    fetchFileWithAuth: vi.fn(),
+  };
+});
+
+vi.mock('./clean-for-storage', () => ({
+  cleanForStorage: (x: any) => x,
+}));
+
+import { exportToZipBytes, importFromZipBytes } from './import-export';
+import type { ExportManifest } from './import-export';
+import { items, collections, groups, appConfig, userSettings } from './stores';
+import type { InboxItem, Collection, CollectionGroup } from '@inbox-rs/rs-module';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function makeNote(id: string, title: string): InboxItem {
+  return { id, type: 'note', title, body: 'test', createdAt: '2026-01-01T00:00:00Z' } as InboxItem;
+}
+
+function makeImage(id: string, title: string): InboxItem {
+  return {
+    id, type: 'image', title, filePath: `images/${id}.jpg`, mimeType: 'image/jpeg', createdAt: '2026-01-01T00:00:00Z',
+  } as InboxItem;
+}
+
+function makeCollection(id: string, name: string): Collection {
+  return { id, name, itemIds: [], createdAt: '2026-01-01T00:00:00Z' };
+}
+
+function makeGroup(id: string, name: string): CollectionGroup {
+  return { id, name, collectionIds: [], createdAt: '2026-01-01T00:00:00Z' };
+}
+
+function makeUnzipResult(manifest: ExportManifest, binaryFiles?: Record<string, Uint8Array>): Record<string, Uint8Array> {
+  const result: Record<string, Uint8Array> = {};
+  result['manifest.json'] = encoder.encode(JSON.stringify(manifest));
+  if (binaryFiles) {
+    for (const [path, data] of Object.entries(binaryFiles)) {
+      result[path] = data;
+    }
+  }
+  return result;
+}
+
+describe('exportToZipBytes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    items.set({});
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+    userSettings.set({});
+    mockZipSync.mockReturnValue(new Uint8Array([1, 2, 3]));
+  });
+
+  it('exports items, collections, groups, config, and settings', async () => {
+    const testItems = { n1: makeNote('n1', 'Note 1') };
+    const testCollections = { c1: makeCollection('c1', 'Col 1') };
+    const testGroups = { g1: makeGroup('g1', 'Group 1') };
+    const testConfig = { todosCollapsed: true };
+    const testSettings = { theme: 'dark' as const };
+
+    mockInbox.getAll.mockResolvedValue(testItems);
+    mockInbox.getAllCollections.mockResolvedValue(testCollections);
+    mockInbox.getAllGroups.mockResolvedValue(testGroups);
+    mockInbox.getConfig.mockResolvedValue(testConfig);
+    mockInbox.getUserSettings.mockResolvedValue(testSettings);
+
+    await exportToZipBytes();
+
+    expect(mockZipSync).toHaveBeenCalledTimes(1);
+    const zipInput = mockZipSync.mock.calls[0][0];
+
+    // Parse the manifest that was passed to zipSync
+    const manifest: ExportManifest = JSON.parse(decoder.decode(zipInput['manifest.json']));
+    expect(manifest.version).toBe(1);
+    expect(manifest.exportedAt).toBeTruthy();
+    expect(manifest.items).toEqual(testItems);
+    expect(manifest.collections).toEqual(testCollections);
+    expect(manifest.groups).toEqual(testGroups);
+    expect(manifest.appConfig).toEqual(testConfig);
+    expect(manifest.userSettings).toEqual(testSettings);
+  });
+
+  it('includes binary files for items with filePath', async () => {
+    const img = makeImage('img1', 'Photo');
+    mockInbox.getAll.mockResolvedValue({ img1: img });
+    mockInbox.getAllCollections.mockResolvedValue({});
+    mockInbox.getAllGroups.mockResolvedValue({});
+    mockInbox.getConfig.mockResolvedValue({});
+    mockInbox.getUserSettings.mockResolvedValue({});
+
+    const fileData = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0]);
+    mockInbox.getFile.mockResolvedValue({ data: fileData.buffer, mimeType: 'image/jpeg' });
+
+    await exportToZipBytes();
+
+    const zipInput = mockZipSync.mock.calls[0][0];
+    expect(zipInput['files/images/img1.jpg']).toBeDefined();
+    expect(Array.from(zipInput['files/images/img1.jpg'])).toEqual([0xFF, 0xD8, 0xFF, 0xE0]);
+
+    const manifest: ExportManifest = JSON.parse(decoder.decode(zipInput['manifest.json']));
+    expect(manifest.files['images/img1.jpg']).toEqual({ mimeType: 'image/jpeg' });
+  });
+
+  it('skips missing files gracefully', async () => {
+    const img = makeImage('img1', 'Missing');
+    mockInbox.getAll.mockResolvedValue({ img1: img });
+    mockInbox.getAllCollections.mockResolvedValue({});
+    mockInbox.getAllGroups.mockResolvedValue({});
+    mockInbox.getConfig.mockResolvedValue({});
+    mockInbox.getUserSettings.mockResolvedValue({});
+    mockInbox.getFile.mockResolvedValue(undefined);
+
+    await exportToZipBytes();
+
+    const zipInput = mockZipSync.mock.calls[0][0];
+    expect(zipInput['files/images/img1.jpg']).toBeUndefined();
+
+    const manifest: ExportManifest = JSON.parse(decoder.decode(zipInput['manifest.json']));
+    expect(manifest.files['images/img1.jpg']).toBeUndefined();
+  });
+
+  it('calls onProgress callback', async () => {
+    mockInbox.getAll.mockResolvedValue({ n1: makeNote('n1', 'Note') });
+    mockInbox.getAllCollections.mockResolvedValue({});
+    mockInbox.getAllGroups.mockResolvedValue({});
+    mockInbox.getConfig.mockResolvedValue({});
+    mockInbox.getUserSettings.mockResolvedValue({});
+
+    const progress = vi.fn();
+    await exportToZipBytes(progress);
+
+    expect(progress).toHaveBeenCalledWith(expect.objectContaining({ phase: 'metadata' }));
+    expect(progress).toHaveBeenCalledWith(expect.objectContaining({ phase: 'zipping' }));
+  });
+});
+
+describe('importFromZipBytes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    items.set({});
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+    userSettings.set({});
+
+    // After import, these are called to reload stores
+    mockInbox.getAll.mockResolvedValue({});
+    mockInbox.getAllCollections.mockResolvedValue({});
+    mockInbox.getAllGroups.mockResolvedValue({});
+    mockInbox.getConfig.mockResolvedValue({});
+    mockInbox.getUserSettings.mockResolvedValue({});
+  });
+
+  it('restores all data from a valid ZIP', async () => {
+    const manifest: ExportManifest = {
+      version: 1,
+      exportedAt: '2026-01-01T00:00:00Z',
+      items: { n1: makeNote('n1', 'Imported Note') },
+      collections: { c1: makeCollection('c1', 'Imported Col') },
+      groups: { g1: makeGroup('g1', 'Imported Group') },
+      appConfig: { todosCollapsed: false },
+      userSettings: { theme: 'light' },
+      files: {},
+    };
+
+    mockUnzipSync.mockReturnValue(makeUnzipResult(manifest));
+
+    // Mock reload after import
+    mockInbox.getAll.mockResolvedValue(manifest.items);
+    mockInbox.getAllCollections.mockResolvedValue(manifest.collections);
+    mockInbox.getAllGroups.mockResolvedValue(manifest.groups);
+    mockInbox.getConfig.mockResolvedValue(manifest.appConfig);
+    mockInbox.getUserSettings.mockResolvedValue(manifest.userSettings);
+
+    await importFromZipBytes(new Uint8Array([1, 2, 3]));
+
+    expect(mockInbox.storeGroup).toHaveBeenCalledWith(manifest.groups.g1);
+    expect(mockInbox.storeCollection).toHaveBeenCalledWith(manifest.collections.c1);
+    expect(mockInbox.store).toHaveBeenCalledWith(manifest.items.n1, undefined);
+    expect(mockInbox.setConfig).toHaveBeenCalledWith(manifest.appConfig);
+    expect(mockInbox.setUserSettings).toHaveBeenCalledWith(manifest.userSettings);
+
+    expect(get(items)).toEqual(manifest.items);
+    expect(get(collections)).toEqual(manifest.collections);
+    expect(get(groups)).toEqual(manifest.groups);
+  });
+
+  it('restores binary files via store(item, fileData)', async () => {
+    const img = makeImage('img1', 'Photo');
+    const fileBytes = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0]);
+    const manifest: ExportManifest = {
+      version: 1,
+      exportedAt: '2026-01-01T00:00:00Z',
+      items: { img1: img },
+      collections: {},
+      groups: {},
+      appConfig: {},
+      userSettings: {},
+      files: { 'images/img1.jpg': { mimeType: 'image/jpeg' } },
+    };
+
+    mockUnzipSync.mockReturnValue(makeUnzipResult(manifest, { 'files/images/img1.jpg': fileBytes }));
+
+    await importFromZipBytes(new Uint8Array([1, 2, 3]));
+
+    expect(mockInbox.store).toHaveBeenCalledTimes(1);
+    const [storedItem, storedFileData] = mockInbox.store.mock.calls[0];
+    expect(storedItem.id).toBe('img1');
+    expect(storedFileData).toBeInstanceOf(ArrayBuffer);
+    expect(Array.from(new Uint8Array(storedFileData))).toEqual([0xFF, 0xD8, 0xFF, 0xE0]);
+  });
+
+  it('clears existing data before restoring', async () => {
+    items.set({ old1: makeNote('old1', 'Old') });
+    collections.set({ oldc: makeCollection('oldc', 'Old Col') });
+    groups.set({ oldg: makeGroup('oldg', 'Old Group') });
+
+    const manifest: ExportManifest = {
+      version: 1,
+      exportedAt: '2026-01-01T00:00:00Z',
+      items: {},
+      collections: {},
+      groups: {},
+      appConfig: {},
+      userSettings: {},
+      files: {},
+    };
+
+    mockUnzipSync.mockReturnValue(makeUnzipResult(manifest));
+
+    await importFromZipBytes(new Uint8Array([1, 2, 3]));
+
+    expect(mockInbox.remove).toHaveBeenCalledWith('old1', expect.objectContaining({ id: 'old1' }));
+    expect(mockInbox.removeCollection).toHaveBeenCalledWith('oldc');
+    expect(mockInbox.removeGroup).toHaveBeenCalledWith('oldg');
+  });
+
+  it('rejects ZIP without manifest.json', async () => {
+    mockUnzipSync.mockReturnValue({ 'other.txt': encoder.encode('hello') });
+
+    await expect(importFromZipBytes(new Uint8Array([1, 2, 3]))).rejects.toThrow('missing manifest.json');
+  });
+
+  it('rejects manifest with wrong version', async () => {
+    const manifest = {
+      version: 99,
+      exportedAt: '2026-01-01T00:00:00Z',
+      items: {},
+      collections: {},
+      groups: {},
+      appConfig: {},
+      userSettings: {},
+      files: {},
+    };
+
+    mockUnzipSync.mockReturnValue(makeUnzipResult(manifest as any));
+
+    await expect(importFromZipBytes(new Uint8Array([1, 2, 3]))).rejects.toThrow('Unsupported export version');
+  });
+
+  it('calls onProgress callback during restore', async () => {
+    const manifest: ExportManifest = {
+      version: 1,
+      exportedAt: '2026-01-01T00:00:00Z',
+      items: { n1: makeNote('n1', 'Note') },
+      collections: {},
+      groups: {},
+      appConfig: {},
+      userSettings: {},
+      files: {},
+    };
+
+    mockUnzipSync.mockReturnValue(makeUnzipResult(manifest));
+
+    const progress = vi.fn();
+    await importFromZipBytes(new Uint8Array([1, 2, 3]), progress);
+
+    expect(progress).toHaveBeenCalledWith(expect.objectContaining({ phase: 'reading' }));
+    expect(progress).toHaveBeenCalledWith(expect.objectContaining({ phase: 'restoring' }));
+  });
+
+  it('does not call setConfig for empty appConfig', async () => {
+    const manifest: ExportManifest = {
+      version: 1,
+      exportedAt: '2026-01-01T00:00:00Z',
+      items: {},
+      collections: {},
+      groups: {},
+      appConfig: {},
+      userSettings: {},
+      files: {},
+    };
+
+    mockUnzipSync.mockReturnValue(makeUnzipResult(manifest));
+
+    await importFromZipBytes(new Uint8Array([1, 2, 3]));
+
+    expect(mockInbox.setConfig).not.toHaveBeenCalled();
+    expect(mockInbox.setUserSettings).not.toHaveBeenCalled();
+  });
+});
+
+describe('round-trip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    items.set({});
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+    userSettings.set({});
+  });
+
+  it('export captures all data types and import restores them', async () => {
+    const testItems = {
+      n1: makeNote('n1', 'My Note'),
+      img1: makeImage('img1', 'My Photo'),
+    };
+    const testCollections = { c1: { ...makeCollection('c1', 'Work'), itemIds: ['n1'] } };
+    const testGroups = { g1: { ...makeGroup('g1', 'Projects'), collectionIds: ['c1'] } };
+    const testConfig = { todosCollapsed: true, collectionsOrder: ['c1'] };
+    const testSettings = { theme: 'dark' as const, abbreviation: 'NJ' };
+    const fileBytes = new Uint8Array([1, 2, 3, 4, 5]);
+
+    mockInbox.getAll.mockResolvedValue(testItems);
+    mockInbox.getAllCollections.mockResolvedValue(testCollections);
+    mockInbox.getAllGroups.mockResolvedValue(testGroups);
+    mockInbox.getConfig.mockResolvedValue(testConfig);
+    mockInbox.getUserSettings.mockResolvedValue(testSettings);
+    mockInbox.getFile.mockResolvedValue({ data: fileBytes.buffer, mimeType: 'image/jpeg' });
+
+    // Capture what gets zipped during export
+    let capturedZipInput: Record<string, Uint8Array> = {};
+    mockZipSync.mockImplementation((data: Record<string, Uint8Array>) => {
+      capturedZipInput = { ...data };
+      return new Uint8Array([1, 2, 3]);
+    });
+
+    await exportToZipBytes();
+
+    // Verify export captured the right data
+    const exportedManifest: ExportManifest = JSON.parse(decoder.decode(capturedZipInput['manifest.json']));
+    expect(exportedManifest.items).toEqual(testItems);
+    expect(exportedManifest.collections).toEqual(testCollections);
+    expect(exportedManifest.groups).toEqual(testGroups);
+    expect(exportedManifest.appConfig).toEqual(testConfig);
+    expect(exportedManifest.userSettings).toEqual(testSettings);
+    expect(capturedZipInput['files/images/img1.jpg']).toBeDefined();
+    expect(Array.from(capturedZipInput['files/images/img1.jpg'])).toEqual([1, 2, 3, 4, 5]);
+
+    // Now simulate import with the same manifest
+    vi.clearAllMocks();
+    items.set({});
+    collections.set({});
+    groups.set({});
+
+    mockUnzipSync.mockReturnValue(capturedZipInput);
+    mockInbox.getAll.mockResolvedValue(testItems);
+    mockInbox.getAllCollections.mockResolvedValue(testCollections);
+    mockInbox.getAllGroups.mockResolvedValue(testGroups);
+    mockInbox.getConfig.mockResolvedValue(testConfig);
+    mockInbox.getUserSettings.mockResolvedValue(testSettings);
+
+    await importFromZipBytes(new Uint8Array([1, 2, 3]));
+
+    // Verify all entities were stored
+    expect(mockInbox.storeGroup).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'g1', name: 'Projects' }),
+    );
+    expect(mockInbox.storeCollection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'c1', name: 'Work' }),
+    );
+    expect(mockInbox.store).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'n1', title: 'My Note' }),
+      undefined,
+    );
+    // Image item should have binary data
+    const imgCall = mockInbox.store.mock.calls.find(
+      (c: any[]) => c[0].id === 'img1',
+    );
+    expect(imgCall).toBeDefined();
+    expect(imgCall![1]).toBeInstanceOf(ArrayBuffer);
+    expect(Array.from(new Uint8Array(imgCall![1]))).toEqual([1, 2, 3, 4, 5]);
+
+    expect(mockInbox.setConfig).toHaveBeenCalledWith(testConfig);
+    expect(mockInbox.setUserSettings).toHaveBeenCalledWith(testSettings);
+
+    // Verify stores were reloaded
+    expect(get(items)).toEqual(testItems);
+    expect(get(collections)).toEqual(testCollections);
+    expect(get(groups)).toEqual(testGroups);
+    expect(get(appConfig)).toEqual(testConfig);
+    expect(get(userSettings)).toEqual(testSettings);
+  });
+});

--- a/packages/web/src/lib/import-export.ts
+++ b/packages/web/src/lib/import-export.ts
@@ -1,0 +1,230 @@
+import { zipSync, unzipSync, strToU8, strFromU8 } from 'fflate';
+import type { InboxItem, AppConfig, UserSettings, Collection, CollectionGroup } from '@inbox-rs/rs-module';
+import rs from './rs';
+import { items, collections, groups, appConfig, userSettings } from './stores';
+import { get } from 'svelte/store';
+
+export interface ExportManifest {
+  version: 1;
+  exportedAt: string;
+  items: Record<string, InboxItem>;
+  collections: Record<string, Collection>;
+  groups: Record<string, CollectionGroup>;
+  appConfig: AppConfig;
+  userSettings: UserSettings;
+  files: Record<string, { mimeType: string }>;
+}
+
+export interface ExportProgress {
+  phase: 'metadata' | 'files' | 'zipping';
+  current: number;
+  total: number;
+}
+
+export interface ImportProgress {
+  phase: 'reading' | 'clearing' | 'restoring';
+  current: number;
+  total: number;
+}
+
+function getInbox() {
+  return (rs as any).inbox;
+}
+
+export async function exportToZipBytes(
+  onProgress?: (progress: ExportProgress) => void,
+): Promise<Uint8Array> {
+  const inbox = getInbox();
+  if (!inbox) throw new Error('Storage not connected');
+
+  onProgress?.({ phase: 'metadata', current: 0, total: 1 });
+
+  const [allItems, allCollections, allGroups, config, settings] = await Promise.all([
+    inbox.getAll() as Promise<Record<string, InboxItem>>,
+    inbox.getAllCollections() as Promise<Record<string, Collection>>,
+    inbox.getAllGroups() as Promise<Record<string, CollectionGroup>>,
+    inbox.getConfig() as Promise<AppConfig>,
+    inbox.getUserSettings() as Promise<UserSettings>,
+  ]);
+
+  onProgress?.({ phase: 'metadata', current: 1, total: 1 });
+
+  // Collect items that have binary files
+  const fileItems: { filePath: string; mimeType: string }[] = [];
+  for (const item of Object.values(allItems)) {
+    if ('filePath' in item && item.filePath && 'mimeType' in item && item.mimeType) {
+      fileItems.push({ filePath: item.filePath, mimeType: item.mimeType });
+    }
+  }
+
+  // Fetch binary files
+  const zipData: Record<string, Uint8Array> = {};
+  const filesManifest: Record<string, { mimeType: string }> = {};
+
+  for (let i = 0; i < fileItems.length; i++) {
+    const { filePath, mimeType } = fileItems[i];
+    onProgress?.({ phase: 'files', current: i, total: fileItems.length });
+    try {
+      const file = await inbox.getFile(filePath);
+      if (file?.data) {
+        zipData[`files/${filePath}`] = new Uint8Array(file.data);
+        filesManifest[filePath] = { mimeType };
+      }
+    } catch (e) {
+      console.warn(`[import-export] skipping file ${filePath}:`, e);
+    }
+  }
+
+  onProgress?.({ phase: 'files', current: fileItems.length, total: fileItems.length });
+
+  const manifest: ExportManifest = {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    items: allItems,
+    collections: allCollections,
+    groups: allGroups,
+    appConfig: config,
+    userSettings: settings,
+    files: filesManifest,
+  };
+
+  onProgress?.({ phase: 'zipping', current: 0, total: 1 });
+
+  zipData['manifest.json'] = strToU8(JSON.stringify(manifest, null, 2));
+  const zipped = zipSync(zipData);
+
+  onProgress?.({ phase: 'zipping', current: 1, total: 1 });
+
+  return zipped;
+}
+
+export async function exportAllData(
+  onProgress?: (progress: ExportProgress) => void,
+): Promise<Blob> {
+  const zipped = await exportToZipBytes(onProgress);
+  return new Blob([zipped as BlobPart], { type: 'application/zip' });
+}
+
+export async function importFromZipBytes(
+  data: Uint8Array,
+  onProgress?: (progress: ImportProgress) => void,
+): Promise<void> {
+  const inbox = getInbox();
+  if (!inbox) throw new Error('Storage not connected');
+
+  onProgress?.({ phase: 'reading', current: 0, total: 1 });
+
+  const unzipped = unzipSync(data);
+
+  const manifestBytes = unzipped['manifest.json'];
+  if (!manifestBytes) {
+    throw new Error('Invalid export file: missing manifest.json');
+  }
+
+  const manifest: ExportManifest = JSON.parse(strFromU8(manifestBytes));
+  if (manifest.version !== 1) {
+    throw new Error(`Unsupported export version: ${manifest.version}`);
+  }
+
+  onProgress?.({ phase: 'reading', current: 1, total: 1 });
+
+  // Clear existing data
+  const existingItems = get(items);
+  const existingCollections = get(collections);
+  const existingGroups = get(groups);
+  const totalToRemove = Object.keys(existingItems).length
+    + Object.keys(existingCollections).length
+    + Object.keys(existingGroups).length;
+  let removed = 0;
+
+  onProgress?.({ phase: 'clearing', current: 0, total: totalToRemove });
+
+  for (const [id, item] of Object.entries(existingItems)) {
+    await inbox.remove(id, item);
+    removed++;
+    onProgress?.({ phase: 'clearing', current: removed, total: totalToRemove });
+  }
+  for (const id of Object.keys(existingCollections)) {
+    await inbox.removeCollection(id);
+    removed++;
+    onProgress?.({ phase: 'clearing', current: removed, total: totalToRemove });
+  }
+  for (const id of Object.keys(existingGroups)) {
+    await inbox.removeGroup(id);
+    removed++;
+    onProgress?.({ phase: 'clearing', current: removed, total: totalToRemove });
+  }
+
+  // Restore data: groups -> collections -> items
+  const totalToRestore = Object.keys(manifest.groups).length
+    + Object.keys(manifest.collections).length
+    + Object.keys(manifest.items).length;
+  let restored = 0;
+
+  onProgress?.({ phase: 'restoring', current: 0, total: totalToRestore });
+
+  for (const group of Object.values(manifest.groups)) {
+    await inbox.storeGroup(group);
+    restored++;
+    onProgress?.({ phase: 'restoring', current: restored, total: totalToRestore });
+  }
+
+  for (const collection of Object.values(manifest.collections)) {
+    await inbox.storeCollection(collection);
+    restored++;
+    onProgress?.({ phase: 'restoring', current: restored, total: totalToRestore });
+  }
+
+  for (const item of Object.values(manifest.items)) {
+    let fileData: ArrayBuffer | undefined;
+    if ('filePath' in item && item.filePath) {
+      const zipPath = `files/${item.filePath}`;
+      const bytes = unzipped[zipPath];
+      if (bytes) {
+        fileData = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+      }
+    }
+    await inbox.store(item, fileData);
+    restored++;
+    onProgress?.({ phase: 'restoring', current: restored, total: totalToRestore });
+  }
+
+  // Restore config and settings
+  if (manifest.appConfig && Object.keys(manifest.appConfig).length > 0) {
+    await inbox.setConfig(manifest.appConfig);
+  }
+  if (manifest.userSettings && Object.keys(manifest.userSettings).length > 0) {
+    await inbox.setUserSettings(manifest.userSettings);
+  }
+
+  // Reload all stores
+  const [allItems, allCollections, allGroups, config, settings] = await Promise.all([
+    inbox.getAll() as Promise<Record<string, InboxItem>>,
+    inbox.getAllCollections() as Promise<Record<string, Collection>>,
+    inbox.getAllGroups() as Promise<Record<string, CollectionGroup>>,
+    inbox.getConfig() as Promise<AppConfig>,
+    inbox.getUserSettings() as Promise<UserSettings>,
+  ]);
+  items.set(allItems);
+  collections.set(allCollections);
+  groups.set(allGroups);
+  appConfig.set(config);
+  userSettings.set(settings);
+}
+
+export async function importAllData(
+  file: File,
+  onProgress?: (progress: ImportProgress) => void,
+): Promise<void> {
+  const buffer = await file.arrayBuffer();
+  return importFromZipBytes(new Uint8Array(buffer), onProgress);
+}
+
+export function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/packages/web/src/lib/import-export.ts
+++ b/packages/web/src/lib/import-export.ts
@@ -57,9 +57,10 @@ export async function exportToZipBytes(
     }
   }
 
-  // Fetch binary files
+  // Fetch binary files — fail on errors to avoid incomplete backups
   const zipData: Record<string, Uint8Array> = {};
   const filesManifest: Record<string, { mimeType: string }> = {};
+  const failedFiles: string[] = [];
 
   for (let i = 0; i < fileItems.length; i++) {
     const { filePath, mimeType } = fileItems[i];
@@ -69,10 +70,18 @@ export async function exportToZipBytes(
       if (file?.data) {
         zipData[`files/${filePath}`] = new Uint8Array(file.data);
         filesManifest[filePath] = { mimeType };
+      } else {
+        failedFiles.push(filePath);
       }
     } catch (e) {
-      console.warn(`[import-export] skipping file ${filePath}:`, e);
+      failedFiles.push(filePath);
     }
+  }
+
+  if (failedFiles.length > 0) {
+    throw new Error(
+      `Export failed: ${failedFiles.length} file(s) could not be retrieved:\n${failedFiles.join('\n')}`,
+    );
   }
 
   onProgress?.({ phase: 'files', current: fileItems.length, total: fileItems.length });
@@ -189,13 +198,9 @@ export async function importFromZipBytes(
     onProgress?.({ phase: 'restoring', current: restored, total: totalToRestore });
   }
 
-  // Restore config and settings
-  if (manifest.appConfig && Object.keys(manifest.appConfig).length > 0) {
-    await inbox.setConfig(manifest.appConfig);
-  }
-  if (manifest.userSettings && Object.keys(manifest.userSettings).length > 0) {
-    await inbox.setUserSettings(manifest.userSettings);
-  }
+  // Restore config and settings (always write, even if empty, to clear old values)
+  await inbox.setConfig(manifest.appConfig ?? {});
+  await inbox.setUserSettings(manifest.userSettings ?? {});
 
   // Reload all stores
   const [allItems, allCollections, allGroups, config, settings] = await Promise.all([


### PR DESCRIPTION
## Summary
- Adds Export Data and Import Data buttons to the user menu dropdown (visible when connected)
- Export creates a ZIP archive containing all items, collections, groups, settings, config, and binary files (images, audio, video, documents)
- Import reads a previously exported ZIP and replaces all existing data after user confirmation
- Uses `fflate` (~8KB, zero deps) for client-side ZIP/unzip
- Includes 12 unit tests covering export, import, validation, and round-trip

## Test plan
- [ ] Connect to remoteStorage, verify Export/Import buttons appear in user menu
- [ ] Export data, verify ZIP downloads with correct filename (`inbox-rs-export-YYYY-MM-DD.zip`)
- [ ] Inspect ZIP contents: `manifest.json` + `files/` directory with binaries
- [ ] Import the exported ZIP into a fresh account, verify all data restored
- [ ] Verify import confirmation modal warns about data replacement
- [ ] Verify progress indicators during export and import
- [ ] `npm test` passes (26 tests)