### PR TITLE
Fix iOS Safari zoom-on-focus and bump mobile text size

### DIFF
--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -109,3 +109,18 @@ a {
 a:hover {
   color: var(--accent-hover);
 }
+
+@media (max-width: 600px) {
+  html {
+    font-size: 17px;
+  }
+
+  /* Prevent iOS Safari zoom-on-focus: any focused text input/textarea/select
+     with a computed font-size below 16px triggers an automatic viewport zoom
+     that then persists. */
+  input:not([type="checkbox"]):not([type="radio"]):not([type="file"]),
+  textarea,
+  select {
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
## Summary

- Tapping any text input on iOS Safari was zooming the viewport and leaving it zoomed, pushing modal Save buttons off-screen. Cause: all text inputs used sub-16px font sizes (Safari's zoom threshold).
- Adds a mobile media query in `packages/web/src/styles/global.css` forcing `input`/`textarea`/`select` to 16px (kills the zoom) and bumps the root font-size to 17px so the rest of the UI also reads a bit larger on phones.
- No viewport-meta / `user-scalable=no` hack — pinch-zoom remains available for accessibility.

## Test plan

- [ ] On a real iOS device, open the web app and tap inputs in: Add entry modal, Edit entity modal, Collection item picker search, UserMenu Connect form, UserMenu initials editor. Confirm no zoom and the Save/Connect button stays visible.
- [ ] Confirm desktop (>600px) layout is unchanged.