### PR TITLE
fix(web): suppress transient migration alert on load

### DIFF
--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { get } from 'svelte/store';
 
 // Mock the RS module to prevent RemoteStorage initialization side effects
@@ -53,7 +53,7 @@ import {
   blobUrls, connected, loadFileBlobUrl,
   collections, groups, groupCollections, moveCollectionToGroup,
   deleteGroup, ungroupedCollections, appConfig,
-  storeCollection, reorderGroupCollections, items, todoItems, reorderTodos,
+  storeCollection, reorderGroupCollections, items, todoItems, reorderTodos, pendingMigrationCount,
 } from './stores';
 import type { Collection, CollectionGroup, InboxItem } from '@inbox-rs/rs-module';
 
@@ -65,7 +65,9 @@ const rsHandlers: Record<string, (...args: any[]) => any> = {};
 function captureRsHandlers() {
   if (Object.keys(rsHandlers).length > 0) return;
   for (const [event, handler] of mockRs.on.mock.calls as [string, (...args: any[]) => any][]) {
-    rsHandlers[event] = handler;
+    if (!(event in rsHandlers)) {
+      rsHandlers[event] = handler;
+    }
   }
 }
 captureRsHandlers();
@@ -214,6 +216,17 @@ function makeTodo(id: string, overrides: Partial<InboxItem> = {}): InboxItem {
     createdAt: '2026-01-01T00:00:00.000Z',
     ...overrides,
   } as InboxItem;
+}
+
+function makeLegacyVoiceMemo(id: string): InboxItem {
+  return {
+    id,
+    type: 'voice-memo',
+    title: `Voice memo ${id}`,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    filePath: `files/${id}.m4a`,
+    mimeType: 'audio/mp4',
+  } as unknown as InboxItem;
 }
 
 describe('groupCollections', () => {
@@ -406,6 +419,51 @@ describe('deleteGroup', () => {
 
     expect(result).toBe(true);
     expect(get(groups)['g1']).toBeUndefined();
+  });
+});
+
+describe('pendingMigrationCount visibility timing', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    connected.set(false);
+    items.set({});
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+    mockInbox.getAll.mockResolvedValue({});
+    mockInbox.getConfig.mockResolvedValue({});
+    mockInbox.getAllCollections.mockResolvedValue({});
+    mockInbox.getAllGroups.mockResolvedValue({});
+    mockInbox.getUserSettings.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps migration count hidden until initial sync settles', async () => {
+    mockInbox.getAll.mockResolvedValue({ legacy: makeLegacyVoiceMemo('legacy') });
+
+    await rsHandlers['connected']();
+
+    expect(get(pendingMigrationCount)).toBe(0);
+
+    rsHandlers['sync-done']();
+
+    expect(get(pendingMigrationCount)).toBe(1);
+  });
+
+  it('shows migration count after the fallback timeout when no sync signal arrives', async () => {
+    mockInbox.getAll.mockResolvedValue({ legacy: makeLegacyVoiceMemo('legacy') });
+
+    await rsHandlers['connected']();
+
+    expect(get(pendingMigrationCount)).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(2500);
+
+    expect(get(pendingMigrationCount)).toBe(1);
   });
 });
 

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -45,7 +45,6 @@ const rawPendingMigrationCount = derived(items, ($items) => {
   return count;
 });
 const migrationAlertReady = writable(false);
