### PR TITLE
fix(extension): add Firefox data_collection_permissions

### DIFF
--- a/packages/extension/manifest.firefox.json
+++ b/packages/extension/manifest.firefox.json
@@ -31,7 +31,11 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "inbox-rs@example.com",
-      "strict_min_version": "109.0"
+      "strict_min_version": "126.0",
+      "data_collection_permissions": {
+        "required": ["none"],
+        "optional": []
+      }
     }
   },
   "content_scripts": [

--- a/packages/extension/manifest.firefox.json
+++ b/packages/extension/manifest.firefox.json
@@ -7,8 +7,7 @@
     "contextMenus",
     "activeTab",
     "storage",
-    "identity",
-    "scripting"
+    "identity"
   ],
   "host_permissions": [
     "<all_urls>"
@@ -30,7 +29,7 @@
   },
   "browser_specific_settings": {
     "gecko": {
-      "id": "inbox-rs@example.com",
+      "id": "inbox-rs@silverbucket.net",
       "strict_min_version": "126.0",
       "data_collection_permissions": {
         "required": ["none"],

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -7,8 +7,7 @@
     "contextMenus",
     "activeTab",
     "storage",
-    "identity",
-    "scripting"
+    "identity"
   ],
   "host_permissions": [
     "<all_urls>"


### PR DESCRIPTION
## Summary
- Add `data_collection_permissions` to `browser_specific_settings.gecko` in the Firefox manifest, required by AMO for new submissions
- Bump `strict_min_version` from 109.0 to 126.0 to match features used (`options_page` requires 126+, `background.type` requires 112+)

## Test plan
- [ ] Build Firefox extension with `BROWSER=firefox npm run build --workspace=packages/extension`
- [ ] Verify `dist/manifest.json` contains `data_collection_permissions` under `browser_specific_settings.gecko`
- [ ] Submit to AMO and confirm validation passes