### PR TITLE
fix(sync): improve sync efficiency based on RS.js event model

### DIFF
--- a/packages/web/src/lib/rs.ts
+++ b/packages/web/src/lib/rs.ts
@@ -10,7 +10,6 @@ const rs = new RemoteStorage({
 rs.access.claim('inbox', 'rw');
 rs.access.claim('shares', 'rw');
 rs.caching.enable('/inbox/');
-rs.setSyncInterval(3000);
 
 /**
  * Fetch a file from an RS server using Authorization header and return a blob URL.

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -52,7 +52,7 @@ import {
   blobUrls, connected, loadFileBlobUrl,
   collections, groups, groupCollections, moveCollectionToGroup,
   deleteGroup, ungroupedCollections, appConfig,
-  storeCollection, reorderGroupCollections, items, todoItems, reorderTodos,
+  storeCollection, reorderGroupCollections, items, todoItems, reorderTodos, userSettings,
 } from './stores';
 import type { Collection, CollectionGroup, InboxItem } from '@inbox-rs/rs-module';
 
@@ -79,11 +79,11 @@ function emitRsEvent(event: string, ...args: any[]) {
 }
 
 /** Capture the onChange handler registered at module load time (before mocks are cleared) */
-const onChangeHandler = mockInbox.onChange.mock.calls[0]?.[0] as (() => void) | undefined;
+const onChangeHandler = mockInbox.onChange.mock.calls[0]?.[0] as ((event: any) => void) | undefined;
 
-/** Simulate a remoteStorage module change event (marks data as changed for sync-done reload) */
-function emitModuleChange() {
-  if (onChangeHandler) onChangeHandler();
+/** Simulate a remoteStorage module change event with per-item data */
+function emitModuleChange(event: { relativePath: string; origin?: string; newValue?: any; oldValue?: any }) {
+  if (onChangeHandler) onChangeHandler({ origin: 'remote', ...event });
 }
 
 /** Backwards-compat: single-handler lookup for events with one handler (e.g. 'connected') */
@@ -563,109 +563,109 @@ describe('no group recreation after deletion', () => {
     mockInbox.getUserSettings.mockResolvedValue(undefined);
   });
 
-  it('does not recreate a group after all groups are deleted and a sync-done reload triggers', async () => {
-    // Start with a group
+  it('does not recreate a group after deletion when unrelated changes arrive', async () => {
     const group = makeGroup('g1', []);
     groups.set({ g1: group });
 
-    // Delete the group
     await deleteGroup('g1');
     expect(get(groups)['g1']).toBeUndefined();
 
-    // Simulate a sync-done event triggering a reload (backend returns empty)
-    emitModuleChange();
-    emitRsEvent('sync-done');
-    await vi.waitFor(() => {
-      expect(Object.keys(get(groups))).toHaveLength(0);
-    }, { timeout: 500 });
+    // An unrelated item change should not recreate the deleted group
+    emitModuleChange({
+      relativePath: 'items/i1',
+      newValue: { id: 'i1', type: 'note', title: 'X', createdAt: '2026-01-01T00:00:00.000Z' },
+    });
 
+    expect(Object.keys(get(groups))).toHaveLength(0);
     expect(mockInbox.storeGroup).not.toHaveBeenCalled();
   });
 });
 
-describe('sync-done reload', () => {
+describe('per-item change handling', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     items.set({});
     collections.set({});
     groups.set({});
     appConfig.set({});
-    mockInbox.getAll.mockResolvedValue({});
-    mockInbox.getAllCollections.mockResolvedValue({});
-    mockInbox.getAllGroups.mockResolvedValue({});
   });
 
-  it('does not reload on idle sync-done when no data changed', async () => {
-    // Drain any stale syncHasChanges flag from prior tests
-    emitRsEvent('sync-done');
-    await new Promise(r => setTimeout(r, 200));
-    vi.clearAllMocks();
-    mockInbox.getAll.mockResolvedValue({});
-    mockInbox.getAllCollections.mockResolvedValue({});
-    mockInbox.getAllGroups.mockResolvedValue({});
+  it('adds an incoming item to the store', () => {
+    const item = { id: 'i1', type: 'note', title: 'Test', createdAt: '2026-01-01T00:00:00.000Z' };
+    emitModuleChange({ relativePath: 'items/i1', newValue: item });
 
-    // Now fire sync-done with no preceding onChange — should not reload
-    emitRsEvent('sync-done');
-    await new Promise(r => setTimeout(r, 200));
+    expect(get(items)['i1']).toBeDefined();
+    expect(get(items)['i1'].title).toBe('Test');
+  });
+
+  it('removes a deleted item from the store', () => {
+    items.set({ i1: { id: 'i1', type: 'note', title: 'Old', createdAt: '2026-01-01T00:00:00.000Z' } as InboxItem });
+
+    emitModuleChange({ relativePath: 'items/i1', newValue: undefined, oldValue: { id: 'i1' } });
+
+    expect(get(items)['i1']).toBeUndefined();
+  });
+
+  it('adds an incoming collection with itemIds normalization', () => {
+    const col = { id: 'c1', name: 'Test', createdAt: '2026-01-01T00:00:00.000Z' };
+    emitModuleChange({ relativePath: 'collections/c1', newValue: col });
+
+    expect(get(collections)['c1']).toBeDefined();
+    expect(get(collections)['c1'].itemIds).toEqual([]);
+  });
+
+  it('adds an incoming group with collectionIds normalization', () => {
+    const grp = { id: 'g1', name: 'Test Group', createdAt: '2026-01-01T00:00:00.000Z' };
+    emitModuleChange({ relativePath: 'groups/g1', newValue: grp });
+
+    expect(get(groups)['g1']).toBeDefined();
+    expect(get(groups)['g1'].collectionIds).toEqual([]);
+  });
+
+  it('updates appConfig on config/app change', () => {
+    emitModuleChange({ relativePath: 'config/app', newValue: { todosOrder: ['t1', 't2'] } });
+
+    expect(get(appConfig).todosOrder).toEqual(['t1', 't2']);
+  });
+
+  it('updates userSettings on config/user change', () => {
+    emitModuleChange({ relativePath: 'config/user', newValue: { theme: 'dark' } });
+
+    expect((get(userSettings) as any).theme).toBe('dark');
+  });
+
+  it('ignores window-origin events (local writes already update stores)', () => {
+    emitModuleChange({ relativePath: 'items/i1', origin: 'window', newValue: { id: 'i1', type: 'note', title: 'X', createdAt: '' } });
+
+    expect(get(items)['i1']).toBeUndefined();
+  });
+
+  it('handles multiple incoming items without calling getAll', () => {
+    for (let i = 0; i < 5; i++) {
+      emitModuleChange({
+        relativePath: `items/i${i}`,
+        newValue: { id: `i${i}`, type: 'note', title: `Note ${i}`, createdAt: '2026-01-01T00:00:00.000Z' },
+      });
+    }
+
+    expect(Object.keys(get(items))).toHaveLength(5);
     expect(mockInbox.getAll).not.toHaveBeenCalled();
   });
 
-  it('reloads items, collections, and groups on sync-done after changes', async () => {
-    const item = { id: 'i1', type: 'note', title: 'Test', createdAt: '2026-01-01T00:00:00.000Z' };
-    const col = makeCollection('c1');
-    const group = makeGroup('g1', ['c1']);
-    mockInbox.getAll.mockResolvedValue({ i1: item });
-    mockInbox.getAllCollections.mockResolvedValue({ c1: col });
-    mockInbox.getAllGroups.mockResolvedValue({ g1: group });
+  it('removes a deleted collection from the store', () => {
+    collections.set({ c1: makeCollection('c1') });
 
-    expect(Object.keys(get(items))).toHaveLength(0);
+    emitModuleChange({ relativePath: 'collections/c1', newValue: undefined, oldValue: { id: 'c1' } });
 
-    // onChange marks data as changed, sync-done triggers the reload
-    emitModuleChange();
-    emitRsEvent('sync-done');
-
-    await vi.waitFor(() => {
-      expect(Object.keys(get(items))).toHaveLength(1);
-      expect(get(items)['i1'].title).toBe('Test');
-      expect(get(collections)['c1']).toBeDefined();
-      expect(get(groups)['g1']).toBeDefined();
-    }, { timeout: 500 });
+    expect(get(collections)['c1']).toBeUndefined();
   });
 
-  it('reloads only once for rapid sync-done events (debounce)', async () => {
-    mockInbox.getAll.mockResolvedValue({});
-    mockInbox.getAllCollections.mockResolvedValue({});
-    mockInbox.getAllGroups.mockResolvedValue({});
+  it('removes a deleted group from the store', () => {
+    groups.set({ g1: makeGroup('g1') });
 
-    // Mark data as changed, then fire sync-done 5 times rapidly
-    emitModuleChange();
-    for (let i = 0; i < 5; i++) {
-      emitRsEvent('sync-done');
-    }
+    emitModuleChange({ relativePath: 'groups/g1', newValue: undefined, oldValue: { id: 'g1' } });
 
-    await vi.waitFor(() => {
-      expect(mockInbox.getAll).toHaveBeenCalled();
-    }, { timeout: 500 });
-
-    // Debounce (100ms) should collapse these into a single reload
-    expect(mockInbox.getAll).toHaveBeenCalledTimes(1);
-  });
-
-  it('picks up new incoming items after sync completes', async () => {
-    items.set({ i1: { id: 'i1', type: 'note', title: 'Old', createdAt: '2026-01-01T00:00:00.000Z' } as InboxItem });
-
-    mockInbox.getAll.mockResolvedValue({
-      i1: { id: 'i1', type: 'note', title: 'Old', createdAt: '2026-01-01T00:00:00.000Z' },
-      i2: { id: 'i2', type: 'image', title: 'Photo', createdAt: '2026-01-02T00:00:00.000Z', filePath: 'files/photo.jpg', mimeType: 'image/jpeg' },
-    });
-
-    emitModuleChange();
-    emitRsEvent('sync-done');
-
-    await vi.waitFor(() => {
-      expect(Object.keys(get(items))).toHaveLength(2);
-      expect(get(items)['i2'].title).toBe('Photo');
-    }, { timeout: 500 });
+    expect(get(groups)['g1']).toBeUndefined();
   });
 });
 

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -14,7 +14,6 @@ const { mockRs, mockInbox } = vi.hoisted(() => {
     getConfig: vi.fn().mockResolvedValue({}),
     getAllCollections: vi.fn().mockResolvedValue({}),
     getAllGroups: vi.fn().mockResolvedValue({}),
-    onChange: vi.fn(),
     store: vi.fn().mockResolvedValue(undefined),
     remove: vi.fn().mockResolvedValue(undefined),
     storeCollection: vi.fn().mockResolvedValue(undefined),
@@ -27,7 +26,6 @@ const { mockRs, mockInbox } = vi.hoisted(() => {
   const mockRs = {
     access: { claim: vi.fn() },
     caching: { enable: vi.fn() },
-    setSyncInterval: vi.fn(),
     on: vi.fn(),
     remote: {},
     startSync: vi.fn(),
@@ -60,15 +58,32 @@ import type { Collection, CollectionGroup, InboxItem } from '@inbox-rs/rs-module
 /**
  * rs.on() handlers are registered at module load time.
  * Capture them once before any test clears mocks.
+ * Multiple handlers may be registered per event (e.g. sync-done has
+ * hideSync, scheduleReload, and a debug logger).
  */
-const rsHandlers: Record<string, (...args: any[]) => any> = {};
+const rsHandlerMap: Record<string, Array<(...args: any[]) => any>> = {};
 function captureRsHandlers() {
-  if (Object.keys(rsHandlers).length > 0) return;
+  if (Object.keys(rsHandlerMap).length > 0) return;
   for (const [event, handler] of mockRs.on.mock.calls as [string, (...args: any[]) => any][]) {
-    rsHandlers[event] = handler;
+    (rsHandlerMap[event] ??= []).push(handler);
   }
 }
 captureRsHandlers();
+
+/** Fire all registered handlers for an RS event */
+function emitRsEvent(event: string, ...args: any[]) {
+  for (const handler of rsHandlerMap[event] ?? []) {
+    handler(...args);
+  }
+}
+
+/** Backwards-compat: single-handler lookup for events with one handler (e.g. 'connected') */
+const rsHandlers = new Proxy({} as Record<string, (...args: any[]) => any>, {
+  get: (_target, prop: string) => {
+    const handlers = rsHandlerMap[prop];
+    return handlers?.[handlers.length - 1];
+  },
+});
 
 describe('loadFileBlobUrl', () => {
   beforeEach(() => {
@@ -539,7 +554,7 @@ describe('no group recreation after deletion', () => {
     mockInbox.getUserSettings.mockResolvedValue(undefined);
   });
 
-  it('does not recreate a group after all groups are deleted and a reload triggers', async () => {
+  it('does not recreate a group after all groups are deleted and a sync-done reload triggers', async () => {
     // Start with a group
     const group = makeGroup('g1', []);
     groups.set({ g1: group });
@@ -548,18 +563,83 @@ describe('no group recreation after deletion', () => {
     await deleteGroup('g1');
     expect(get(groups)['g1']).toBeUndefined();
 
-    // Simulate a reload (scheduleReload loads from backend which returns empty)
-    const onChange = mockInbox.onChange.mock.calls[0]?.[1] ?? mockInbox.onChange.mock.calls[0]?.[0];
-    if (onChange) {
-      onChange();
-      // Wait for debounced reload
-      await vi.waitFor(() => {
-        // After reload, groups should still be empty
-        expect(Object.keys(get(groups))).toHaveLength(0);
-      }, { timeout: 500 });
-    }
+    // Simulate a sync-done event triggering a reload (backend returns empty)
+    emitRsEvent('sync-done');
+    await vi.waitFor(() => {
+      expect(Object.keys(get(groups))).toHaveLength(0);
+    }, { timeout: 500 });
 
     expect(mockInbox.storeGroup).not.toHaveBeenCalled();
+  });
+});
+
+describe('sync-done reload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    items.set({});
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+    mockInbox.getAll.mockResolvedValue({});
+    mockInbox.getAllCollections.mockResolvedValue({});
+    mockInbox.getAllGroups.mockResolvedValue({});
+  });
+
+  it('reloads items, collections, and groups on sync-done', async () => {
+    const item = { id: 'i1', type: 'note', title: 'Test', createdAt: '2026-01-01T00:00:00.000Z' };
+    const col = makeCollection('c1');
+    const group = makeGroup('g1', ['c1']);
+    mockInbox.getAll.mockResolvedValue({ i1: item });
+    mockInbox.getAllCollections.mockResolvedValue({ c1: col });
+    mockInbox.getAllGroups.mockResolvedValue({ g1: group });
+
+    // Before sync-done, stores are empty
+    expect(Object.keys(get(items))).toHaveLength(0);
+
+    emitRsEvent('sync-done');
+
+    await vi.waitFor(() => {
+      expect(Object.keys(get(items))).toHaveLength(1);
+      expect(get(items)['i1'].title).toBe('Test');
+      expect(get(collections)['c1']).toBeDefined();
+      expect(get(groups)['g1']).toBeDefined();
+    }, { timeout: 500 });
+  });
+
+  it('reloads only once for rapid sync-done events (debounce)', async () => {
+    mockInbox.getAll.mockResolvedValue({});
+    mockInbox.getAllCollections.mockResolvedValue({});
+    mockInbox.getAllGroups.mockResolvedValue({});
+
+    // Fire sync-done 5 times rapidly
+    for (let i = 0; i < 5; i++) {
+      emitRsEvent('sync-done');
+    }
+
+    await vi.waitFor(() => {
+      expect(mockInbox.getAll).toHaveBeenCalled();
+    }, { timeout: 500 });
+
+    // Debounce (100ms) should collapse these into a single reload
+    expect(mockInbox.getAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('picks up new incoming items after sync completes', async () => {
+    // Simulate initial state with one item
+    items.set({ i1: { id: 'i1', type: 'note', title: 'Old', createdAt: '2026-01-01T00:00:00.000Z' } as InboxItem });
+
+    // Backend now has two items (one new from another device)
+    mockInbox.getAll.mockResolvedValue({
+      i1: { id: 'i1', type: 'note', title: 'Old', createdAt: '2026-01-01T00:00:00.000Z' },
+      i2: { id: 'i2', type: 'image', title: 'Photo', createdAt: '2026-01-02T00:00:00.000Z', filePath: 'files/photo.jpg', mimeType: 'image/jpeg' },
+    });
+
+    emitRsEvent('sync-done');
+
+    await vi.waitFor(() => {
+      expect(Object.keys(get(items))).toHaveLength(2);
+      expect(get(items)['i2'].title).toBe('Photo');
+    }, { timeout: 500 });
   });
 });
 

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -14,6 +14,7 @@ const { mockRs, mockInbox } = vi.hoisted(() => {
     getConfig: vi.fn().mockResolvedValue({}),
     getAllCollections: vi.fn().mockResolvedValue({}),
     getAllGroups: vi.fn().mockResolvedValue({}),
+    onChange: vi.fn(),
     store: vi.fn().mockResolvedValue(undefined),
     remove: vi.fn().mockResolvedValue(undefined),
     storeCollection: vi.fn().mockResolvedValue(undefined),
@@ -75,6 +76,14 @@ function emitRsEvent(event: string, ...args: any[]) {
   for (const handler of rsHandlerMap[event] ?? []) {
     handler(...args);
   }
+}
+
+/** Capture the onChange handler registered at module load time (before mocks are cleared) */
+const onChangeHandler = mockInbox.onChange.mock.calls[0]?.[0] as (() => void) | undefined;
+
+/** Simulate a remoteStorage module change event (marks data as changed for sync-done reload) */
+function emitModuleChange() {
+  if (onChangeHandler) onChangeHandler();
 }
 
 /** Backwards-compat: single-handler lookup for events with one handler (e.g. 'connected') */
@@ -564,6 +573,7 @@ describe('no group recreation after deletion', () => {
     expect(get(groups)['g1']).toBeUndefined();
 
     // Simulate a sync-done event triggering a reload (backend returns empty)
+    emitModuleChange();
     emitRsEvent('sync-done');
     await vi.waitFor(() => {
       expect(Object.keys(get(groups))).toHaveLength(0);
@@ -585,7 +595,22 @@ describe('sync-done reload', () => {
     mockInbox.getAllGroups.mockResolvedValue({});
   });
 
-  it('reloads items, collections, and groups on sync-done', async () => {
+  it('does not reload on idle sync-done when no data changed', async () => {
+    // Drain any stale syncHasChanges flag from prior tests
+    emitRsEvent('sync-done');
+    await new Promise(r => setTimeout(r, 200));
+    vi.clearAllMocks();
+    mockInbox.getAll.mockResolvedValue({});
+    mockInbox.getAllCollections.mockResolvedValue({});
+    mockInbox.getAllGroups.mockResolvedValue({});
+
+    // Now fire sync-done with no preceding onChange — should not reload
+    emitRsEvent('sync-done');
+    await new Promise(r => setTimeout(r, 200));
+    expect(mockInbox.getAll).not.toHaveBeenCalled();
+  });
+
+  it('reloads items, collections, and groups on sync-done after changes', async () => {
     const item = { id: 'i1', type: 'note', title: 'Test', createdAt: '2026-01-01T00:00:00.000Z' };
     const col = makeCollection('c1');
     const group = makeGroup('g1', ['c1']);
@@ -593,9 +618,10 @@ describe('sync-done reload', () => {
     mockInbox.getAllCollections.mockResolvedValue({ c1: col });
     mockInbox.getAllGroups.mockResolvedValue({ g1: group });
 
-    // Before sync-done, stores are empty
     expect(Object.keys(get(items))).toHaveLength(0);
 
+    // onChange marks data as changed, sync-done triggers the reload
+    emitModuleChange();
     emitRsEvent('sync-done');
 
     await vi.waitFor(() => {
@@ -611,7 +637,8 @@ describe('sync-done reload', () => {
     mockInbox.getAllCollections.mockResolvedValue({});
     mockInbox.getAllGroups.mockResolvedValue({});
 
-    // Fire sync-done 5 times rapidly
+    // Mark data as changed, then fire sync-done 5 times rapidly
+    emitModuleChange();
     for (let i = 0; i < 5; i++) {
       emitRsEvent('sync-done');
     }
@@ -625,15 +652,14 @@ describe('sync-done reload', () => {
   });
 
   it('picks up new incoming items after sync completes', async () => {
-    // Simulate initial state with one item
     items.set({ i1: { id: 'i1', type: 'note', title: 'Old', createdAt: '2026-01-01T00:00:00.000Z' } as InboxItem });
 
-    // Backend now has two items (one new from another device)
     mockInbox.getAll.mockResolvedValue({
       i1: { id: 'i1', type: 'note', title: 'Old', createdAt: '2026-01-01T00:00:00.000Z' },
       i2: { id: 'i2', type: 'image', title: 'Photo', createdAt: '2026-01-02T00:00:00.000Z', filePath: 'files/photo.jpg', mimeType: 'image/jpeg' },
     });
 
+    emitModuleChange();
     emitRsEvent('sync-done');
 
     await vi.waitFor(() => {

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -176,9 +176,15 @@ rs.on('wire-busy', showSync);
 rs.on('wire-done', hideSync);
 rs.on('sync-done', hideSync);
 
-// Reload stores once per completed sync cycle (not per-item change event)
+// Reload stores once per sync cycle, but only if data actually changed.
+// onChange fires per-item during sync; we just set a flag and wait for
+// sync-done to batch the reload into a single getAll() call.
+let syncHasChanges = false;
 rs.on('sync-done', () => {
-  scheduleReload();
+  if (syncHasChanges) {
+    syncHasChanges = false;
+    scheduleReload();
+  }
 });
 
 // Debug: log sync activity
@@ -266,6 +272,11 @@ function scheduleReload() {
     reloadTimeout = undefined;
     await Promise.all([loadItems(), loadCollections(), loadGroups()]);
   }, 100);
+}
+
+const inboxRef = getInbox();
+if (inboxRef) {
+  inboxRef.onChange(() => { syncHasChanges = true; });
 }
 
 document.addEventListener('visibilitychange', () => {

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -176,6 +176,11 @@ rs.on('wire-busy', showSync);
 rs.on('wire-done', hideSync);
 rs.on('sync-done', hideSync);
 
+// Reload stores once per completed sync cycle (not per-item change event)
+rs.on('sync-done', () => {
+  scheduleReload();
+});
+
 // Debug: log sync activity
 rs.on('sync-req-done', (e: any) => {
   console.log('[inbox] sync-req-done, tasks remaining:', e?.tasksRemaining);
@@ -254,17 +259,13 @@ export async function updateUserSettings(patch: Partial<UserSettings>) {
   }
 }
 
-// Update items on remote/local changes — debounced to avoid redundant reloads during sync
-const inboxRef = getInbox();
+// Reload stores after sync completes — debounced in case multiple sync-done events fire closely
 function scheduleReload() {
   if (reloadTimeout) clearTimeout(reloadTimeout);
   reloadTimeout = setTimeout(async () => {
     reloadTimeout = undefined;
     await Promise.all([loadItems(), loadCollections(), loadGroups()]);
   }, 100);
-}
-if (inboxRef) {
-  inboxRef.onChange(scheduleReload);
 }
 
 document.addEventListener('visibilitychange', () => {

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -432,8 +432,6 @@ export async function storeItem(item: InboxItem, fileData?: ArrayBuffer) {
     const blob = new Blob([fileData], { type: (item as any).mimeType });
     const url = URL.createObjectURL(blob);
     blobUrls.update(current => ({ ...current, [item.filePath as string]: url }));
-    console.log('[inbox] stored file, triggering sync:', item.filePath);
-    rs.startSync();
   }
   items.update(current => ({ ...current, [cleanItem.id]: cleanItem }));
 }

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -176,17 +176,6 @@ rs.on('wire-busy', showSync);
 rs.on('wire-done', hideSync);
 rs.on('sync-done', hideSync);
 
-// Reload stores once per sync cycle, but only if data actually changed.
-// onChange fires per-item during sync; we just set a flag and wait for
-// sync-done to batch the reload into a single getAll() call.
-let syncHasChanges = false;
-rs.on('sync-done', () => {
-  if (syncHasChanges) {
-    syncHasChanges = false;
-    scheduleReload();
-  }
-});
-
 // Debug: log sync activity
 rs.on('sync-req-done', (e: any) => {
   console.log('[inbox] sync-req-done, tasks remaining:', e?.tasksRemaining);
@@ -196,8 +185,6 @@ rs.on('sync-done', (e: any) => {
 });
 rs.on('wire-busy', () => console.log('[inbox] wire-busy'));
 rs.on('wire-done', () => console.log('[inbox] wire-done'));
-
-let reloadTimeout: ReturnType<typeof setTimeout> | undefined;
 
 rs.on('connected', async () => {
   connected.set(true);
@@ -213,10 +200,6 @@ rs.on('disconnected', () => {
   connected.set(false);
   userAddress.set('');
   localStorage.removeItem('inbox-rs:userAddress');
-  if (reloadTimeout) {
-    clearTimeout(reloadTimeout);
-    reloadTimeout = undefined;
-  }
   items.set({});
   appConfig.set({});
   userSettings.set({});
@@ -265,18 +248,66 @@ export async function updateUserSettings(patch: Partial<UserSettings>) {
   }
 }
 
-// Reload stores after sync completes — debounced in case multiple sync-done events fire closely
-function scheduleReload() {
-  if (reloadTimeout) clearTimeout(reloadTimeout);
-  reloadTimeout = setTimeout(async () => {
-    reloadTimeout = undefined;
-    await Promise.all([loadItems(), loadCollections(), loadGroups()]);
-  }, 100);
-}
-
+// Handle incoming changes per-item instead of reloading full collections.
+// Each change event updates a single entry in the relevant store.
 const inboxRef = getInbox();
 if (inboxRef) {
-  inboxRef.onChange(() => { syncHasChanges = true; });
+  inboxRef.onChange((event: any) => {
+    if (!event || event.origin === 'window') return;
+    const path: string = event.relativePath || '';
+    const value = event.newValue;
+
+    if (path.startsWith('items/')) {
+      const key = path.slice('items/'.length);
+      if (value && typeof value === 'object' && value.id) {
+        items.update(current => ({ ...current, [key]: value as InboxItem }));
+      } else if (!value) {
+        items.update(current => {
+          const next = { ...current };
+          delete next[key];
+          return next;
+        });
+      }
+    } else if (path.startsWith('collections/')) {
+      const key = path.slice('collections/'.length);
+      if (value && typeof value === 'object' && value.id) {
+        const col = value as Collection;
+        collections.update(current => ({
+          ...current,
+          [key]: { ...col, itemIds: Array.isArray(col.itemIds) ? col.itemIds : [] },
+        }));
+      } else if (!value) {
+        collections.update(current => {
+          const next = { ...current };
+          delete next[key];
+          return next;
+        });
+      }
+    } else if (path.startsWith('groups/')) {
+      const key = path.slice('groups/'.length);
+      if (value && typeof value === 'object' && value.id) {
+        const grp = value as CollectionGroup;
+        groups.update(current => ({
+          ...current,
+          [key]: { ...grp, collectionIds: Array.isArray(grp.collectionIds) ? grp.collectionIds : [] },
+        }));
+      } else if (!value) {
+        groups.update(current => {
+          const next = { ...current };
+          delete next[key];
+          return next;
+        });
+      }
+    } else if (path === 'config/app') {
+      if (value && typeof value === 'object') {
+        appConfig.set(value as AppConfig);
+      }
+    } else if (path === 'config/user') {
+      if (value && typeof value === 'object') {
+        userSettings.set(value as UserSettings);
+      }
+    }
+  });
 }
 
 document.addEventListener('visibilitychange', () => {

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -248,8 +248,17 @@ export async function updateUserSettings(patch: Partial<UserSettings>) {
   }
 }
 
-// Handle incoming changes per-item instead of reloading full collections.
-// Each change event updates a single entry in the relevant store.
+// Handle incoming remote changes per-item rather than reloading full
+// collections with getAll(). RS.js fires a `change` event for each item
+// during a sync cycle — we parse relativePath to route each change to the
+// correct store. This avoids redundant cache reads when many items arrive
+// at once (e.g. bulk image sync from another device).
+//
+// Local writes already update stores optimistically (see storeItem,
+// deleteItem, etc.), so we skip 'window' origin events to avoid duplicates.
+// getAll() is only used for the initial load on connect.
+//
+// See: https://remotestorage.io/rs.js/docs/api/baseclient/classes/BaseClient.html#change-events
 const inboxRef = getInbox();
 if (inboxRef) {
   inboxRef.onChange((event: any) => {
@@ -272,6 +281,7 @@ if (inboxRef) {
       const key = path.slice('collections/'.length);
       if (value && typeof value === 'object' && value.id) {
         const col = value as Collection;
+        // Normalize itemIds — may be missing if written by another client
         collections.update(current => ({
           ...current,
           [key]: { ...col, itemIds: Array.isArray(col.itemIds) ? col.itemIds : [] },
@@ -287,6 +297,7 @@ if (inboxRef) {
       const key = path.slice('groups/'.length);
       if (value && typeof value === 'object' && value.id) {
         const grp = value as CollectionGroup;
+        // Normalize collectionIds — may be missing if written by another client
         groups.update(current => ({
           ...current,
           [key]: { ...grp, collectionIds: Array.isArray(grp.collectionIds) ? grp.collectionIds : [] },
@@ -307,9 +318,14 @@ if (inboxRef) {
         userSettings.set(value as UserSettings);
       }
     }
+    // File paths (e.g. files/photo.jpg) are ignored here — binary data
+    // is fetched on demand via loadFileBlobUrl when components render.
   });
 }
 
+// Request a check for remote changes when the tab returns to foreground.
+// This is the correct use of startSync() — local writes push automatically,
+// but we need to explicitly ask for remote changes after being backgrounded.
 document.addEventListener('visibilitychange', () => {
   if (document.visibilityState === 'visible' && (rs as any).remote?.connected) {
     rs.startSync();


### PR DESCRIPTION
## Summary

- **Per-item change handling** — incoming sync changes now update individual store entries via `onChange` events instead of calling `getAll()` to reload entire collections. Each change event parses `relativePath` and updates the relevant store (items, collections, groups, config, userSettings).
- **Remove `getAll()` from sync path** — `getAll()` is now only used for initial load on `connected`. Ongoing sync never calls it.
- **Remove aggressive 3s `setSyncInterval`** — fall back to RS.js default (10s). The `visibilitychange` listener handles immediate sync on tab return.
- **Remove unnecessary `startSync()` after file uploads** — RS.js pushes local writes immediately, outside of the periodic sync cycle.

## Context

Evaluated remotestorage/remotestorage.js#1364 (background mode activation timing). Feedback from @raucao clarified:

1. `change` events are the data-change signal — handle each one individually instead of batch-reloading with `getAll()`
2. Local writes push immediately — `startSync()` after writes is unnecessary
3. `sync-done` is a lifecycle event, not a data-change signal
4. `getAll()` should only be used for initial loading, not ongoing sync

Doc PRs filed upstream: remotestorage/remotestorage.js#1368, remotestorage/remotestorage.js#1369, silverbucket/unhosted-web-skills#5

## Test plan

- [ ] Open web app, add items from another client, verify items appear incrementally as they sync
- [ ] Upload a file — verify it syncs without manual `startSync()` call
- [ ] Delete an item on another device — verify it disappears from the web app
- [ ] Config/settings changes from another device propagate correctly
- [ ] Verify `getAll()` is NOT called during ongoing sync (only on initial connect)