### PR TITLE
fix(web): improve sharesome sharing and add image lightbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inbox-rs",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inbox-rs",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "workspaces": [
         "packages/*"
       ]
@@ -3142,7 +3142,7 @@
     },
     "packages/extension": {
       "name": "@inbox-rs/extension",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "remotestoragejs": "^2.0.0-beta.8",
@@ -3316,7 +3316,7 @@
     },
     "packages/rs-module": {
       "name": "@inbox-rs/rs-module",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dependencies": {
         "remotestoragejs": "^2.0.0-beta.8",
         "rs-migrate": "^1.0.0"
@@ -3327,7 +3327,7 @@
     },
     "packages/thunderbird": {
       "name": "@inbox-rs/thunderbird",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dependencies": {
         "@inbox-rs/rs-module": "*"
       },
@@ -3497,7 +3497,7 @@
     },
     "packages/web": {
       "name": "@inbox-rs/web",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "@xenova/transformers": "^2.17.2",

--- a/packages/web/src/components/Lightbox.svelte
+++ b/packages/web/src/components/Lightbox.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import rs from '../lib/rs';
-  import { getSharedUrl, saveSharedUrl } from '../lib/shared-state';
+  import { getSharedUrl, saveSharedUrl, verifySharedUrl } from '../lib/shared-state';
 
   let { src, alt = '', onclose, filePath, mimeType, filename }: {
     src: string;
@@ -11,6 +11,20 @@
     filename?: string;
   } = $props();
 
+  /** Build a safe share filename from a short random id, preserving extension. */
+  function safeShareName(ext: string): string {
+    const uid = Math.random().toString(36).slice(2, 8);
+    return uid + (ext.startsWith('.') ? ext : '.' + ext);
+  }
+
+  function mimeToExt(mime: string): string {
+    const map: Record<string, string> = {
+      'image/jpeg': '.jpg', 'image/png': '.png', 'image/gif': '.gif',
+      'image/webp': '.webp', 'image/avif': '.avif', 'image/svg+xml': '.svg',
+    };
+    return map[mime] || '.jpg';
+  }
+
   function stableKey(): string {
     if (filePath) return filePath;
     try { const u = new URL(src); return u.origin + u.pathname; }
@@ -20,11 +34,19 @@
   const existingUrl = $derived(getSharedUrl(stableKey()));
   let shareState = $state<'idle' | 'sharing' | 'done' | 'error'>('idle');
   let publicUrl = $state('');
+  let verified = $state(false);
 
   $effect(() => {
-    if (existingUrl && shareState === 'idle') {
+    if (existingUrl && shareState === 'idle' && !verified) {
       publicUrl = existingUrl;
       shareState = 'done';
+      verified = true;
+      verifySharedUrl(stableKey()).then((live) => {
+        if (!live && shareState === 'done') {
+          publicUrl = '';
+          shareState = 'idle';
+        }
+      });
     }
   });
   let copied = $state(false);
@@ -135,21 +157,21 @@
       let shareName: string;
       let isRedirect = false;
 
+      const datePrefix = shares._formattedDate(new Date());
+
       try {
         const result = await fetchFileData();
         data = result.data;
         mime = result.mime;
-        const baseName = filename || filePath?.split('/').pop() || 'image.jpg';
-        shareName = shares._formattedDate(new Date()) + '-' + baseName;
+        const ext = (filePath?.split('/').pop()?.match(/\.[^.]+$/)?.[0]) || mimeToExt(mime);
+        shareName = datePrefix + '-' + safeShareName(ext);
       } catch {
         // Image data couldn't be fetched (likely CORS-blocked external URL).
         // Save an HTML redirect page instead so the user still gets a shareable link.
         if (!isExternalUrl(src)) throw new Error('Could not load file data');
         data = buildRedirectPage(src);
         mime = 'text/html';
-        const baseName = filename || filePath?.split('/').pop() || 'image';
-        const stem = baseName.replace(/\.[^.]+$/, '');
-        shareName = shares._formattedDate(new Date()) + '-' + stem + '.html';
+        shareName = datePrefix + '-' + safeShareName('.html');
         isRedirect = true;
       }
 

--- a/packages/web/src/components/Lightbox.svelte
+++ b/packages/web/src/components/Lightbox.svelte
@@ -46,7 +46,15 @@
         };
       }
     } catch {
-      // src fetch failed, try RS module
+      // src fetch failed, try other methods
+    }
+
+    // Try canvas-based extraction (works when server sends CORS headers for images)
+    try {
+      const canvasResult = await extractViaCanvas(src);
+      if (canvasResult) return canvasResult;
+    } catch {
+      // Canvas extraction failed
     }
 
     // Fallback: RS module direct file access
