### PR TITLE
fix(web): only count content-changing migrations

### DIFF
--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -253,6 +253,17 @@ function makeLegacyVoiceMemo(id: string): InboxItem {
   } as unknown as InboxItem;
 }
 
+function makeVersionedNote(id: string, version: number): InboxItem {
+  return {
+    id,
+    type: 'note',
+    title: `Note ${id}`,
+    body: `Body ${id}`,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    _migrateVersion: version,
+  } as InboxItem;
+}
+
 describe('groupCollections', () => {
   beforeEach(() => {
     collections.set({});
@@ -533,6 +544,15 @@ describe('pendingMigrationCount visibility timing', () => {
     await vi.advanceTimersByTimeAsync(2500);
 
     expect(get(pendingMigrationCount)).toBe(1);
+  });
+
+  it('does not count docs that only need a version bump with no content change', async () => {
+    mockInbox.getAll.mockResolvedValue({ note1: makeVersionedNote('note1', 1) });
+
+    await rsHandlers['connected']();
+    emitRsEvent('sync-done');
+
+    expect(get(pendingMigrationCount)).toBe(0);
   });
 });
 

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -33,14 +33,25 @@ export const collections = writable<Record<string, Collection>>({});
 export const groups = writable<Record<string, CollectionGroup>>({});
 const INITIAL_MIGRATION_ALERT_TIMEOUT_MS = 2500;
 
-/** Raw count from loaded items using rs-migrate's getPending */
+function stripMigrationVersion<T>(doc: T): T {
+  if (!doc || typeof doc !== 'object') return doc;
+  const { _migrateVersion: _, ...rest } = doc as Record<string, unknown>;
+  return rest as T;
+}
+
+function requiresContentMigration(doc: InboxItem): boolean {
+  const migrated = migrator.migrateDocument('items', doc);
+  if (migrated === doc) return false;
+  return JSON.stringify(stripMigrationVersion(migrated)) !== JSON.stringify(stripMigrationVersion(doc));
+}
+
+/** Count only docs whose non-version content would actually change under migration */
 const rawPendingMigrationCount = derived(items, ($items) => {
   const docs = Object.values($items);
   if (docs.length === 0) return 0;
-  const pending = migrator.getPending('items', docs);
   let count = 0;
-  for (const r of pending) {
-    if (r.pendingMigrations.length > 0) count++;
+  for (const doc of docs) {
+    if (requiresContentMigration(doc)) count++;
   }
   return count;
 });


### PR DESCRIPTION
## Summary
- count only migrations that change item content, not pure `_migrateVersion` bumps
- keep the migration alert hidden for docs that are only behind a no-op migration
- add a regression test for a note at version 1 that should not trigger the alert

## Validation
- npm run test --workspace=packages/web
- npm run build --workspace=packages/rs-module
- npx vite build