### PR TITLE
fix(web): remove auto-group-creation, fix deleteGroup guard

### DIFF
--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -12,14 +12,15 @@
   import CollectionsPage from './components/CollectionsPage.svelte';
   import CollectionFormModal from './components/CollectionFormModal.svelte';
   import GroupFormModal from './components/GroupFormModal.svelte';
-  import { connected, deleteItem, todoItems, appConfig, updateConfig, pendingMigrationCount, runAllMigrations, storeCollection, sortedGroups, storeGroup, moveCollectionToGroup } from './lib/stores';
+  import { connected, deleteItem, todoItems, appConfig, updateConfig, pendingMigrationCount, runAllMigrations, storeCollection, sortedGroups, storeGroup, moveCollectionToGroup, ungroupedCollections } from './lib/stores';
   import { pluginArtifactVersion } from './lib/plugin-downloads.generated';
   import LogoShield from './components/LogoShield.svelte';
 
   type Route =
     | { page: 'home' }
     | { page: 'plugins' }
-    | { page: 'group'; groupId: string };
+    | { page: 'group'; groupId: string }
+    | { page: 'ungrouped' };
 
   let activeModal = $state<InboxItemType | null>(null);
   let editingItem = $state<InboxItem | undefined>(undefined);
@@ -32,18 +33,11 @@
     if (typeof window === 'undefined') return { page: 'home' };
     const hash = window.location.hash;
     if (hash === '#/plugins') return { page: 'plugins' };
-    if (hash === '#/collections') return { page: 'home' };
+    if (hash === '#/collections') return { page: 'ungrouped' };
     const groupMatch = hash.match(/^#\/group\/(.+)$/);
     if (groupMatch) return { page: 'group', groupId: groupMatch[1] };
     return { page: 'home' };
   }
-
-  // Legacy #/collections redirect: wait for groups to load, then redirect
-  $effect(() => {
-    if (window.location.hash === '#/collections' && $sortedGroups.length > 0) {
-      window.location.hash = `#/group/${$sortedGroups[0].id}`;
-    }
-  });
 
   let route = $state<Route>(getRouteFromHash());
   let userToggledTodos = false;
@@ -182,6 +176,13 @@
             <span class="group-name">{group.name}</span>
           </a>
         {/each}