@@ -63,6 +71,50 @@
     throw new Error('Could not load file data');
   }
 
+  function extractViaCanvas(url: string): Promise<{ data: ArrayBuffer; mime: string } | null> {
+    return new Promise((resolve) => {
+      const img = new Image();
+      img.crossOrigin = 'anonymous';
+      img.onload = async () => {
+        try {
+          const canvas = document.createElement('canvas');
+          canvas.width = img.naturalWidth;
+          canvas.height = img.naturalHeight;
+          const ctx = canvas.getContext('2d')!;
+          ctx.drawImage(img, 0, 0);
+          const blob = await new Promise<Blob | null>((res) => canvas.toBlob(res, 'image/png'));
+          if (blob) {
+            resolve({ data: await blob.arrayBuffer(), mime: 'image/png' });
+          } else {
+            resolve(null);
+          }
+        } catch {
+          resolve(null);
+        }
+      };
+      img.onerror = () => resolve(null);
+      img.src = url;
+    });
+  }
+
+  function isExternalUrl(url: string): boolean {
+    try {
+      const u = new URL(url);
+      return u.protocol === 'http:' || u.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+
+  function buildRedirectPage(url: string): ArrayBuffer {
+    const html = `<!DOCTYPE html>
+<html><head>
+<meta http-equiv="refresh" content="0;url=${url.replace(/"/g, '&quot;')}">
+<style>body{margin:0;display:flex;align-items:center;justify-content:center;min-height:100vh;font-family:system-ui;background:#111;color:#ccc}a{color:#6cf}</style>
+</head><body><a href="${url.replace(/"/g, '&quot;')}">View image</a></body></html>`;
+    return new TextEncoder().encode(html).buffer;
+  }
+
   async function share() {
     if (shareState === 'sharing') return;
     shareState = 'sharing';
@@ -71,11 +123,6 @@
       const shares = (rs as any).shares;
       if (!shares) throw new Error('Shares module not available');
 
-      const { data, mime } = await fetchFileData();
-      const baseName = filename || filePath?.split('/').pop() || 'image.jpg';
-      const date = shares._formattedDate(new Date());
-      const name = date + '-' + baseName;
-
       // PUT directly to remote, bypassing the sync layer entirely.
       // Two reasons: (1) shares module has a sync thumbnail bug that throws
       // because it reads Image dimensions before onload, and (2) the sync
@@ -83,13 +130,36 @@
       const remote = (rs as any).remote;
       if (!remote?.connected) throw new Error('Not connected to remote storage');
 
-      const filePutPath = '/public/shares/' + name;
+      let data: ArrayBuffer;
+      let mime: string;
+      let shareName: string;
+      let isRedirect = false;
+
+      try {
+        const result = await fetchFileData();
+        data = result.data;
+        mime = result.mime;
+        const baseName = filename || filePath?.split('/').pop() || 'image.jpg';
+        shareName = shares._formattedDate(new Date()) + '-' + baseName;
+      } catch {
+        // Image data couldn't be fetched (likely CORS-blocked external URL).
+        // Save an HTML redirect page instead so the user still gets a shareable link.
+        if (!isExternalUrl(src)) throw new Error('Could not load file data');
+        data = buildRedirectPage(src);
+        mime = 'text/html';
+        const baseName = filename || filePath?.split('/').pop() || 'image';
+        const stem = baseName.replace(/\.[^.]+$/, '');
+        shareName = shares._formattedDate(new Date()) + '-' + stem + '.html';
+        isRedirect = true;
+      }
+
+      const filePutPath = '/public/shares/' + shareName;
       await remote.put(filePutPath, data, mime);
 
       // Generate and upload thumbnail directly if it's an image
-      if (shares._isImage(mime)) {
+      if (!isRedirect && shares._isImage(mime)) {
         try {
-          await generateThumbnail(data, mime, name, remote);
+          await generateThumbnail(data, mime, shareName, remote);
         } catch {
           // Thumbnail failure is non-critical
         }

--- a/packages/web/src/components/ShareButton.svelte
+++ b/packages/web/src/components/ShareButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import rs from '../lib/rs';
-  import { getSharedUrl, saveSharedUrl } from '../lib/shared-state';
+  import { getSharedUrl, saveSharedUrl, verifySharedUrl } from '../lib/shared-state';
 
   let { filePath, mimeType, filename }: {
     filePath: string;
@@ -12,13 +12,31 @@
   let state = $state<'idle' | 'sharing' | 'done' | 'error'>('idle');
   let publicUrl = $state('');
   let copied = $state(false);
+  let verified = $state(false);
 
   $effect(() => {
-    if (existingUrl && state === 'idle') {
+    if (existingUrl && state === 'idle' && !verified) {
       publicUrl = existingUrl;
       state = 'done';
+      verified = true;
+      verifySharedUrl(filePath).then((live) => {
+        if (!live && state === 'done') {
+          publicUrl = '';
+          state = 'idle';
+        }
+      });
     }
   });
+
+  function mimeToExt(mime: string): string {
+    const map: Record<string, string> = {
+      'image/jpeg': '.jpg', 'image/png': '.png', 'image/gif': '.gif',
+      'image/webp': '.webp', 'image/avif': '.avif', 'image/svg+xml': '.svg',
+      'audio/webm': '.webm', 'audio/ogg': '.ogg', 'audio/mpeg': '.mp3',
+      'application/pdf': '.pdf',
+    };
+    return map[mime] || '.bin';
+  }
 
   async function share() {
     if (state === 'sharing') return;
@@ -28,20 +46,31 @@
       const shares = (rs as any).shares;
       if (!shares) throw new Error('Shares module not available');
 
-      // Read file via RS inbox module (no token-in-URL)
+      // PUT directly to remote, bypassing shares.storeFile() which has a
+      // thumbnail bug (reads Image dimensions before onload → 0×0 canvas throw).
+      const remote = (rs as any).remote;
+      if (!remote?.connected) throw new Error('Not connected to remote storage');
+
+      // Read file via RS inbox module
       const inbox = (rs as any).inbox;
-      if (!inbox) throw new Error('Not connected');
+      if (!inbox) throw new Error('Inbox module not available');
       const file = await inbox.getFile(filePath);
       if (!file?.data) throw new Error('File not found');
 
       const resolvedMime = mimeType || file.mimeType || 'application/octet-stream';
-      const name = filename || filePath.split('/').pop() || 'file';
+      const ext = (filePath.split('/').pop()?.match(/\.[^.]+$/)?.[0]) || mimeToExt(resolvedMime);
+      const uid = Math.random().toString(36).slice(2, 8);
+      const shareName = shares._formattedDate(new Date()) + '-' + uid + ext;
 
-      const shareUrl = await shares.storeFile(resolvedMime, name, file.data);
+      const filePutPath = '/public/shares/' + shareName;
+      await remote.put(filePutPath, file.data, resolvedMime);
+
+      const shareUrl = remote.href + filePutPath;
       publicUrl = shareUrl;
       state = 'done';
       saveSharedUrl(filePath, shareUrl);
-    } catch {
+    } catch (e) {
+      console.error('Sharesome save failed:', e);
       state = 'error';
       setTimeout(() => { state = 'idle'; }, 2000);
     }

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -5,6 +5,7 @@
   import rs from '../lib/rs';
   import { transcribeAudio } from '../lib/transcribe';
   import ShareButton from './ShareButton.svelte';
+  import Lightbox from './Lightbox.svelte';
   import DeleteConfirm from './DeleteConfirm.svelte';
   import hljs from 'highlight.js/lib/core';
   import 'highlight.js/styles/github-dark.min.css';
@@ -50,6 +51,7 @@
 
   let showDelete = $state(false);
   let deleting = $state(false);
+  let showLightbox = $state(false);
   let showMoveMenu = $state(false);
   let moveButtonEl = $state<HTMLButtonElement | null>(null);
   let dropdownStyle = $state('');
@@ -82,6 +84,7 @@
     transcribing = false;
     transcriptionError = false;
     highlightedHtml = '';
+    showLightbox = false;
     untrack(() => { if (docBlobUrl) URL.revokeObjectURL(docBlobUrl); });
     docBlobUrl = null;
     docLoading = false;
@@ -367,8 +370,22 @@
     {/if}
 
     {#if imageSrc}
-      <img class="view-image" src={imageSrc} alt=""
-        onerror={(e) => (e.currentTarget as HTMLImageElement).style.display = 'none'} />
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div class="view-image-link" onclick={() => showLightbox = true}>
+        <img class="view-image" src={imageSrc} alt=""
+          onerror={(e) => (e.currentTarget as HTMLImageElement).style.display = 'none'} />
+      </div>
+    {/if}
+    {#if showLightbox && imageSrc}
+      <Lightbox
+        src={imageSrc}
+        alt={item.title}
+        onclose={() => showLightbox = false}
+        filePath={'filePath' in item ? (item as any).filePath : undefined}
+        mimeType={'mimeType' in item ? (item as any).mimeType : undefined}
+        filename={item.title || undefined}
+      />
     {/if}
 
     {#if item.type === 'audio'}
@@ -615,13 +632,17 @@
     margin-bottom: 0.5rem;
   }
 
+  .view-image-link {
+    cursor: zoom-in;
+    margin-bottom: 0.75rem;
+  }
+
   .view-image {
     width: 100%;
     max-height: 300px;
     object-fit: cover;
     border-radius: var(--radius-sm);
     border: 1px solid var(--border);
-    margin-bottom: 0.75rem;
   }
 
   .player {

--- a/packages/web/src/lib/shared-state.ts
+++ b/packages/web/src/lib/shared-state.ts
@@ -18,3 +18,32 @@ export function saveSharedUrl(key: string, url: string): void {
     // localStorage quota exceeded or disabled — non-fatal
   }
 }
+
+export function removeSharedUrl(key: string): void {
+  try {
+    const map = getSharedMap();
+    delete map[key];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // non-fatal
+  }
+}
+
+/**
+ * HEAD-check a stored sharesome URL. Returns true if still live, false if stale.
+ * On stale (404/network error), removes the entry from localStorage.
+ */
+export async function verifySharedUrl(key: string): Promise<boolean> {
+  const url = getSharedUrl(key);
+  if (!url) return false;
+  try {
+    const resp = await fetch(url, { method: 'HEAD', mode: 'cors' });
+    if (resp.ok) return true;
+    removeSharedUrl(key);
+    return false;
+  } catch {
+    // Network error or CORS block — assume stale
+    removeSharedUrl(key);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- Fix "Save to Sharesome" failing for external images (e.g. Reddit's `i.redd.it`) that don't send CORS headers — falls back to an HTML redirect page
- Use safe random filenames in share URLs instead of original filenames
- Verify cached share URLs on mount (HEAD check) and reset to the share button when the remote file is gone
- Bypass `shares.storeFile()` in ShareButton to avoid its 0×0 canvas thumbnail bug — PUT directly to remote storage instead
- Add lightbox zoom overlay when clicking images in the card view modal

## Test plan

- [ ] Open a bookmark with an `ogImage` from `i.redd.it`, click the image to open the Lightbox, and click "Save to Sharesome" — should succeed and produce a shareable link
- [ ] Open the shareable link — should redirect to the original image
- [ ] Save an image that's stored in remoteStorage (has a `filePath`) — should still save the actual image data as before
- [ ] Save a blob URL image — should still work via direct `fetch()`
- [ ] Share a file via ShareButton in the card view — should use a random filename, not the original
- [ ] Delete a shared file from remote storage, reload the page — the share button should reset to "idle" instead of showing the stale URL
- [ ] Click an image in ViewCardModal — should open the lightbox with zoom and share controls