-let waitingForInitialMigrationSettle = false;
 let migrationAlertTimeout: ReturnType<typeof setTimeout> | null = null;
 
 function clearMigrationAlertTimeout() {
@@ -56,22 +55,19 @@ function clearMigrationAlertTimeout() {
 
 function resetMigrationAlertReadiness() {
   clearMigrationAlertTimeout();
-  waitingForInitialMigrationSettle = true;
   migrationAlertReady.set(false);
 }
 
 function scheduleMigrationAlertFallback() {
   clearMigrationAlertTimeout();
   migrationAlertTimeout = setTimeout(() => {
-    waitingForInitialMigrationSettle = false;
     migrationAlertTimeout = null;
     migrationAlertReady.set(true);
   }, INITIAL_MIGRATION_ALERT_TIMEOUT_MS);
 }
 
 function markMigrationAlertReady() {
-  if (!waitingForInitialMigrationSettle) return;
-  waitingForInitialMigrationSettle = false;
+  if (get(migrationAlertReady)) return;
   clearMigrationAlertTimeout();
   migrationAlertReady.set(true);
 }
@@ -256,7 +252,6 @@ rs.on('disconnected', () => {
     reloadTimeout = undefined;
   }
   clearMigrationAlertTimeout();
-  waitingForInitialMigrationSettle = false;
   migrationAlertReady.set(false);
   items.set({});
   appConfig.set({});

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -31,8 +31,10 @@ export const appConfig = writable<AppConfig>({});
 export const userSettings = writable<UserSettings>({});
 export const collections = writable<Record<string, Collection>>({});
 export const groups = writable<Record<string, CollectionGroup>>({});
-/** Derived from loaded items using rs-migrate's getPending */
-export const pendingMigrationCount = derived(items, ($items) => {
+const INITIAL_MIGRATION_ALERT_TIMEOUT_MS = 2500;
+
+/** Raw count from loaded items using rs-migrate's getPending */
+const rawPendingMigrationCount = derived(items, ($items) => {
   const docs = Object.values($items);
   if (docs.length === 0) return 0;
   const pending = migrator.getPending('items', docs);
@@ -42,6 +44,45 @@ export const pendingMigrationCount = derived(items, ($items) => {
   }
   return count;
 });
+const migrationAlertReady = writable(false);
+let waitingForInitialMigrationSettle = false;
+let migrationAlertTimeout: ReturnType<typeof setTimeout> | null = null;
+
+function clearMigrationAlertTimeout() {
+  if (!migrationAlertTimeout) return;
+  clearTimeout(migrationAlertTimeout);
+  migrationAlertTimeout = null;
+}
+
+function resetMigrationAlertReadiness() {
+  clearMigrationAlertTimeout();
+  waitingForInitialMigrationSettle = true;
+  migrationAlertReady.set(false);
+}
+
+function scheduleMigrationAlertFallback() {
+  clearMigrationAlertTimeout();
+  migrationAlertTimeout = setTimeout(() => {
+    waitingForInitialMigrationSettle = false;
+    migrationAlertTimeout = null;
+    migrationAlertReady.set(true);
+  }, INITIAL_MIGRATION_ALERT_TIMEOUT_MS);
+}
+
+function markMigrationAlertReady() {
+  if (!waitingForInitialMigrationSettle) return;
+  waitingForInitialMigrationSettle = false;
+  clearMigrationAlertTimeout();
+  migrationAlertReady.set(true);
+}
+
+/** Visible count for the app after the initial connect/sync state settles */
+export const pendingMigrationCount = derived(
+  [rawPendingMigrationCount, migrationAlertReady],
+  ([$rawPendingMigrationCount, $migrationAlertReady]) => (
+    $migrationAlertReady ? $rawPendingMigrationCount : 0
+  ),
+);
 
 // ---- Generic helpers ----
 
@@ -173,8 +214,14 @@ function hideSync() {
 }
 
 rs.on('wire-busy', showSync);
-rs.on('wire-done', hideSync);
-rs.on('sync-done', hideSync);
+rs.on('wire-done', () => {
+  hideSync();
+  markMigrationAlertReady();
+});
+rs.on('sync-done', () => {
+  hideSync();
+  markMigrationAlertReady();
+});
 
 // Debug: log sync activity
 rs.on('sync-req-done', (e: any) => {
@@ -190,12 +237,14 @@ let reloadTimeout: ReturnType<typeof setTimeout> | undefined;
 
 rs.on('connected', async () => {
   connected.set(true);
+  resetMigrationAlertReadiness();
   const addr =
     (rs as any).remote?.userAddress ||
     localStorage.getItem('inbox-rs:userAddress') ||
     '';
   userAddress.set(addr);
   await Promise.all([loadItems(), loadConfig(), loadUserSettings(), loadCollections(), loadGroups()]);
+  scheduleMigrationAlertFallback();
 });
 
 rs.on('disconnected', () => {
@@ -206,6 +255,9 @@ rs.on('disconnected', () => {
     clearTimeout(reloadTimeout);
     reloadTimeout = undefined;
   }
+  clearMigrationAlertTimeout();
+  waitingForInitialMigrationSettle = false;
+  migrationAlertReady.set(false);
   items.set({});
   appConfig.set({});
   userSettings.set({});


### PR DESCRIPTION
## Summary
- suppress the migration alert until the initial post-connect state has settled
- reveal the alert after the first sync/wire completion event or a short fallback timeout
- add regression coverage for both the sync-settled and fallback-timer paths

## Testing
- npm run build --workspace=packages/rs-module
- npm test --workspace=packages/web