+        {#if $ungroupedCollections.length > 0}
+          <a
+            class:active={route.page === 'ungrouped'}
+            aria-current={route.page === 'ungrouped' ? 'page' : undefined}
+            href="#/collections"
+          >Ungrouped</a>
+        {/if}
         <button class="nav-add-group" onclick={() => showGroupForm = true} title="New group" aria-label="Create new group">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
             <line x1="12" y1="5" x2="12" y2="19"></line>
@@ -199,6 +200,16 @@
 <main>
   {#if route.page === 'plugins'}
     <PluginsPage />
+  {:else if route.page === 'ungrouped'}
+    {#if $connected}
+      <CollectionsPage onselect={openView} oncreate={() => showCollectionForm = true} groupId="" />
+    {:else}
+      <div class="empty-state">
+        <div class="empty-icon">📥</div>
+        <h2>Connect your storage</h2>
+        <p>Enter your remoteStorage address above to view your collections.</p>
+      </div>
+    {/if}
   {:else if route.page === 'group'}
     {#if $connected}
       <CollectionsPage onselect={openView} oncreate={() => showCollectionForm = true} groupId={route.groupId} />

--- a/packages/web/src/components/CollectionsPage.svelte
+++ b/packages/web/src/components/CollectionsPage.svelte
@@ -102,9 +102,11 @@
   async function handleDeleteGroup() {
     if (!groupId) return;
     editingGroup = null;
-    await deleteGroup(groupId);
-    const remaining = get(sortedGroups);
-    window.location.hash = remaining.length > 0 ? `#/group/${remaining[0].id}` : '#/';
+    const deleted = await deleteGroup(groupId);
+    if (deleted) {
+      const remaining = get(sortedGroups);
+      window.location.hash = remaining.length > 0 ? `#/group/${remaining[0].id}` : '#/';
+    }
   }
 </script>
 

--- a/packages/web/src/components/CollectionsPage.svelte
+++ b/packages/web/src/components/CollectionsPage.svelte
@@ -5,6 +5,7 @@
   import {
     storeCollection, deleteCollection,
     groups, groupCollections, sortedGroups, storeGroup, deleteGroup, moveCollectionToGroup,
+    ungroupedCollections,
     appConfig, updateConfig, reorderGroupCollections
   } from '../lib/stores';
   import CollectionView from './CollectionView.svelte';
@@ -40,9 +41,12 @@
     }
   });
 
+  const isUngrouped = $derived(!groupId);
   const currentGroup = $derived(groupId ? $groups[groupId] : undefined);
 
-  const filteredCollections = $derived($groupCollections[groupId] ?? []);
+  const filteredCollections = $derived(
+    isUngrouped ? $ungroupedCollections : ($groupCollections[groupId] ?? [])
+  );
 
   // DnD: local mutable copy of filtered collections
   let dndCollections = $state<Array<Collection & { id: string }>>([]);
@@ -106,7 +110,9 @@
 
 <div class="collections-page">
   <div class="page-header">
-    {#if currentGroup}
+    {#if isUngrouped}
+      <h2>Ungrouped</h2>
+    {:else if currentGroup}
       <div class="group-header">
         <span class="group-dot-lg" style="background: {currentGroup.color || 'var(--accent)'}"></span>
         <h2>{currentGroup.name}</h2>

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -8,28 +8,37 @@ const { mockFetchFileBlobUrl } = vi.hoisted(() => {
   return { mockFetchFileBlobUrl };
 });
 
-vi.mock('./rs', () => {
-  const rs = {
+const { mockRs, mockInbox } = vi.hoisted(() => {
+  const mockInbox = {
+    getAll: vi.fn().mockResolvedValue({}),
+    getConfig: vi.fn().mockResolvedValue({}),
+    getAllCollections: vi.fn().mockResolvedValue({}),
+    getAllGroups: vi.fn().mockResolvedValue({}),
+    onChange: vi.fn(),
+    store: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+    storeCollection: vi.fn().mockResolvedValue(undefined),
+    removeCollection: vi.fn().mockResolvedValue(undefined),
+    storeGroup: vi.fn().mockResolvedValue(undefined),
+    removeGroup: vi.fn().mockResolvedValue(undefined),
+    setConfig: vi.fn().mockResolvedValue(undefined),
+    getUserSettings: vi.fn().mockResolvedValue(undefined),
+  };
+  const mockRs = {
     access: { claim: vi.fn() },
     caching: { enable: vi.fn() },
     setSyncInterval: vi.fn(),
     on: vi.fn(),
     remote: {},
     startSync: vi.fn(),
-    inbox: {
-      getAll: vi.fn().mockResolvedValue({}),
-      getConfig: vi.fn().mockResolvedValue({}),
-      getAllCollections: vi.fn().mockResolvedValue({}),
-      getAllGroups: vi.fn().mockResolvedValue({}),
-      onChange: vi.fn(),
-      store: vi.fn().mockResolvedValue(undefined),
-      remove: vi.fn().mockResolvedValue(undefined),
-      storeCollection: vi.fn().mockResolvedValue(undefined),
-      storeGroup: vi.fn().mockResolvedValue(undefined),
-    },
+    inbox: mockInbox,
   };
+  return { mockRs, mockInbox };
+});
+
+vi.mock('./rs', () => {
   return {
-    default: rs,
+    default: mockRs,
     fetchFileBlobUrl: mockFetchFileBlobUrl,
     fetchFileWithAuth: vi.fn(),
   };
@@ -42,9 +51,23 @@ vi.mock('./clean-for-storage', () => ({
 
 import {
   blobUrls, connected, loadFileBlobUrl,
-  collections, groups, groupCollections, moveCollectionToGroup,
+  items, collections, groups, groupCollections, moveCollectionToGroup,
+  deleteGroup, deleteCollection, ungroupedCollections, appConfig,
 } from './stores';
-import type { Collection, CollectionGroup } from '@inbox-rs/rs-module';
+import type { InboxItem, Collection, CollectionGroup } from '@inbox-rs/rs-module';
+
+/**
+ * rs.on() handlers are registered at module load time.
+ * Capture them once before any test clears mocks.
+ */
+const rsHandlers: Record<string, (...args: any[]) => any> = {};
+function captureRsHandlers() {
+  if (Object.keys(rsHandlers).length > 0) return;
+  for (const [event, handler] of mockRs.on.mock.calls as [string, (...args: any[]) => any][]) {
+    rsHandlers[event] = handler;
+  }
+}
+captureRsHandlers();
 
 describe('loadFileBlobUrl', () => {
   beforeEach(() => {
@@ -266,6 +289,326 @@ describe('groupCollections', () => {
 
     const result = get(groupCollections);
     expect(result['g1']).toEqual([]);
+  });
+});
+
+describe('deleteGroup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+  });
+
+  it('refuses to delete a group when collections reference it via groupId (even if collectionIds is empty)', async () => {
+    const col = makeCollection('c1', 'g1');
+    const group = makeGroup('g1', []); // collectionIds is empty but col has groupId
+
+    collections.set({ c1: col });
+    groups.set({ g1: group });
+
+    await deleteGroup('g1');
+
+    // Group should still exist
+    expect(get(groups)['g1']).toBeDefined();
+  });
+
+  it('refuses to delete a group when collectionIds and groupId both reference it', async () => {
+    const col = makeCollection('c1', 'g1');
+    const group = makeGroup('g1', ['c1']);
+
+    collections.set({ c1: col });
+    groups.set({ g1: group });
+
+    await deleteGroup('g1');
+
+    expect(get(groups)['g1']).toBeDefined();
+  });
+
+  it('allows deleting a group with no collections referencing it', async () => {
+    const group = makeGroup('g1', []);
+
+    groups.set({ g1: group });
+
+    await deleteGroup('g1');
+
+    expect(get(groups)['g1']).toBeUndefined();
+  });
+
+  it('allows deleting a group where collectionIds has stale entries but no collection has matching groupId', async () => {
+    // collectionIds references c_deleted which doesn't exist, and c1 has groupId pointing elsewhere
+    const col = makeCollection('c1', 'g2');
+    const group = makeGroup('g1', ['c_deleted']);
+
+    collections.set({ c1: col });
+    groups.set({ g1: group, g2: makeGroup('g2', ['c1']) });
+
+    await deleteGroup('g1');
+
+    expect(get(groups)['g1']).toBeUndefined();
+  });
+});
+
+describe('ungroupedCollections', () => {
+  beforeEach(() => {
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+  });
+
+  it('returns collections with no groupId', () => {
+    const col1 = makeCollection('c1');
+    const col2 = makeCollection('c2', 'g1');
+    const group = makeGroup('g1', ['c2']);
+
+    collections.set({ c1: col1, c2: col2 });
+    groups.set({ g1: group });
+
+    const result = get(ungroupedCollections);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('c1');
+  });
+
+  it('returns collections whose groupId points to a non-existent group', () => {
+    const col = makeCollection('c1', 'g_deleted');
+
+    collections.set({ c1: col });
+    groups.set({});
+
+    const result = get(ungroupedCollections);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('c1');
+  });
+
+  it('does not include collections with a valid groupId', () => {
+    const col = makeCollection('c1', 'g1');
+    const group = makeGroup('g1', ['c1']);
+
+    collections.set({ c1: col });
+    groups.set({ g1: group });
+
+    const result = get(ungroupedCollections);
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns empty array when all collections belong to groups', () => {
+    const col1 = makeCollection('c1', 'g1');
+    const col2 = makeCollection('c2', 'g1');
+    const group = makeGroup('g1', ['c1', 'c2']);
+
+    collections.set({ c1: col1, c2: col2 });
+    groups.set({ g1: group });
+
+    const result = get(ungroupedCollections);
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('no auto-group-creation on connect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+    // Reset mock return values for loaders
+    mockInbox.getAll.mockResolvedValue({});
+    mockInbox.getConfig.mockResolvedValue({});
+    mockInbox.getAllCollections.mockResolvedValue({});
+    mockInbox.getAllGroups.mockResolvedValue({});
+    mockInbox.getUserSettings.mockResolvedValue(undefined);
+  });
+
+  it('does not create a group when connecting with no groups', async () => {
+    await rsHandlers['connected']();
+
+    expect(get(groups)).toEqual({});
+    expect(mockInbox.storeGroup).not.toHaveBeenCalled();
+  });
+
+  it('does not create a group when connecting with ungrouped collections', async () => {
+    const col = makeCollection('c1');
+    mockInbox.getAllCollections.mockResolvedValue({ c1: col });
+
+    await rsHandlers['connected']();
+
+    // Collections should load but no group should be created
+    expect(get(collections)['c1']).toBeDefined();
+    expect(Object.keys(get(groups))).toHaveLength(0);
+    expect(mockInbox.storeGroup).not.toHaveBeenCalled();
+  });
+
+  it('does not force-migrate ungrouped collections into an existing group', async () => {
+    const col = makeCollection('c1'); // no groupId
+    const group = makeGroup('g1', []);
+    mockInbox.getAllCollections.mockResolvedValue({ c1: col });
+    mockInbox.getAllGroups.mockResolvedValue({ g1: group });
+
+    await rsHandlers['connected']();
+
+    // Collection should remain ungrouped
+    expect(get(collections)['c1'].groupId).toBeUndefined();
+    // storeCollection should not have been called to migrate
+    expect(mockInbox.storeCollection).not.toHaveBeenCalled();
+  });
+
+  it('preserves existing groups on connect without modification', async () => {
+    const group = makeGroup('g1', ['c1']);
+    const col = makeCollection('c1', 'g1');
+    mockInbox.getAllCollections.mockResolvedValue({ c1: col });
+    mockInbox.getAllGroups.mockResolvedValue({ g1: group });
+
+    await rsHandlers['connected']();
+
+    expect(get(groups)['g1']).toBeDefined();
+    expect(get(groups)['g1'].name).toBe('Group g1');
+    // No new groups created, no groups modified
+    expect(mockInbox.storeGroup).not.toHaveBeenCalled();
+  });
+});
+
+describe('no group recreation after deletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+    mockInbox.getAll.mockResolvedValue({});
+    mockInbox.getConfig.mockResolvedValue({});
+    mockInbox.getAllCollections.mockResolvedValue({});
+    mockInbox.getAllGroups.mockResolvedValue({});
+    mockInbox.getUserSettings.mockResolvedValue(undefined);
+  });
+
+  it('does not recreate a group after all groups are deleted and a reload triggers', async () => {
+    // Start with a group
+    const group = makeGroup('g1', []);
+    groups.set({ g1: group });
+
+    // Delete the group
+    await deleteGroup('g1');
+    expect(get(groups)['g1']).toBeUndefined();
+
+    // Simulate a reload (scheduleReload loads from backend which returns empty)
+    const onChange = mockInbox.onChange.mock.calls[0]?.[1] ?? mockInbox.onChange.mock.calls[0]?.[0];
+    if (onChange) {
+      onChange();
+      // Wait for debounced reload
+      await vi.waitFor(() => {
+        // After reload, groups should still be empty
+        expect(Object.keys(get(groups))).toHaveLength(0);
+      }, { timeout: 500 });
+    }
+
+    expect(mockInbox.storeGroup).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteGroup preserves collections', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+  });
+
+  it('does not delete collections when deleting an empty group', async () => {
+    const col = makeCollection('c1', 'g2');
+    const group1 = makeGroup('g1', []);
+    const group2 = makeGroup('g2', ['c1']);
+
+    collections.set({ c1: col });
+    groups.set({ g1: group1, g2: group2 });
+
+    await deleteGroup('g1');
+
+    // g1 is gone, g2 and c1 are untouched
+    expect(get(groups)['g1']).toBeUndefined();
+    expect(get(groups)['g2']).toBeDefined();
+    expect(get(collections)['c1']).toBeDefined();
+    expect(get(collections)['c1'].groupId).toBe('g2');
+  });
+
+  it('does not modify any collection groupId when deleting a group', async () => {
+    const col1 = makeCollection('c1', 'g2');
+    const col2 = makeCollection('c2');
+    const emptyGroup = makeGroup('g1', []);
+    const otherGroup = makeGroup('g2', ['c1']);
+
+    collections.set({ c1: col1, c2: col2 });
+    groups.set({ g1: emptyGroup, g2: otherGroup });
+
+    await deleteGroup('g1');
+
+    // All collection groupIds unchanged
+    expect(get(collections)['c1'].groupId).toBe('g2');
+    expect(get(collections)['c2'].groupId).toBeUndefined();
+    expect(mockInbox.storeCollection).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteGroup with non-existent group', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+  });
+
+  it('does not crash when deleting a group that does not exist', async () => {
+    groups.set({ g1: makeGroup('g1', []) });
+
+    await deleteGroup('g_nonexistent');
+
+    // g1 still exists, no crash
+    expect(get(groups)['g1']).toBeDefined();
+  });
+});
+
+describe('ungroupedCollections reacts to group deletion', () => {
+  beforeEach(() => {
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+  });
+
+  it('collections appear in ungroupedCollections after their group is deleted', async () => {
+    const col = makeCollection('c1', 'g1');
+    const group = makeGroup('g1', ['c1']);
+
+    collections.set({ c1: col });
+    groups.set({ g1: group });
+
+    // Before deletion: c1 is grouped
+    expect(get(ungroupedCollections)).toHaveLength(0);
+    expect(get(groupCollections)['g1']).toHaveLength(1);
+
+    // Simulate the group being removed from the store (as if deleted on another device)
+    groups.update(current => {
+      const next = { ...current };
+      delete next['g1'];
+      return next;
+    });
+
+    // c1 still has groupId 'g1' but that group no longer exists
+    expect(get(ungroupedCollections)).toHaveLength(1);
+    expect(get(ungroupedCollections)[0].id).toBe('c1');
+  });
+
+  it('collections move from ungrouped to grouped when assigned a valid group', async () => {
+    const col = makeCollection('c1');
+    const group = makeGroup('g1', []);
+
+    collections.set({ c1: col });
+    groups.set({ g1: group });
+
+    // Before: ungrouped
+    expect(get(ungroupedCollections)).toHaveLength(1);
+
+    await moveCollectionToGroup('c1', 'g1');
+
+    // After: grouped
+    expect(get(ungroupedCollections)).toHaveLength(0);
+    expect(get(groupCollections)['g1']).toHaveLength(1);
   });
 });
 

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -51,10 +51,10 @@ vi.mock('./clean-for-storage', () => ({
 
 import {
   blobUrls, connected, loadFileBlobUrl,
-  items, collections, groups, groupCollections, moveCollectionToGroup,
-  deleteGroup, deleteCollection, ungroupedCollections, appConfig,
+  collections, groups, groupCollections, moveCollectionToGroup,
+  deleteGroup, ungroupedCollections, appConfig,
 } from './stores';
-import type { InboxItem, Collection, CollectionGroup } from '@inbox-rs/rs-module';
+import type { Collection, CollectionGroup } from '@inbox-rs/rs-module';
 
 /**
  * rs.on() handlers are registered at module load time.
@@ -307,9 +307,9 @@ describe('deleteGroup', () => {
     collections.set({ c1: col });
     groups.set({ g1: group });
 
-    await deleteGroup('g1');
+    const result = await deleteGroup('g1');
 
-    // Group should still exist
+    expect(result).toBe(false);
     expect(get(groups)['g1']).toBeDefined();
   });
 
@@ -320,8 +320,9 @@ describe('deleteGroup', () => {
     collections.set({ c1: col });
     groups.set({ g1: group });
 
-    await deleteGroup('g1');
+    const result = await deleteGroup('g1');
 
+    expect(result).toBe(false);
     expect(get(groups)['g1']).toBeDefined();
   });
 
@@ -330,8 +331,9 @@ describe('deleteGroup', () => {
 
     groups.set({ g1: group });
 
-    await deleteGroup('g1');
+    const result = await deleteGroup('g1');
 
+    expect(result).toBe(true);
     expect(get(groups)['g1']).toBeUndefined();
   });
 
@@ -343,8 +345,9 @@ describe('deleteGroup', () => {
     collections.set({ c1: col });
     groups.set({ g1: group, g2: makeGroup('g2', ['c1']) });
 
-    await deleteGroup('g1');
+    const result = await deleteGroup('g1');
 
+    expect(result).toBe(true);
     expect(get(groups)['g1']).toBeUndefined();
   });
 });
@@ -554,13 +557,14 @@ describe('deleteGroup with non-existent group', () => {
     appConfig.set({});
   });
 
-  it('does not crash when deleting a group that does not exist', async () => {
+  it('returns false and skips backend call for non-existent group', async () => {
     groups.set({ g1: makeGroup('g1', []) });
 
-    await deleteGroup('g_nonexistent');
+    const result = await deleteGroup('g_nonexistent');
 
-    // g1 still exists, no crash
+    expect(result).toBe(false);
     expect(get(groups)['g1']).toBeDefined();
+    expect(mockInbox.removeGroup).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -53,6 +53,7 @@ import {
   blobUrls, connected, loadFileBlobUrl,
   collections, groups, groupCollections, moveCollectionToGroup,
   deleteGroup, ungroupedCollections, appConfig,
+  storeCollection, reorderGroupCollections,
 } from './stores';
 import type { Collection, CollectionGroup } from '@inbox-rs/rs-module';
 
@@ -613,6 +614,92 @@ describe('ungroupedCollections reacts to group deletion', () => {
     // After: grouped
     expect(get(ungroupedCollections)).toHaveLength(0);
     expect(get(groupCollections)['g1']).toHaveLength(1);
+  });
+});
+
+// ---- Tests exercising the component code paths for the ungrouped route ----
+// These mirror what CollectionsPage and App.svelte do when groupId is "" or undefined.
+
+describe('ungrouped route: collection creation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+  });
+
+  it('collection created without groupId stays ungrouped', async () => {
+    // App.svelte passes groupId=undefined to CollectionFormModal on the ungrouped route.
+    // CollectionFormModal sets groupId to undefined, so handleCreateCollection
+    // calls storeCollection but skips moveCollectionToGroup.
+    const col = makeCollection('c1'); // no groupId — mirrors what CollectionFormModal produces
+
+    await storeCollection(col);
+    // App.svelte: if (col.groupId) { await moveCollectionToGroup(...) }
+    // groupId is undefined so this branch is skipped.
+
+    expect(get(collections)['c1']).toBeDefined();
+    expect(get(collections)['c1'].groupId).toBeUndefined();
+    expect(get(ungroupedCollections)).toHaveLength(1);
+    expect(mockInbox.storeGroup).not.toHaveBeenCalled();
+  });
+
+  it('collection created with empty-string groupId is treated as ungrouped', async () => {
+    // Edge case: if groupId were "" instead of undefined
+    const col: Collection = {
+      id: 'c1',
+      name: 'Test',
+      itemIds: [],
+      createdAt: new Date().toISOString(),
+      groupId: '',
+    };
+
+    await storeCollection(col);
+    // "" is falsy so moveCollectionToGroup would be skipped in handleCreateCollection
+
+    expect(get(collections)['c1'].groupId).toBe('');
+    // ungroupedCollections checks !c.groupId — empty string is falsy, so it's included
+    expect(get(ungroupedCollections)).toHaveLength(1);
+  });
+});
+
+describe('ungrouped route: reorder is a no-op', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+  });
+
+  it('reorderGroupCollections with empty groupId does not modify any group', async () => {
+    // CollectionsPage calls reorderGroupCollections(groupId, newIds) on DnD finalize.
+    // When groupId is "", no group matches, so it should be a no-op.
+    const group = makeGroup('g1', ['c1', 'c2']);
+    const col1 = makeCollection('c1', 'g1');
+    const col2 = makeCollection('c2', 'g1');
+
+    collections.set({ c1: col1, c2: col2 });
+    groups.set({ g1: group });
+
+    await reorderGroupCollections('', ['c2', 'c1']);
+
+    // g1 should be untouched
+    expect(get(groups)['g1'].collectionIds).toEqual(['c1', 'c2']);
+    expect(mockInbox.storeGroup).not.toHaveBeenCalled();
+  });
+
+  it('reorderGroupCollections with valid groupId works normally', async () => {
+    const group = makeGroup('g1', ['c1', 'c2']);
+    const col1 = makeCollection('c1', 'g1');
+    const col2 = makeCollection('c2', 'g1');
+
+    collections.set({ c1: col1, c2: col2 });
+    groups.set({ g1: group });
+
+    await reorderGroupCollections('g1', ['c2', 'c1']);
+
+    expect(get(groups)['g1'].collectionIds).toEqual(['c2', 'c1']);
+    expect(mockInbox.storeGroup).toHaveBeenCalled();
   });
 });
 

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -607,19 +607,19 @@ export async function storeGroup(group: CollectionGroup) {
   groups.update(current => ({ ...current, [clean.id]: clean }));
 }
 
-export async function deleteGroup(id: string) {
+export async function deleteGroup(id: string): Promise<boolean> {
   const inbox = getInbox();
   const currentGroups = get(groups);
   const group = currentGroups[id];
 
+  if (!group) return false;
+
   // Refuse to delete a group that still has collections (check groupId, not stale collectionIds)
-  if (group) {
-    const allCollections = get(collections);
-    const hasCollections = Object.values(allCollections).some(col => col.groupId === id);
-    if (hasCollections) {
-      console.warn('[inbox] cannot delete group with collections — remove them first');
-      return;
-    }
+  const allCollections = get(collections);
+  const hasCollections = Object.values(allCollections).some(col => col.groupId === id);
+  if (hasCollections) {
+    console.warn('[inbox] cannot delete group with collections — remove them first');
+    return false;
   }
 
   const prevGroups = get(groups);
@@ -631,6 +631,7 @@ export async function deleteGroup(id: string) {
       return next;
     });
     await removeFromOrderConfig(id, 'groupsOrder');
+    return true;
   } catch (e) {
     groups.set(prevGroups);
     console.error('[inbox] deleteGroup failed, rolling back:', e);

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -149,66 +149,6 @@ async function loadGroups() {
   await loadEntities<CollectionGroup>(() => inbox.getAllGroups(), groups, 'collectionIds');
 }
 
-const DEFAULT_GROUP_COLOR = '#6b7280';
-let ensureDefaultGroupRunning = false;
-
-async function ensureDefaultGroup() {
-  if (ensureDefaultGroupRunning) return;
-  ensureDefaultGroupRunning = true;
-  try {
-    const currentGroups = get(groups);
-    let targetGroupId: string | undefined;
-
-    // If no groups exist, create a default "Collections" group
-    if (Object.keys(currentGroups).length === 0) {
-      const defaultGroup: CollectionGroup = {
-        id: crypto.randomUUID(),
-        name: 'Collections',
-        collectionIds: [],
-        createdAt: new Date().toISOString(),
-        color: DEFAULT_GROUP_COLOR,
-      };
-      await storeGroup(defaultGroup);
-      targetGroupId = defaultGroup.id;
-    }
-
-    // Migrate any ungrouped collections into the first group
-    const allCollections = get(collections);
-    const allGroups = get(groups);
-    const firstGroupId = targetGroupId || Object.values(allGroups)[0]?.id;
-    if (!firstGroupId) return;
-
-    const groupIds = new Set(Object.keys(allGroups));
-    for (const col of Object.values(allCollections)) {
-      if (!col.groupId || !groupIds.has(col.groupId)) {
-        await moveCollectionToGroup(col.id, firstGroupId);
-      }
-    }
-
-    // Reconcile: ensure group.collectionIds includes all collections that reference it
-    const reconciledGroups = get(groups);
-    for (const [gid, group] of Object.entries(reconciledGroups)) {
-      const colIdSet = new Set(group.collectionIds);
-      const missing: string[] = [];
-      for (const col of Object.values(get(collections))) {
-        if (col.groupId === gid && !colIdSet.has(col.id)) {
-          missing.push(col.id);
-        }
-      }
-      if (missing.length > 0) {
-        console.warn(`[inbox] reconciling group "${group.name}": adding ${missing.length} missing collection(s)`);
-        const updated: CollectionGroup = {
-          ...group,
-          collectionIds: [...group.collectionIds, ...missing],
-        };
-        await storeGroup(updated);
-      }
-    }
-  } finally {
-    ensureDefaultGroupRunning = false;
-  }
-}
-
 // Debounced sync indicator: stays visible for at least 1 second to avoid flicker
 let syncTimeout: ReturnType<typeof setTimeout> | null = null;
 let syncVisibleUntil = 0;
@@ -258,7 +198,6 @@ rs.on('connected', async () => {
     '';
   userAddress.set(addr);
   await Promise.all([loadItems(), loadConfig(), loadUserSettings(), loadCollections(), loadGroups()]);
-  await ensureDefaultGroup();
 });
 
 rs.on('disconnected', () => {
@@ -324,7 +263,6 @@ function scheduleReload() {
   reloadTimeout = setTimeout(async () => {
     reloadTimeout = undefined;
     await Promise.all([loadItems(), loadCollections(), loadGroups()]);
-    await ensureDefaultGroup();
   }, 100);
 }
 if (inboxRef) {
@@ -654,6 +592,14 @@ export const groupCollections = derived([collections, groups, appConfig], ([$col
   return result;
 });
 
+export const ungroupedCollections = derived(
+  [sortedCollections, groups],
+  ([$sortedCollections, $groups]) => {
+    const groupIds = new Set(Object.keys($groups));
+    return $sortedCollections.filter(c => !c.groupId || !groupIds.has(c.groupId));
+  }
+);
+
 export async function storeGroup(group: CollectionGroup) {
   const inbox = getInbox();
   const clean = cleanForStorage(group);
@@ -666,10 +612,14 @@ export async function deleteGroup(id: string) {
   const currentGroups = get(groups);
   const group = currentGroups[id];
 
-  // Refuse to delete a group that still has collections
-  if (group && group.collectionIds.length > 0) {
-    console.warn('[inbox] cannot delete group with collections — remove them first');
-    return;
+  // Refuse to delete a group that still has collections (check groupId, not stale collectionIds)
+  if (group) {
+    const allCollections = get(collections);
+    const hasCollections = Object.values(allCollections).some(col => col.groupId === id);
+    if (hasCollections) {
+      console.warn('[inbox] cannot delete group with collections — remove them first');
+      return;
+    }
   }
 
   const prevGroups = get(groups);


### PR DESCRIPTION
## Summary

- Remove `ensureDefaultGroup()` which ran on every connect/reload, silently recreating groups the user had deleted and masking data loss with empty replacements
- Fix `deleteGroup()` guard to check `collection.groupId` (source of truth) instead of the stale `collectionIds` array
- Add `ungroupedCollections` derived store and an "Ungrouped" nav link/route so collections without a valid group remain visible
- Remove legacy `#/collections` redirect that depended on auto-created groups

## Test plan

- [x] No group auto-created when connecting with no groups (test)
- [x] No group auto-created when connecting with ungrouped collections (test)
- [x] Ungrouped collections not force-migrated into existing groups on connect (test)
- [x] Existing groups preserved without modification on connect (test)
- [x] No group recreated after deletion + reload (test)
- [x] deleteGroup refused when collections reference group via groupId (even with empty collectionIds) (test)
- [x] deleteGroup allowed for empty groups (test)
- [x] deleteGroup preserves unrelated collections (test)
- [x] ungroupedCollections surfaces collections with no/stale groupId (test)
- [x] Collections move between ungrouped and grouped reactively (test)