### PR TITLE
fix(rs-module): stop corrupting binary uploads via the sync layer

### DIFF
--- a/packages/rs-module/src/index.ts
+++ b/packages/rs-module/src/index.ts
@@ -103,22 +103,30 @@ const InboxModule = {
             item._migrateVersion = migrator.getLatestVersion('items');
           }
           if (fileData && 'filePath' in item && item.filePath && 'mimeType' in item && item.mimeType) {
-            // Store file locally for immediate access
-            const bytes = new Uint8Array(fileData);
-            let binaryString = '';
-            for (let i = 0; i < bytes.length; i++) {
-              binaryString += String.fromCharCode(bytes[i]);
-            }
-            await privateClient.storeFile(item.mimeType, item.filePath, binaryString);
+            // Store file locally as the original ArrayBuffer (not a binary
+            // string). Two reasons this matters:
+            //
+            //   1. The local IndexedDB cache stays exact — `getFile` returns
+            //      the same bytes we wrote, with no string/byte round-trip.
+            //   2. `remotestoragejs`'s sync layer guards remote PUT with
+            //      `needsRemotePut(node) { return typeof node.local.body === 'string' }`
+            //      (see release/remotestorage.js). Passing an ArrayBuffer
+            //      makes that check return false, so the sync **does not**
+            //      try to push the body. That's what we want, because when
+            //      the sync did push, it sent the binary-string body via
+            //      `fetch(..., { body: string })` which UTF-8 encodes bytes
+            //      > 127 and corrupts JPEGs (the file came back as zeros on
+            //      5apps). Our direct `remote.put` below handles the upload
+            //      with the original bytes; we just need sync to keep its
+            //      hands off.
+            await privateClient.storeFile(item.mimeType, item.filePath, fileData);
 
-            // Also PUT directly to remote — remotestoragejs sync has a bug
-            // where it silently fails to push binary file bodies to the server.
+            // Push the file to the server ourselves, since the sync layer
+            // intentionally skips ArrayBuffer bodies (see above).
             const remote = privateClient.storage.remote;
             if (remote?.connected) {
               const fullPath = '/inbox/' + item.filePath;
               try {
-                // Send the original ArrayBuffer, not the binary string —
-                // fetch encodes strings as UTF-8, corrupting bytes > 127.
                 // `remote.put` resolves with `{ statusCode }` for non-2xx
                 // responses too (it only rejects on network errors), so
                 // inspect the status explicitly — otherwise a 401/412/500


### PR DESCRIPTION
## Summary
PR #89 cleaned up the Blob MIME type so Chrome would render the image, but the actual bytes on the server were still being corrupted, so freshly added images came back as zero bytes after refresh (the `0x00000000` payload reported on iOS Safari with `content-length: 78064`, `content-type: image/jpeg`).

The store path called `storeFile(mime, path, binaryString)` — converting the ArrayBuffer to a binary string before handing it to remotestoragejs. That string is what `needsRemotePut` keys on (`typeof node.local.body === 'string'`, see `release/remotestorage.js`) to queue an upload, so the sync layer happily PUT the string body via `fetch`. `fetch` then UTF-8-encodes every byte > 127, mangling JPEG bytes on the server. The direct `remote.put` we added uploaded correct bytes, but the deferred sync ran later and overwrote them — a classic race that consistently lost.

Pass the original ArrayBuffer to `storeFile` instead. Two effects:

1. The local IndexedDB cache stores the bytes exactly, so `getFile` stops needing the binary-string round-trip for newly written files.
2. `needsRemotePut` returns false for non-string bodies, so the sync layer no longer tries to push a corrupt copy. Our direct `remote.put` (unchanged) remains the sole writer to the server, sending the original ArrayBuffer.

`getFile` keeps its existing string→ArrayBuffer fallback for backward compatibility with files written by the previous code (so old corrupted-looking entries in the cache still decode to bytes — they'll just be wrong bytes; re-uploading the affected items is the user-side fix for those).

## Test plan
- [ ] `npm run build` passes (rs-module + web)
- [ ] `npm test --workspace=packages/web` passes (187 tests)
- [ ] Add a new image on iOS Safari, refresh — image renders
- [ ] Add a new image on Chrome desktop, refresh — image renders
- [ ] Inspect the underlying file via `curl -H "Authorization: Bearer $TOKEN" $HREF/inbox/files/<id>.jpg | xxd | head` and confirm it starts with `ff d8 ff e0` (JPEG magic), not zeros
- [ ] Confirm audio cards and bookmark thumbnails still render (same code path)
- [ ] Re-upload a previously broken image and verify it now displays correctly after refresh