### PR TITLE
fix(web): render images on RS servers that echo charset=binary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inbox-rs",
-  "version": "1.8.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inbox-rs",
-      "version": "1.8.0",
+      "version": "2.0.0",
       "workspaces": [
         "packages/*"
       ]
@@ -3985,7 +3985,7 @@
     },
     "packages/extension": {
       "name": "@inbox-rs/extension",
-      "version": "1.8.0",
+      "version": "2.0.0",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "remotestoragejs": "^2.0.0-beta.8",
@@ -4176,7 +4176,7 @@
     },
     "packages/rs-module": {
       "name": "@inbox-rs/rs-module",
-      "version": "1.8.0",
+      "version": "2.0.0",
       "dependencies": {
         "remotestoragejs": "^2.0.0-beta.8",
         "rs-migrate": "^1.0.0"
@@ -4187,7 +4187,7 @@
     },
     "packages/thunderbird": {
       "name": "@inbox-rs/thunderbird",
-      "version": "1.8.0",
+      "version": "2.0.0",
       "dependencies": {
         "@inbox-rs/rs-module": "*"
       },
@@ -4374,7 +4374,7 @@
     },
     "packages/web": {
       "name": "@inbox-rs/web",
-      "version": "1.8.0",
+      "version": "2.0.0",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "@tiptap/core": "^3.22.1",

--- a/packages/rs-module/src/index.ts
+++ b/packages/rs-module/src/index.ts
@@ -118,9 +118,19 @@ const InboxModule = {
               const fullPath = '/inbox/' + item.filePath;
               try {
                 // Send the original ArrayBuffer, not the binary string —
-                // fetch encodes strings as UTF-8, corrupting bytes > 127
-                await remote.put(fullPath, fileData, item.mimeType);
-                console.log('[rs-module] direct PUT succeeded:', fullPath);
+                // fetch encodes strings as UTF-8, corrupting bytes > 127.
+                // `remote.put` resolves with `{ statusCode }` for non-2xx
+                // responses too (it only rejects on network errors), so
+                // inspect the status explicitly — otherwise a 401/412/500
+                // silently looks like success and the file is never uploaded.
+                const resp = await remote.put(fullPath, fileData, item.mimeType);
+                const status = resp?.statusCode;
+                const success = typeof status === 'number' && status >= 200 && status < 300;
+                if (success) {
+                  console.log('[rs-module] direct PUT succeeded:', fullPath, status);
+                } else {
+                  console.warn('[rs-module] direct PUT returned non-success status:', fullPath, status);
+                }
               } catch (e) {
                 console.warn('[rs-module] direct PUT failed:', fullPath, e);
               }

--- a/packages/web/src/components/BookmarkCard.svelte
+++ b/packages/web/src/components/BookmarkCard.svelte
@@ -25,9 +25,12 @@
     (item.filePath ? ($blobUrls[item.filePath] || null) : null) || item.ogImage || null
   );
 
-  // Fetch stored file via Authorization header (works on all RS servers)
+  // Fetch stored file via Authorization header (works on all RS servers).
+  // Pass mimeType so the blob is tagged with the clean type from item metadata
+  // rather than the server's Content-Type (which on 5apps carries the
+  // `; charset=binary` suffix that Chrome won't render as <img>).
   $effect(() => {
-    if ($connected && item.filePath) loadFileBlobUrl(item.filePath);
+    if ($connected && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
   });
 </script>
 

--- a/packages/web/src/components/ImageCard.svelte
+++ b/packages/web/src/components/ImageCard.svelte
@@ -8,9 +8,12 @@
 
   const imageSrc = $derived($blobUrls[item.filePath] || null);
 
-  // Fetch file via Authorization header when connected (works on all RS servers)
+  // Fetch file via Authorization header when connected (works on all RS servers).
+  // Pass mimeType so the blob is tagged as `image/jpeg` rather than whatever
+  // the server echoes back (e.g. `image/jpeg; charset=binary` on 5apps, which
+  // Chrome refuses to render as an <img> source).
   $effect(() => {
-    if ($connected && item.filePath) loadFileBlobUrl(item.filePath);
+    if ($connected && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
   });
 </script>
 

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -387,12 +387,16 @@
         : null
   );
 
-  // Fetch file-backed items via Authorization header (works on all RS servers)
+  // Fetch file-backed items via Authorization header (works on all RS servers).
+  // Forward mimeType so the blob is tagged with the clean type from item
+  // metadata rather than the server's Content-Type (5apps preserves the
+  // `; charset=binary` suffix that wireclient adds on upload, and Chrome won't
+  // render an <img>/<audio> whose Blob type carries that suffix).
   $effect(() => {
     if (!$connected) return;
-    if (item.type === 'image' && item.filePath) loadFileBlobUrl(item.filePath);
-    if (item.type === 'audio' && item.filePath) loadFileBlobUrl(item.filePath);
-    if (item.type === 'bookmark' && 'filePath' in item && item.filePath) loadFileBlobUrl(item.filePath);
+    if (item.type === 'image' && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
+    if (item.type === 'audio' && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
+    if (item.type === 'bookmark' && 'filePath' in item && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
   });
 
   /**

--- a/packages/web/src/lib/rs.test.ts
+++ b/packages/web/src/lib/rs.test.ts
@@ -3,25 +3,49 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
-// Mock URL.createObjectURL
+// Mock URL.createObjectURL. Capture the Blob passed in so tests can assert
+// on its type — fetchFileWithAuth is supposed to build a fresh Blob with a
+// clean MIME type (see the `; charset=binary` quirk in its JSDoc).
 let blobUrlCounter = 0;
+let lastCreatedBlob: Blob | null = null;
 vi.stubGlobal('URL', {
   ...globalThis.URL,
-  createObjectURL: (blob: Blob) => `blob:test/${blobUrlCounter++}`,
+  createObjectURL: (blob: Blob) => {
+    lastCreatedBlob = blob;
+    return `blob:test/${blobUrlCounter++}`;
+  },
   revokeObjectURL: vi.fn(),
 });
 
 import { fetchFileWithAuth } from './rs';
 
+/** Build a fake fetch Response matching what fetchFileWithAuth reads. */
+function makeResponse(opts: {
+  ok?: boolean;
+  status?: number;
+  contentType?: string | null;
+  body?: ArrayBuffer;
+} = {}) {
+  return {
+    ok: opts.ok ?? true,
+    status: opts.status ?? 200,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'content-type' ? (opts.contentType ?? null) : null,
+    },
+    arrayBuffer: () => Promise.resolve(opts.body ?? new ArrayBuffer(0)),
+  };
+}
+
 describe('fetchFileWithAuth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     blobUrlCounter = 0;
+    lastCreatedBlob = null;
   });
 
   it('fetches file with Authorization Bearer header', async () => {
-    const imageBlob = new Blob(['fake-image-data'], { type: 'image/jpeg' });
-    mockFetch.mockResolvedValue({ ok: true, blob: () => Promise.resolve(imageBlob) });
+    mockFetch.mockResolvedValue(makeResponse({ contentType: 'image/jpeg' }));
 
     const result = await fetchFileWithAuth(
       'https://storage.5apps.com/user',
@@ -37,7 +61,7 @@ describe('fetchFileWithAuth', () => {
   });
 
   it('returns null when server returns non-OK response (e.g. 401)', async () => {
-    mockFetch.mockResolvedValue({ ok: false, status: 401 });
+    mockFetch.mockResolvedValue(makeResponse({ ok: false, status: 401 }));
 
     const result = await fetchFileWithAuth(
       'https://storage.5apps.com/user',
@@ -49,7 +73,7 @@ describe('fetchFileWithAuth', () => {
   });
 
   it('returns null when server returns 404', async () => {
-    mockFetch.mockResolvedValue({ ok: false, status: 404 });
+    mockFetch.mockResolvedValue(makeResponse({ ok: false, status: 404 }));
 
     const result = await fetchFileWithAuth(
       'https://storage.5apps.com/user',
@@ -73,10 +97,7 @@ describe('fetchFileWithAuth', () => {
   });
 
   it('constructs correct URL with path under /inbox/', async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      blob: () => Promise.resolve(new Blob([])),
-    });
+    mockFetch.mockResolvedValue(makeResponse({ contentType: 'image/png' }));
 
     await fetchFileWithAuth(
       'https://storage.example.com/storage/nick',
@@ -91,14 +112,55 @@ describe('fetchFileWithAuth', () => {
   });
 
   it('returns unique blob URLs for different files', async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      blob: () => Promise.resolve(new Blob([])),
-    });
+    mockFetch.mockResolvedValue(makeResponse({ contentType: 'image/jpeg' }));
 
     const url1 = await fetchFileWithAuth('https://s.example.com/u', 'tok', 'files/a.jpg');
     const url2 = await fetchFileWithAuth('https://s.example.com/u', 'tok', 'files/b.jpg');
 
     expect(url1).not.toBe(url2);
+  });
+
+  it('prefers expectedMimeType over the server-echoed Content-Type', async () => {
+    // 5apps appends `; charset=binary` to binary Content-Types — the
+    // resulting Blob type would otherwise be `image/jpeg; charset=binary`,
+    // which Chrome refuses to render as an <img> source.
+    mockFetch.mockResolvedValue(makeResponse({
+      contentType: 'image/jpeg; charset=binary',
+    }));
+
+    await fetchFileWithAuth(
+      'https://storage.5apps.com/user',
+      'my-token',
+      'files/photo.jpg',
+      'image/jpeg',
+    );
+
+    expect(lastCreatedBlob?.type).toBe('image/jpeg');
+  });
+
+  it('strips charset parameter from server Content-Type when no expectedMimeType is given', async () => {
+    mockFetch.mockResolvedValue(makeResponse({
+      contentType: 'image/jpeg; charset=binary',
+    }));
+
+    await fetchFileWithAuth(
+      'https://storage.5apps.com/user',
+      'my-token',
+      'files/photo.jpg',
+    );
+
+    expect(lastCreatedBlob?.type).toBe('image/jpeg');
+  });
+
+  it('falls back to application/octet-stream when neither expectedMimeType nor Content-Type is available', async () => {
+    mockFetch.mockResolvedValue(makeResponse({ contentType: null }));
+
+    await fetchFileWithAuth(
+      'https://storage.5apps.com/user',
+      'my-token',
+      'files/photo.jpg',
+    );
+
+    expect(lastCreatedBlob?.type).toBe('application/octet-stream');
   });
 });

--- a/packages/web/src/lib/rs.ts
+++ b/packages/web/src/lib/rs.ts
@@ -33,11 +33,21 @@ rs.caching.enable('/inbox/');
 /**
  * Fetch a file from an RS server using Authorization header and return a blob URL.
  * Exported separately for testability; the default export uses the singleton RS instance.
+ *
+ * The blob's MIME type is taken from `expectedMimeType` when provided, otherwise
+ * from the server's Content-Type (with any `; charset=...` parameter stripped).
+ * This matters because remotestoragejs's wireclient auto-appends `; charset=binary`
+ * to binary uploads, and 5apps echoes that suffix back on GET. Some browsers —
+ * Chrome among them — then refuse to render an `<img>` whose Blob type carries
+ * the charset suffix, producing a valid-looking `blob:` URL that never paints.
+ * Callers who know the intended type (all current call sites read `item.mimeType`)
+ * should pass it so we never depend on the server's Content-Type staying clean.
  */
 export async function fetchFileWithAuth(
   href: string,
   token: string,
   path: string,
+  expectedMimeType?: string,
 ): Promise<string | null> {
   try {
     const url = `${href}/inbox/${path}`;
@@ -45,8 +55,13 @@ export async function fetchFileWithAuth(
       headers: { 'Authorization': `Bearer ${token}` }
     });
     if (!resp.ok) return null;
-    const blob = await resp.blob();
-    return URL.createObjectURL(blob);
+    const serverType = resp.headers.get('Content-Type') ?? '';
+    const cleanType =
+      expectedMimeType?.trim() ||
+      serverType.split(';')[0].trim() ||
+      'application/octet-stream';
+    const buffer = await resp.arrayBuffer();
+    return URL.createObjectURL(new Blob([buffer], { type: cleanType }));
   } catch {
     return null;
   }
@@ -57,10 +72,10 @@ export async function fetchFileWithAuth(
  * Works with all RS servers (5apps requires Bearer header, not query params).
  * Returns null if not connected or fetch fails.
  */
-export async function fetchFileBlobUrl(path: string): Promise<string | null> {
+export async function fetchFileBlobUrl(path: string, expectedMimeType?: string): Promise<string | null> {
   const remote = (rs as any).remote;
   if (!remote?.href || !remote?.token) return null;
-  return fetchFileWithAuth(remote.href, remote.token, path);
+  return fetchFileWithAuth(remote.href, remote.token, path, expectedMimeType);
 }
 
 export default rs;

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -120,7 +120,23 @@ describe('loadFileBlobUrl', () => {
       expect(get(blobUrls)['files/photo.jpg']).toBe('blob:test/123');
     });
 
-    expect(mockFetchFileBlobUrl).toHaveBeenCalledWith('files/photo.jpg');
+    expect(mockFetchFileBlobUrl).toHaveBeenCalledWith('files/photo.jpg', undefined);
+  });
+
+  it('forwards mimeType through to fetchFileBlobUrl', async () => {
+    // Callers (ImageCard, BookmarkCard, ViewCardModal) pass the item's
+    // mimeType so the resulting blob gets a clean type instead of whatever
+    // the server echoes back (5apps appends `; charset=binary`, which
+    // Chrome refuses to render).
+    mockFetchFileBlobUrl.mockResolvedValue('blob:test/typed');
+
+    loadFileBlobUrl('files/photo.jpg', 'image/jpeg');
+
+    await vi.waitFor(() => {
+      expect(get(blobUrls)['files/photo.jpg']).toBe('blob:test/typed');
+    });
+
+    expect(mockFetchFileBlobUrl).toHaveBeenCalledWith('files/photo.jpg', 'image/jpeg');
   });
 
   it('does not fetch if blob URL already exists', () => {

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -546,13 +546,18 @@ const pendingBlobLoads = new Set<string>();
 /**
  * Fetch a file from RS and create a blob URL, stored in blobUrls for reactive display.
  * No-ops if already loaded or in progress. Components should call this on mount.
+ *
+ * Callers should pass `mimeType` when they know it (e.g. from item metadata) so the
+ * resulting blob is created with a clean image/audio/... type regardless of what the
+ * server echoes back in its Content-Type header. See `fetchFileWithAuth` for the
+ * `charset=binary` quirk that makes this necessary.
  */
-export function loadFileBlobUrl(filePath: string): void {
+export function loadFileBlobUrl(filePath: string, mimeType?: string): void {
   if (!filePath) return;
   if (get(blobUrls)[filePath] || pendingBlobLoads.has(filePath)) return;
   if (!get(connected)) return;
   pendingBlobLoads.add(filePath);
-  fetchFileBlobUrl(filePath)
+  fetchFileBlobUrl(filePath, mimeType)
     .then((url) => {
       if (url) {
         const old = get(blobUrls)[filePath];


### PR DESCRIPTION
## Summary
- Stored images and bookmark thumbnails were showing broken on 5apps because remotestoragejs's wireclient appends `; charset=binary` to binary uploads and 5apps echoes that suffix back on GET. Chrome refuses to render an `<img>` whose Blob type carries the charset parameter.
- `fetchFileWithAuth` now constructs the Blob from an ArrayBuffer with a clean MIME type, preferring the caller-supplied `expectedMimeType` (read from `item.mimeType`) and otherwise stripping the `; charset=...` parameter from the server's Content-Type. `ImageCard`, `BookmarkCard`, and `ViewCardModal` forward `item.mimeType` through `loadFileBlobUrl`.
- Fixes a related silent failure in `rs-module`'s direct PUT path: `remote.put` resolves on 4xx/5xx too, so a 401/412/500 was being logged as a successful upload. We now inspect `statusCode` and warn on non-2xx.
- Syncs `package-lock.json` with the v2.0.0 bump in `package.json`.

## Test plan
- [ ] `npm test --workspace=packages/web` passes (new cases cover charset stripping, mimeType preference, and the octet-stream fallback)
- [ ] Manually verify on a 5apps account: existing image cards, image thumbnails on bookmark cards, and audio playback in the view modal all render
- [ ] Manually verify on a local Armadietto server: same flows still work (clean Content-Type path)
- [ ] Manually verify a failing PUT (e.g. revoke token) now logs a warning instead of "direct PUT succeeded"