### PR TITLE
feat(rs-module): recover legacy binary-string-encoded files on read

### DIFF
--- a/packages/rs-module/src/index.ts
+++ b/packages/rs-module/src/index.ts
@@ -46,6 +46,57 @@ function schemaAlias(type: string): string {
   }
 }
 
+/**
+ * Recover the original bytes of a file that was uploaded by the legacy store
+ * path (web app v1.8 and earlier).
+ *
+ * The legacy path converted the ArrayBuffer to a binary string with
+ * `String.fromCharCode(byte)` per byte, then handed that string to
+ * `storeFile`. The remotestoragejs sync layer then PUT the string body via
+ * `fetch`, which UTF-8 encodes any code point > 0x7F — so a JPEG byte 0xFF
+ * landed on the server as the two-byte sequence 0xC3 0xBF, doubling the size
+ * of every high byte and making the file no longer a valid JPEG.
+ *
+ * The recovery is the exact inverse: UTF-8 decode the bytes back to the
+ * binary string, then read each char's low byte to get the original byte.
+ *
+ * Detection is by structural test, not by per-format magic bytes:
+ *
+ *   - Real binary files (JPEG/PNG/etc.) almost always contain byte sequences
+ *     that aren't valid UTF-8 (e.g. a lone 0xFF, which UTF-8 reserves as a
+ *     never-valid lead byte). `TextDecoder({fatal:true})` throws on those,
+ *     so we fall through and return the bytes unchanged.
+ *   - Bytes that *do* decode as valid UTF-8 *and* whose every code point is
+ *     < 256 can only have come from the binary-string-then-UTF-8 path —
+ *     normal text with extended characters would produce code points >= 256
+ *     for any non-Latin1 char, and arbitrary binary almost never round-trips
+ *     through UTF-8 cleanly. So in practice this only fires on the legacy
+ *     corruption pattern.
+ *
+ * Files that are already in the correct format pass through untouched
+ * because of the throw on the first invalid byte. Returns the original
+ * `ArrayBuffer` reference (not a copy) in that case.
+ */
+export function recoverLegacyBinaryStringEncoding(buffer: ArrayBuffer): ArrayBuffer {
+  if (buffer.byteLength === 0) return buffer;
+  try {
+    const decoded = new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+    for (let i = 0; i < decoded.length; i++) {
+      // If any code point is >= 256, this isn't a binary-string round-trip
+      // (the legacy encoder only ever produced chars 0–255). Bail out.
+      if (decoded.charCodeAt(i) >= 256) return buffer;
+    }
+    const recovered = new Uint8Array(decoded.length);
+    for (let i = 0; i < decoded.length; i++) {
+      recovered[i] = decoded.charCodeAt(i);
+    }
+    return recovered.buffer;
+  } catch {
+    // Invalid UTF-8 → already raw binary. Return as-is.
+    return buffer;
+  }
+}
+
 const InboxModule = {
   name: 'inbox',
   builder: (privateClient: any) => {
@@ -157,15 +208,25 @@ const InboxModule = {
         async getFile(path: string): Promise<{ data: ArrayBuffer; mimeType: string } | undefined> {
           const file = await privateClient.getFile(path);
           if (!file?.data) return undefined;
-          // remotestoragejs may return a binary string; convert to ArrayBuffer
+          const mimeType = file.mimeType || file.contentType;
+          // remotestoragejs may return a binary string when the file was
+          // written by the legacy store path (`storeFile(mime, path,
+          // binaryString)`). One charCodeAt per char gives back the original
+          // bytes — that's the inverse of what the legacy encoder did.
           if (typeof file.data === 'string') {
             const bytes = new Uint8Array(file.data.length);
             for (let i = 0; i < file.data.length; i++) {
               bytes[i] = file.data.charCodeAt(i);
             }
-            return { data: bytes.buffer, mimeType: file.mimeType || file.contentType };
+            return { data: bytes.buffer, mimeType };
           }
-          return { data: file.data, mimeType: file.mimeType || file.contentType };
+          // ArrayBuffer path covers two cases:
+          //   - new uploads (correct raw bytes — passes through untouched)
+          //   - legacy uploads synced down from the server, where the sync
+          //     layer's UTF-8 corruption baked into the bytes on disk
+          // `recoverLegacyBinaryStringEncoding` handles the second case and
+          // is a no-op for the first.
+          return { data: recoverLegacyBinaryStringEncoding(file.data), mimeType };
         },
 
         async getConfig(): Promise<AppConfig> {

--- a/packages/web/src/lib/rs.test.ts
+++ b/packages/web/src/lib/rs.test.ts
@@ -18,6 +18,20 @@ vi.stubGlobal('URL', {
 });
 
 import { fetchFileWithAuth } from './rs';
+import { recoverLegacyBinaryStringEncoding } from '@inbox-rs/rs-module';
+
+/**
+ * Encode bytes the way the v1.8-and-earlier upload path did:
+ * `String.fromCharCode(byte)` per byte to make a binary string, then UTF-8
+ * encode that string (which is what `fetch(..., { body: string })` does).
+ */
+function legacyEncodeBytes(bytes: Uint8Array): Uint8Array {
+  let binaryString = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binaryString += String.fromCharCode(bytes[i]);
+  }
+  return new TextEncoder().encode(binaryString);
+}
 
 /** Build a fake fetch Response matching what fetchFileWithAuth reads. */
 function makeResponse(opts: {
@@ -162,5 +176,116 @@ describe('fetchFileWithAuth', () => {
     );
 
     expect(lastCreatedBlob?.type).toBe('application/octet-stream');
+  });
+
+  it('recovers original bytes for files uploaded by the legacy binary-string path', async () => {
+    // A JPEG header byte sequence — the legacy path UTF-8-encoded each byte,
+    // turning 0xFF into 0xC3 0xBF and 0xD8 into 0xC3 0x98.
+    const original = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46]);
+    const corrupted = legacyEncodeBytes(original);
+    expect(corrupted.length).toBeGreaterThan(original.length); // sanity: encoding inflated the size
+
+    mockFetch.mockResolvedValue(makeResponse({
+      contentType: 'image/jpeg',
+      body: corrupted.buffer.slice(corrupted.byteOffset, corrupted.byteOffset + corrupted.byteLength),
+    }));
+
+    await fetchFileWithAuth(
+      'https://storage.5apps.com/user',
+      'my-token',
+      'files/old-photo.jpg',
+      'image/jpeg',
+    );
+
+    // The Blob should contain the recovered original bytes, not the corrupted ones.
+    expect(lastCreatedBlob).toBeTruthy();
+    const recoveredBuf = await lastCreatedBlob!.arrayBuffer();
+    expect(new Uint8Array(recoveredBuf)).toEqual(original);
+  });
+
+  it('passes through correctly-uploaded binary files unchanged', async () => {
+    const raw = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]); // raw JPEG header
+
+    mockFetch.mockResolvedValue(makeResponse({
+      contentType: 'image/jpeg',
+      body: raw.buffer.slice(0),
+    }));
+
+    await fetchFileWithAuth(
+      'https://storage.5apps.com/user',
+      'my-token',
+      'files/new-photo.jpg',
+      'image/jpeg',
+    );
+
+    expect(lastCreatedBlob).toBeTruthy();
+    const result = new Uint8Array(await lastCreatedBlob!.arrayBuffer());
+    expect(result).toEqual(raw);
+  });
+});
+
+describe('recoverLegacyBinaryStringEncoding', () => {
+  it('returns raw binary unchanged when the bytes are not valid UTF-8', () => {
+    // Lone 0xFF is never a valid UTF-8 lead byte → TextDecoder({fatal}) throws.
+    const raw = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46]);
+    const result = recoverLegacyBinaryStringEncoding(raw.buffer.slice(0));
+    expect(new Uint8Array(result)).toEqual(raw);
+  });
+
+  it('recovers the original JPEG bytes from the legacy UTF-8-encoded form', () => {
+    const original = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46]);
+    const corrupted = legacyEncodeBytes(original);
+    const result = recoverLegacyBinaryStringEncoding(
+      corrupted.buffer.slice(corrupted.byteOffset, corrupted.byteOffset + corrupted.byteLength)
+    );
+    expect(new Uint8Array(result)).toEqual(original);
+  });
+
+  it('recovers the original PNG bytes from the legacy UTF-8-encoded form', () => {
+    // PNG signature: 89 50 4E 47 0D 0A 1A 0A
+    const original = new Uint8Array([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D]);
+    const corrupted = legacyEncodeBytes(original);
+    const result = recoverLegacyBinaryStringEncoding(
+      corrupted.buffer.slice(corrupted.byteOffset, corrupted.byteOffset + corrupted.byteLength)
+    );
+    expect(new Uint8Array(result)).toEqual(original);
+  });
+
+  it('handles an empty buffer', () => {
+    const result = recoverLegacyBinaryStringEncoding(new ArrayBuffer(0));
+    expect(result.byteLength).toBe(0);
+  });
+
+  it('passes through pure ASCII unchanged (decoding gives same bytes back)', () => {
+    // Pure ASCII is valid UTF-8 with all chars < 256 — the helper would
+    // "recover" it, but the recovered bytes are identical to the input
+    // because each ASCII byte UTF-8-encodes to itself.
+    const ascii = new TextEncoder().encode('Hello, world!');
+    const result = recoverLegacyBinaryStringEncoding(
+      ascii.buffer.slice(ascii.byteOffset, ascii.byteOffset + ascii.byteLength)
+    );
+    expect(new Uint8Array(result)).toEqual(ascii);
+  });
+
+  it('does not touch real UTF-8 text containing non-Latin1 chars', () => {
+    // "héllo 世界" — 世 has code point 0x4E16 which is >= 256, so the
+    // recovery bails out and returns the bytes untouched.
+    const text = new TextEncoder().encode('héllo 世界');
+    const result = recoverLegacyBinaryStringEncoding(
+      text.buffer.slice(text.byteOffset, text.byteOffset + text.byteLength)
+    );
+    expect(new Uint8Array(result)).toEqual(text);
+  });
+
+  it('round-trips: encode → recover gives back the original for a 256-byte sweep', () => {
+    // Cover every possible byte value 0–255. This is the strongest possible
+    // test of the inverse property because it exercises the full domain.
+    const original = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) original[i] = i;
+    const corrupted = legacyEncodeBytes(original);
+    const result = recoverLegacyBinaryStringEncoding(
+      corrupted.buffer.slice(corrupted.byteOffset, corrupted.byteOffset + corrupted.byteLength)
+    );
+    expect(new Uint8Array(result)).toEqual(original);
   });
 });

