### PR TITLE
feat: drag & drop reordering for todos and groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inbox-rs",
-  "version": "1.3.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inbox-rs",
-      "version": "1.3.0",
+      "version": "1.4.1",
       "workspaces": [
         "packages/*"
       ]
@@ -3142,7 +3142,7 @@
     },
     "packages/extension": {
       "name": "@inbox-rs/extension",
-      "version": "1.3.0",
+      "version": "1.4.1",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "remotestoragejs": "^2.0.0-beta.8",
@@ -3316,7 +3316,7 @@
     },
     "packages/rs-module": {
       "name": "@inbox-rs/rs-module",
-      "version": "1.3.0",
+      "version": "1.4.1",
       "dependencies": {
         "remotestoragejs": "^2.0.0-beta.8",
         "rs-migrate": "^1.0.0"
@@ -3327,7 +3327,7 @@
     },
     "packages/thunderbird": {
       "name": "@inbox-rs/thunderbird",
-      "version": "1.3.0",
+      "version": "1.4.1",
       "dependencies": {
         "@inbox-rs/rs-module": "*"
       },
@@ -3497,7 +3497,7 @@
     },
     "packages/web": {
       "name": "@inbox-rs/web",
-      "version": "1.3.0",
+      "version": "1.4.1",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "@xenova/transformers": "^2.17.2",

--- a/packages/rs-module/src/types.ts
+++ b/packages/rs-module/src/types.ts
@@ -93,6 +93,7 @@ export interface AppConfig {
   todosCollapsed?: boolean;
   collectionsOrder?: string[]; // ordered list of collection IDs for nav display
   groupsOrder?: string[];      // ordered list of group IDs for nav display
+  todosOrder?: string[];       // ordered list of inbox todo IDs for manual sorting
   expandedCollections?: string[]; // IDs of collections currently expanded
 }
 

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -12,7 +12,8 @@
   import CollectionsPage from './components/CollectionsPage.svelte';
   import CollectionFormModal from './components/CollectionFormModal.svelte';
   import GroupFormModal from './components/GroupFormModal.svelte';
-  import { connected, deleteItem, todoItems, appConfig, updateConfig, pendingMigrationCount, runAllMigrations, storeCollection, sortedGroups, storeGroup, moveCollectionToGroup, ungroupedCollections } from './lib/stores';
+  import { dndzone } from 'svelte-dnd-action';
+  import { connected, deleteItem, todoItems, appConfig, updateConfig, pendingMigrationCount, runAllMigrations, storeCollection, sortedGroups, storeGroup, moveCollectionToGroup, ungroupedCollections, reorderGroups } from './lib/stores';
   import { pluginArtifactVersion } from './lib/plugin-downloads.generated';
   import LogoShield from './components/LogoShield.svelte';
 
@@ -28,6 +29,36 @@
   let todosExpanded = $state(false);
   let showCollectionForm = $state(false);
   let showGroupForm = $state(false);
+
+  // DnD for group tabs in nav
+  let isTouchDevice = $state(false);
+  $effect(() => {
+    const mql = window.matchMedia('(pointer: coarse)');
+    isTouchDevice = mql.matches;
+    const handler = (e: MediaQueryListEvent) => { isTouchDevice = e.matches; };
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  });
+
+  let dndGroups = $state<Array<CollectionGroup & { id: string }>>([]);
+  $effect(() => {
+    dndGroups = $sortedGroups.map(g => ({ ...g }));
+  });
+
+  function handleGroupDndConsider(e: CustomEvent<{ items: Array<CollectionGroup & { id: string }> }>) {
+    dndGroups = e.detail.items;
+  }
+
+  async function handleGroupDndFinalize(e: CustomEvent<{ items: Array<CollectionGroup & { id: string }> }>) {
+    const previous = $sortedGroups.map(g => ({ ...g }));
+    dndGroups = e.detail.items;
+    try {
+      await reorderGroups(dndGroups.map(g => g.id));
+    } catch (error) {
+      console.error('Failed to reorder groups', error);
+      dndGroups = previous;
+    }
+  }
 
   function getRouteFromHash(): Route {
     if (typeof window === 'undefined') return { page: 'home' };
@@ -164,18 +195,27 @@
     <nav class="header-nav" aria-label="Primary">
       <a class:active={route.page === 'home'} aria-current={route.page === 'home' ? 'page' : undefined} href="#/">Inbox</a>
       {#if $connected}
-        {#each $sortedGroups as group (group.id)}
-          <a
-            class="group-link"
-            class:active={route.page === 'group' && route.groupId === group.id}
-            aria-current={route.page === 'group' && route.groupId === group.id ? 'page' : undefined}
-            href="#/group/{group.id}"
-            style="--group-color: {group.color || 'var(--accent)'}"
+        {#if dndGroups.length > 0}
+          <div
+            class="nav-groups-dnd"
+            use:dndzone={{ items: dndGroups, flipDurationMs: 200, dropTargetStyle: {}, dragDisabled: isTouchDevice, type: 'nav-groups' }}
+            onconsider={handleGroupDndConsider}
+            onfinalize={handleGroupDndFinalize}
           >
-            <span class="group-dot"></span>
-            <span class="group-name">{group.name}</span>
-          </a>
-        {/each}
+            {#each dndGroups as group (group.id)}
+              <a
+                class="group-link"
+                class:active={route.page === 'group' && route.groupId === group.id}
+                aria-current={route.page === 'group' && route.groupId === group.id ? 'page' : undefined}
+                href="#/group/{group.id}"
+                style="--group-color: {group.color || 'var(--accent)'}"
+              >
+                <span class="group-dot"></span>
+                <span class="group-name">{group.name}</span>
+              </a>
+            {/each}
+          </div>
+        {/if}
         {#if $ungroupedCollections.length > 0}
           <a
             class:active={route.page === 'ungrouped'}
@@ -409,6 +449,13 @@
 
   .header-nav .group-link.active {
     background: color-mix(in srgb, var(--group-color) 18%, var(--surface) 82%);
+  }
+
+  .nav-groups-dnd {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    min-width: 0;
   }
 
   .group-dot {

--- a/packages/web/src/components/CollectionView.svelte
+++ b/packages/web/src/components/CollectionView.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import type { InboxItem, InboxItemType, Collection } from '@inbox-rs/rs-module';
+  import { dndzone } from 'svelte-dnd-action';
   import {
     collectionItems, storeItem,
     deleteItem,
-    sortedGroups, moveCollectionToGroup
+    sortedGroups, moveCollectionToGroup,
+    reorderCollectionItems
   } from '../lib/stores';
   import { makeTodo, makeReference, typeBadge, todoNote } from '../lib/item-utils';
   import { cleanForStorage } from '../lib/clean-for-storage';
@@ -62,6 +64,32 @@
       completedAt: nowCompleted ? new Date().toISOString() : undefined,
     };
     await storeItem(cleanForStorage(updated));
+  }
+
+  // DnD for open todos within the collection
+  let dndOpenTodos = $state<Array<InboxItem & { id: string }>>([]);
+  $effect(() => {
+    dndOpenTodos = openTodos.map(t => ({ ...t }));
+  });
+
+  function handleTodoDndConsider(e: CustomEvent<{ items: Array<InboxItem & { id: string }> }>) {
+    dndOpenTodos = e.detail.items;
+  }
+
+  async function handleTodoDndFinalize(e: CustomEvent<{ items: Array<InboxItem & { id: string }> }>) {
+    const previous = openTodos.map(t => ({ ...t }));
+    dndOpenTodos = e.detail.items;
+    // Rebuild full itemIds: new open todo order + completed todos + reference items (preserving their relative order)
+    const openTodoIds = new Set(openTodos.map(t => t.id));
+    const newOpenIds = dndOpenTodos.map(t => t.id);
+    const rest = collection.itemIds.filter(id => !openTodoIds.has(id));
+    const newItemIds = [...newOpenIds, ...rest];
+    try {
+      await reorderCollectionItems(collection.id, newItemIds);
+    } catch (error) {
+      console.error('Failed to reorder collection todos', error);
+      dndOpenTodos = previous;
+    }
   }
 
 </script>
@@ -189,9 +217,13 @@
                 {/if}
               </div>
 
-              {#if openTodos.length > 0}
-                <ul class="todo-list" role="list">
-                  {#each openTodos as item (item.id)}
+              {#if dndOpenTodos.length > 0}
+                <ul class="todo-list" role="list"
+                  use:dndzone={{ items: dndOpenTodos, flipDurationMs: 200, dropTargetStyle: {}, dragDisabled: isTouchDevice }}
+                  onconsider={handleTodoDndConsider}
+                  onfinalize={handleTodoDndFinalize}
+                >
+                  {#each dndOpenTodos as item (item.id)}
                     {@const badge = typeBadge(item)}
                     {@const note = todoNote(item)}
                     <li class="todo-item" role="button" tabindex="0"

--- a/packages/web/src/components/TodoList.svelte
+++ b/packages/web/src/components/TodoList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { InboxItem } from '@inbox-rs/rs-module';
-  import { todoItems, storeItem, activeCollectionTodos } from '../lib/stores';
+  import { dndzone } from 'svelte-dnd-action';
+  import { todoItems, storeItem, activeCollectionTodos, reorderTodos } from '../lib/stores';
   import { cleanForStorage } from '../lib/clean-for-storage';
   import { typeBadge } from '../lib/item-utils';
 
@@ -17,6 +18,36 @@
   const totalOpenCount = $derived(openTodos.length + collectionTodos.length);
   let expanded = $state(!inline);
   let showCompleted = $state(false);
+
+  let isTouchDevice = $state(false);
+  $effect(() => {
+    const mql = window.matchMedia('(pointer: coarse)');
+    isTouchDevice = mql.matches;
+    const handler = (e: MediaQueryListEvent) => { isTouchDevice = e.matches; };
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  });
+
+  let dndOpenTodos = $state<Array<InboxItem & { id: string }>>([]);
+  $effect(() => {
+    dndOpenTodos = openTodos.map(t => ({ ...t }));
+  });
+
+  function handleDndConsider(e: CustomEvent<{ items: Array<InboxItem & { id: string }> }>) {
+    dndOpenTodos = e.detail.items;
+  }
+
+  async function handleDndFinalize(e: CustomEvent<{ items: Array<InboxItem & { id: string }> }>) {
+    const previous = openTodos.map(t => ({ ...t }));
+    dndOpenTodos = e.detail.items;
+    try {
+      await reorderTodos(dndOpenTodos.map(t => t.id));
+    } catch (error) {
+      console.error('Failed to reorder todos', error);
+      dndOpenTodos = previous;
+    }
+  }
+
   async function toggleCompleted(e: Event, todo: InboxItem) {
     e.stopPropagation();
     const updated = {
@@ -56,9 +87,13 @@
     </button>
   </div>
   {#if expanded}
-    {#if openTodos.length > 0}
-      <ul role="list">
-        {#each openTodos as todo (todo.id)}
+    {#if dndOpenTodos.length > 0}
+      <ul role="list"
+        use:dndzone={{ items: dndOpenTodos, flipDurationMs: 200, dropTargetStyle: {}, dragDisabled: isTouchDevice }}
+        onconsider={handleDndConsider}
+        onfinalize={handleDndFinalize}
+      >
+        {#each dndOpenTodos as todo (todo.id)}
           {@const badge = typeBadge(todo)}
           {@const note = todoNote(todo)}
           <li class="todo-item" role="button" tabindex="0"

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -53,9 +53,9 @@ import {
   blobUrls, connected, loadFileBlobUrl,
   collections, groups, groupCollections, moveCollectionToGroup,
   deleteGroup, ungroupedCollections, appConfig,
-  storeCollection, reorderGroupCollections,
+  storeCollection, reorderGroupCollections, items, todoItems, reorderTodos,
 } from './stores';
-import type { Collection, CollectionGroup } from '@inbox-rs/rs-module';
+import type { Collection, CollectionGroup, InboxItem } from '@inbox-rs/rs-module';
 
 /**
  * rs.on() handlers are registered at module load time.
@@ -206,6 +206,16 @@ function makeGroup(id: string, collectionIds: string[] = []): CollectionGroup {
   };
 }
 
+function makeTodo(id: string, overrides: Partial<InboxItem> = {}): InboxItem {
+  return {
+    id,
+    type: 'todo',
+    title: `Todo ${id}`,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  } as InboxItem;
+}
+
 describe('groupCollections', () => {
   beforeEach(() => {
     collections.set({});
@@ -290,6 +300,52 @@ describe('groupCollections', () => {
 
     const result = get(groupCollections);
     expect(result['g1']).toEqual([]);
+  });
+});
+
+describe('todoItems ordering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    items.set({});
+    appConfig.set({});
+  });
+
+  it('keeps configured open todo order and falls back to newest-first for new todos', () => {
+    items.set({
+      t1: makeTodo('t1', { createdAt: '2026-01-01T00:00:00.000Z' }),
+      t2: makeTodo('t2', { createdAt: '2026-01-02T00:00:00.000Z' }),
+      t3: makeTodo('t3', { createdAt: '2026-01-03T00:00:00.000Z' }),
+    });
+    appConfig.set({ todosOrder: ['t2'] });
+
+    expect(get(todoItems).map(todo => todo.id)).toEqual(['t2', 't3', 't1']);
+  });
+
+  it('keeps completed todos after open todos and sorts them by completion time', () => {
+    items.set({
+      open: makeTodo('open', { createdAt: '2026-01-01T00:00:00.000Z' }),
+      'done-older': makeTodo('done-older', {
+        createdAt: '2026-01-02T00:00:00.000Z',
+        completed: true,
+        completedAt: '2026-01-04T00:00:00.000Z',
+      }),
+      'done-newer': makeTodo('done-newer', {
+        createdAt: '2026-01-03T00:00:00.000Z',
+        completed: true,
+        completedAt: '2026-01-05T00:00:00.000Z',
+      }),
+    });
+
+    expect(get(todoItems).map(todo => todo.id)).toEqual(['open', 'done-newer', 'done-older']);
+  });
+
+  it('persists reordered inbox todo ids in config', async () => {
+    appConfig.set({});
+
+    await reorderTodos(['t3', 't1', 't2']);
+
+    expect(get(appConfig).todosOrder).toEqual(['t3', 't1', 't2']);
+    expect(mockInbox.setConfig).toHaveBeenCalledWith({ todosOrder: ['t3', 't1', 't2'] });
   });
 });
 

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -77,13 +77,11 @@ function orderedDerived<T extends { id: string; createdAt: string }>(
   configOrderKey: 'collectionsOrder' | 'groupsOrder',
 ): Readable<T[]> {
   return derived([entityStore, appConfig], ([$entities, $config]) => {
-    const items = Object.values($entities);
-    const order = $config[configOrderKey];
-    if (order?.length) {
-      const orderIndex = new Map(order.map((id, i) => [id, i]));
-      return items.sort((a, b) => (orderIndex.get(a.id) ?? Infinity) - (orderIndex.get(b.id) ?? Infinity));
-    }
-    return items.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+    return sortWithConfiguredOrder(
+      Object.values($entities),
+      $config[configOrderKey],
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    );
   });
 }
 
@@ -275,6 +273,30 @@ document.addEventListener('visibilitychange', () => {
   }
 });
 
+function sortWithConfiguredOrder<T extends { id: string }>(
+  entities: T[],
+  order: string[] | undefined,
+  fallbackCompare: (a: T, b: T) => number,
+): T[] {
+  const orderIndex = order?.length
+    ? new Map(order.map((id, index) => [id, index]))
+    : undefined;
+
+  return entities.sort((a, b) => {
+    if (orderIndex) {
+      const aIndex = orderIndex.get(a.id);
+      const bIndex = orderIndex.get(b.id);
+      if (aIndex !== undefined || bIndex !== undefined) {
+        if (aIndex === undefined) return 1;
+        if (bIndex === undefined) return -1;
+        if (aIndex !== bIndex) return aIndex - bIndex;
+      }
+    }
+
+    return fallbackCompare(a, b);
+  });
+}
+
 // ---- Derived stores ----
 
 export const sortedItems = derived(items, ($items) => {
@@ -289,14 +311,11 @@ export const todoItems = derived([items, appConfig], ([$items, $config]) => {
   const open = all.filter(i => !i.completed);
   const completed = all.filter(i => i.completed);
 
-  // Sort open todos by todosOrder if available, else by creation date
-  const order = $config.todosOrder;
-  if (order?.length) {
-    const orderIndex = new Map(order.map((id, i) => [id, i]));
-    open.sort((a, b) => (orderIndex.get(a.id) ?? Infinity) - (orderIndex.get(b.id) ?? Infinity));
-  } else {
-    open.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-  }
+  sortWithConfiguredOrder(
+    open,
+    $config.todosOrder,
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
 
   // Completed sorted by completedAt desc
   completed.sort((a, b) => new Date(b.completedAt ?? b.createdAt).getTime() - new Date(a.completedAt ?? a.createdAt).getTime());

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -87,7 +87,7 @@ function orderedDerived<T extends { id: string; createdAt: string }>(
   });
 }
 
-async function removeFromOrderConfig(id: string, key: 'collectionsOrder' | 'groupsOrder') {
+async function removeFromOrderConfig(id: string, key: 'collectionsOrder' | 'groupsOrder' | 'todosOrder') {
   const currentOrder = get(appConfig)[key] ?? [];
   if (currentOrder.includes(id)) {
     await updateConfig({ [key]: currentOrder.filter((x: string) => x !== id) });
@@ -283,15 +283,25 @@ export const sortedItems = derived(items, ($items) => {
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 });
 
-export const todoItems = derived(items, ($items) => {
-  return Object.values($items)
-    .filter(i => (i.isTodo || i.type === 'todo') && !i.collectionId)
-    .sort((a, b) => {
-      const aDone = !!a.completed;
-      const bDone = !!b.completed;
-      if (aDone !== bDone) return aDone ? 1 : -1;
-      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-    });
+export const todoItems = derived([items, appConfig], ([$items, $config]) => {
+  const all = Object.values($items)
+    .filter(i => (i.isTodo || i.type === 'todo') && !i.collectionId);
+  const open = all.filter(i => !i.completed);
+  const completed = all.filter(i => i.completed);
+
+  // Sort open todos by todosOrder if available, else by creation date
+  const order = $config.todosOrder;
+  if (order?.length) {
+    const orderIndex = new Map(order.map((id, i) => [id, i]));
+    open.sort((a, b) => (orderIndex.get(a.id) ?? Infinity) - (orderIndex.get(b.id) ?? Infinity));
+  } else {
+    open.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  }
+
+  // Completed sorted by completedAt desc
+  completed.sort((a, b) => new Date(b.completedAt ?? b.createdAt).getTime() - new Date(a.completedAt ?? a.createdAt).getTime());
+
+  return [...open, ...completed];
 });
 
 export const sortedCollections = orderedDerived<Collection>(collections, 'collectionsOrder');
@@ -731,4 +741,8 @@ export async function reorderGroupCollections(groupId: string, newCollectionIds:
 
 export async function reorderGroups(newOrder: string[]) {
   await updateConfig({ groupsOrder: newOrder });
+}
+
+export async function reorderTodos(newOrder: string[]) {
+  await updateConfig({ todosOrder: newOrder });
 }


### PR DESCRIPTION
## Summary

- Add drag & drop reordering for open inbox todos (persisted via `todosOrder` in AppConfig)
- Add drag & drop reordering for open todos within collections (persisted via existing `itemIds` order)
- Add drag & drop reordering for group tabs in the navigation header (persisted via existing `groupsOrder`)
- Uses existing `svelte-dnd-action` library and follows the same DnD patterns already used for collection reordering
- Touch devices have drag disabled, matching existing behavior

## Test plan

- [ ] Create several inbox todos, drag to reorder, reload — order persists
- [ ] Expand a collection with multiple todos, drag to reorder, reload — order persists
- [ ] Create multiple groups, drag group tabs in nav header, reload — order persists
- [ ] Verify completed todos are not draggable
- [ ] Verify collection todos (from active collections) in the inbox sidebar are not draggable
- [ ] Test on touch device or emulated touch — drag should be disabled
- [ ] Run `npx vitest run` — all 57 tests pass