### PR TITLE
fix: duplicate inbox todos for collection items

### DIFF
--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -240,6 +240,10 @@
         if (editItem!.completedAt) item.completedAt = editItem!.completedAt;
       }
 
+      if (!isEdit && collectionId) {
+        item.collectionId = collectionId;
+      }
+
       await storeItem(item!, fileData);
       if (collectionId && !isEdit) {
         await moveItemToCollection(item!.id, collectionId);

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -54,6 +54,7 @@ import {
   collections, groups, groupCollections, moveCollectionToGroup,
   deleteGroup, ungroupedCollections, appConfig,
   storeCollection, reorderGroupCollections, items, todoItems, reorderTodos,
+  activeCollectionTodos, collectionItems,
 } from './stores';
 import type { Collection, CollectionGroup, InboxItem } from '@inbox-rs/rs-module';
 
@@ -346,6 +347,51 @@ describe('todoItems ordering', () => {
 
     expect(get(appConfig).todosOrder).toEqual(['t3', 't1', 't2']);
     expect(mockInbox.setConfig).toHaveBeenCalledWith({ todosOrder: ['t3', 't1', 't2'] });
+  });
+});
+
+describe('collection todo consistency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    items.set({});
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+    mockInbox.getAll.mockResolvedValue({});
+    mockInbox.getConfig.mockResolvedValue({});
+    mockInbox.getAllCollections.mockResolvedValue({});
+    mockInbox.getAllGroups.mockResolvedValue({});
+    mockInbox.getUserSettings.mockResolvedValue(undefined);
+  });
+
+  it('ignores item records whose storage key does not match the item id', async () => {
+    const canonical = makeTodo('t1', { collectionId: 'c1' });
+    const stale = makeTodo('t1');
+    mockInbox.getAll.mockResolvedValue({
+      stale_copy: stale,
+      t1: canonical,
+    });
+
+    await rsHandlers['connected']();
+
+    expect(get(items)).toEqual({ t1: canonical });
+    expect(get(todoItems)).toEqual([]);
+  });
+
+  it('does not surface stale collection refs when an item is not actually in that collection', () => {
+    const inboxTodo = makeTodo('t1');
+    const collection = {
+      ...makeCollection('c1'),
+      active: true,
+      itemIds: ['t1'],
+    };
+
+    items.set({ t1: inboxTodo });
+    collections.set({ c1: collection });
+
+    expect(get(collectionItems)['c1']).toEqual([]);
+    expect(get(activeCollectionTodos)).toEqual([]);
+    expect(get(todoItems).map(todo => todo.id)).toEqual(['t1']);
   });
 });
 

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -102,7 +102,11 @@ async function loadItems() {
     const valid: Record<string, InboxItem> = {};
     for (const [key, item] of Object.entries(all)) {
       if (item && typeof item === 'object' && 'id' in item && (item as InboxItem).id) {
-        valid[key] = item as InboxItem;
+        const inboxItem = item as InboxItem;
+        // Only trust canonically-addressed item records. This avoids rendering
+        // duplicate/stale documents that may still exist under malformed keys.
+        if (key !== inboxItem.id) continue;
+        valid[inboxItem.id] = inboxItem;
       }
     }
     items.set(valid);
@@ -356,7 +360,7 @@ export const activeCollectionTodos = derived(
       for (const id of col.itemIds) {
         if (count >= MAX_PER_COLLECTION) break;
         const item = itemMap.get(id);
-        if (!item || !(item.isTodo || item.type === 'todo') || item.completed) continue;
+        if (!item || item.collectionId !== col.id || !(item.isTodo || item.type === 'todo') || item.completed) continue;
         result.push({
           item,
           collectionId: col.id,
@@ -379,7 +383,7 @@ export const collectionItems = derived([items, collections], ([$items, $collecti
   for (const [cid, col] of Object.entries($collections)) {
     result[cid] = col.itemIds
       .map(id => itemMap.get(id))
-      .filter((i): i is InboxItem => i !== undefined);
+      .filter((i): i is InboxItem => i !== undefined && i.collectionId === cid);
   }
   return result;
 });
@@ -526,11 +530,13 @@ export async function moveItemToCollection(itemId: string, collectionId: string 
 
   if (!item) return;
 
+  const isSameCollection = oldCollectionId === collectionId;
+
   try {
     await inbox.store(cleanForStorage(item));
 
     // Update source collection's itemIds
-    if (oldCollectionId) {
+    if (oldCollectionId && !isSameCollection) {
       collections.update(current => {
         const col = current[oldCollectionId!];
         if (col) {


### PR DESCRIPTION
## Summary
Fix a bug where a todo created inside a collection could appear twice on the inbox page: once as a collection todo and once as a plain inbox todo.

## What Changed
- Seed `collectionId` on newly created collection todos before the first save.
- Make collection moves idempotent when the item is already in the target collection.
- Tighten store derivations so collection views and surfaced collection todos only include items whose `collectionId` matches the collection.
- Ignore malformed or stale item records whose storage key does not match the item id.
- Add regression tests for duplicate/stale item records and stale collection references.

## Root Cause
The create flow saved a new todo as an inbox item first and then moved it into the collection. If stale or duplicate records existed in remoteStorage, the inbox store could load both representations and render the same logical todo twice.

## Impact
Collection todos now stay scoped to their collection from the initial write, and stale storage data is less likely to leak into inbox rendering.

## Validation
- `npm exec --workspace=packages/web -- vitest run src/lib/stores.test.ts`
- `npm run build --workspace=packages/web`

## Notes
The web build still reports existing Svelte and accessibility warnings unrelated to this fix.