--- a/packages/web/src/lib/rs.ts
+++ b/packages/web/src/lib/rs.ts
@@ -1,5 +1,5 @@
 import RemoteStorage from 'remotestoragejs';
-import InboxModule from '@inbox-rs/rs-module';
+import InboxModule, { recoverLegacyBinaryStringEncoding } from '@inbox-rs/rs-module';
 import SharesModule from 'remotestorage-module-shares';
 
 // remotestoragejs' `Authorize._rs_init` unconditionally clears
@@ -42,6 +42,12 @@ rs.caching.enable('/inbox/');
  * the charset suffix, producing a valid-looking `blob:` URL that never paints.
  * Callers who know the intended type (all current call sites read `item.mimeType`)
  * should pass it so we never depend on the server's Content-Type staying clean.
+ *
+ * The bytes are passed through `recoverLegacyBinaryStringEncoding` to repair
+ * files that were uploaded by the v1.8-and-earlier store path, which sent
+ * the file body to the server as a UTF-8-encoded binary string. New uploads
+ * are raw binary and pass through unchanged. See the helper's JSDoc for the
+ * detection invariant.
  */
 export async function fetchFileWithAuth(
   href: string,
@@ -60,7 +66,7 @@ export async function fetchFileWithAuth(
       expectedMimeType?.trim() ||
       serverType.split(';')[0].trim() ||
       'application/octet-stream';
-    const buffer = await resp.arrayBuffer();
+    const buffer = recoverLegacyBinaryStringEncoding(await resp.arrayBuffer());
     return URL.createObjectURL(new Blob([buffer], { type: cleanType }));
   } catch {
     return null;


### PR DESCRIPTION
## Summary
PR #90 stopped *new* uploads from being corrupted, but old images uploaded by the v1.8-and-earlier web store path are still on the server in the broken format and don't render. This PR adds read-side recovery so those files become viewable again.

### How the corruption happened
1. Old store path called `String.fromCharCode(byte)` per ArrayBuffer byte to make a binary string
2. Handed the string to `storeFile` → sync layer queued a string body for PUT
3. `fetch(..., { body: string })` UTF-8-encoded it before sending
4. Result on server: every byte > 0x7F doubled into a 2-byte 0xC2/0xC3-prefixed sequence — a JPEG `0xFF` landed as `0xC3 0xBF`, a `0x89` as `0xC2 0x89`. The file is no longer a valid JPEG/PNG.

### The recovery
New `recoverLegacyBinaryStringEncoding(buffer)` in rs-module applies the exact inverse: UTF-8 decode → `charCodeAt` per char to recover the original bytes.

Detection is structural (no per-format magic byte tables):
- Real binary files almost always contain bytes that aren't valid UTF-8 (e.g. a lone `0xFF`, which UTF-8 reserves as a never-valid lead byte) → `TextDecoder({fatal:true})` throws → return buffer unchanged
- Bytes that decode cleanly *and* whose every code point is < 256 can only have come from the legacy round-trip (the legacy encoder only ever produced chars 0–255) → recover
- Real UTF-8 text containing any char ≥ 0x100 (e.g. `世`) bails out via the < 256 check, untouched

Applied at both read points:
- **`getFile` in rs-module** — Lightbox, downloads, ShareButton (local cache reads)
- **`fetchFileWithAuth` in web** — image-grid blob URLs (direct HTTP fetch)

New uploads pass through both paths untouched (raw binary fails the UTF-8 validity check).

### Tests (9 new, 196 total passing)
- JPEG round-trip via `fetchFileWithAuth`: corrupted bytes in → original bytes in the Blob
- Pass-through of correctly-uploaded raw JPEG bytes via `fetchFileWithAuth`
- Helper-level: JPEG and PNG signature recovery
- Helper-level: exhaustive 256-byte sweep proves the inverse property over the full byte domain
- Helper-level: pure ASCII round-trips to itself
- Helper-level: real UTF-8 text with non-Latin1 chars (`héllo 世界`) is left alone
- Helper-level: empty buffer returns empty
- Helper-level: lone `0xFF` (raw JPEG header) returns unchanged

## Test plan
- [ ] Open an image item created with v1.8.0 — image renders both in the grid and in the Lightbox
- [ ] Open an image item created with v2.0.2 (post-PR-#90) — still renders correctly
- [ ] Download a v1.8.0 image via ShareButton — file on disk opens as a valid JPEG
- [ ] `npm run build` passes
- [ ] `npm test --workspace=packages/web` passes (196 tests)