### PR TITLE
Remove synthetic collection group bucket  

### DIFF
--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -5,7 +5,7 @@
   import type { InboxItemType, InboxItem } from '@inbox-rs/rs-module';
   import {
     storeItem, moveItemToCollection,
-    sortedGroups, groupCollections, ungroupedCollections,
+    sortedGroups, groupCollections,
     hasUncategorizedItems, UNCATEGORIZED_COLLECTION_ID,
     collections, appConfig, updateConfig,
   } from '../lib/stores';
@@ -28,8 +28,8 @@
 
   /**
    * Find the first real collection in display order — iterate groups in
-   * sorted order, take the first collection from each, then fall back to
-   * ungrouped. Used as the last-resort default for the todo picker when
+   * sorted order, then take the first collection from each. Used as the
+   * last-resort default for the todo picker when
    * there's no explicit `collectionId` prop and no valid
    * `lastSelectedCollectionId`. Returns `undefined` when the user has no
    * collections at all (the picker then shows its empty-state hint).
@@ -39,7 +39,7 @@
       const cols = get(groupCollections)[group.id] ?? [];
       if (cols.length > 0) return cols[0].id;
     }
-    return get(ungroupedCollections)[0]?.id;
+    return undefined;
   }
 
   /**
@@ -102,8 +102,6 @@
       const found = cols.find(c => c.id === selectedCollectionId);
       if (found) return found.name;
     }
-    const orphan = $ungroupedCollections.find(c => c.id === selectedCollectionId);
-    if (orphan) return orphan.name;
     return noCollectionLabel;
   });
 
@@ -120,7 +118,7 @@
     || selectedCollectionId === UNCATEGORIZED_COLLECTION_ID
   );
 
-  // Whether the user has any real collections at all (grouped or ungrouped).
+  // Whether the user has any real grouped collections at all.
   // Used to decide when to surface an empty-state hint in the todo picker —
   // todos require a real collection, so an empty picker is a dead end without
   // guidance.
@@ -128,7 +126,7 @@
     for (const group of $sortedGroups) {
       if (($groupCollections[group.id] ?? []).length > 0) return true;
     }
-    return $ungroupedCollections.length > 0;
+    return false;
   });
 
   $effect(() => {
@@ -917,29 +915,6 @@
                     {/each}
                   {/if}
                 {/each}
-                {#if $ungroupedCollections.length > 0}
-                  <!--
-                    Ungrouped collections — either legacy collections from
-                    before groups became mandatory, or collections whose
-                    parent group was deleted. Surface them so todos and refs
-                    can still be filed there instead of falling off the list.
-                  -->
-                  <div class="dest-group-label">
-                    <span class="dest-dot" style="background: #9ca3af" aria-hidden="true"></span>
-                    Ungrouped
-                  </div>
-                  {#each $ungroupedCollections as col (col.id)}
-                    <button
-                      type="button"
-                      class="dest-item nested"
-                      class:selected={selectedCollectionId === col.id}
-                      onclick={() => selectCollection(col.id)}
-                    >
-                      <span class="dest-dot" style="background: {col.color || 'var(--accent)'}" aria-hidden="true"></span>
-                      {col.name}
-                    </button>
-                  {/each}
-                {/if}
                 {#if isTodoType && !hasAnyCollection}
                   <!--
                     Todos require a real collection, so when the user has no

--- a/packages/web/src/components/CollectionFormModal.svelte
+++ b/packages/web/src/components/CollectionFormModal.svelte
@@ -50,11 +50,12 @@
   let selectedGroupId = $state<string>(pickInitialGroupId());
 
   const hasGroups = $derived($sortedGroups.length > 0);
-  const canSubmit = $derived(!!selectedGroupId);
+  const canSubmit = $derived(!!selectedGroupId && !!$groups[selectedGroupId]);
 
   async function handleSubmit() {
     if (!name.trim()) return;
     if (!selectedGroupId) return;
+    if (!$groups[selectedGroupId]) return;
     // Persist the picked group as the next default before the parent's
     // onsave runs. Best-effort: if the write fails the user's creation
     // still succeeds, they just lose the preference memory this once.

--- a/packages/web/src/components/CollectionView.svelte
+++ b/packages/web/src/components/CollectionView.svelte
@@ -81,7 +81,7 @@
     showMoveMenu = !showMoveMenu;
   }
 
-  async function handleMoveToGroup(groupId: string | undefined) {
+  async function handleMoveToGroup(groupId: string) {
     showMoveMenu = false;
     await moveCollectionToGroup(collection.id, groupId);
   }
@@ -189,21 +189,6 @@
             <div class="move-menu-backdrop" onclick={(e) => { e.stopPropagation(); showMoveMenu = false; }}></div>
             <div class="move-menu" style="top: {menuPos.top}px; right: {menuPos.right}px;" onclick={(e) => e.stopPropagation()}>
               <div class="move-menu-label">Move to group</div>
-              <button
-                class="move-menu-item"
-                class:current={!collection.groupId}
-                onclick={() => handleMoveToGroup(undefined)}
-                disabled={!collection.groupId}
-              >
-                <span class="move-dot" style="background: var(--text-muted)"></span>
-                Collections
-                {#if !collection.groupId}
-                  <svg class="check-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                    <polyline points="20 6 9 17 4 12"></polyline>
-                  </svg>
-                {/if}
-              </button>
-              <div class="move-menu-divider"></div>
               {#each availableGroups as g (g.id)}
                 <button
                   class="move-menu-item"
@@ -581,12 +566,6 @@
     margin-left: auto;
     color: var(--accent);
     flex-shrink: 0;
-  }
-
-  .move-menu-divider {
-    height: 1px;
-    background: var(--border);
-    margin: 0.25rem 0;
   }
 
   /* ================================================================

--- a/packages/web/src/components/CollectionsPage.svelte
+++ b/packages/web/src/components/CollectionsPage.svelte
@@ -5,7 +5,7 @@
     createCollection, storeCollection, deleteCollection, moveCollectionToGroup,
     visibleGroupedCollections, sortedGroups, storeGroup, deleteGroup,
     appConfig, updateConfig, reorderGroupCollections, setExpandedCollections,
-    UNCATEGORIZED_FILTER_ID, reorderUngroupedCollections,
+    UNCATEGORIZED_FILTER_ID, collectionItems, groups,
   } from '../lib/stores';
   import CollectionView from './CollectionView.svelte';
   import GroupSection from './GroupSection.svelte';
@@ -95,13 +95,7 @@
       const updated = e.detail.items;
       dndByGroup = { ...dndByGroup, [groupId]: updated };
       try {
-        // The Uncategorized section is virtual — there's no backing group
-        // record to update, so route reorders to collectionsOrder instead.
-        if (groupId === UNCATEGORIZED_FILTER_ID) {
-          await reorderUngroupedCollections(updated.map(c => c.id));
-        } else {
-          await reorderGroupCollections(groupId, updated.map(c => c.id));
-        }
+        await reorderGroupCollections(groupId, updated.map(c => c.id));
       } catch (error) {
         console.error('Failed to reorder collections', error);
         dndByGroup = { ...dndByGroup, [groupId]: previous };
@@ -111,9 +105,8 @@
 
   function openAddCollection(groupId: string | undefined) {
     // `undefined` means the user triggered creation outside any group (e.g.
-    // from the page-level FAB). The modal's form captures name/colour only;
-    // ungrouped collections land in the "Collections" bucket and can be
-    // dragged into a group afterwards.
+    // from the page-level FAB). The modal itself chooses an explicit real
+    // group before saving; collections should never be created ungrouped.
     collectionFormGroupId = groupId;
     creatingCollection = true;
   }
@@ -135,14 +128,11 @@
     if (!editingCollection) return;
     const previousGroupId = editingCollection.groupId;
     try {
-      await storeCollection(col);
-      // Fire the move on any group change — including group → undefined, so
-      // a user who picks "No group" in the edit modal actually ends up in
-      // Uncategorized. The previous `col.groupId && …` guard swallowed the
-      // group-to-none transition silently.
+      if (!col.groupId || !$groups[col.groupId]) throw new Error('Collection must have a real group');
       if (col.groupId !== previousGroupId) {
         await moveCollectionToGroup(col.id, col.groupId);
       }
+      await storeCollection(col);
       editingCollection = null;
     } catch (error) {
       console.error('Failed to update collection', error);
@@ -187,18 +177,11 @@
   });
 
   // Collections must be empty before they can be deleted — same rule as
-  // groups. The store-level `deleteCollection` enforces this too, but
-  // hiding the Delete button when it would be refused keeps the UI honest
-  // about why nothing happens. Empty here means "no items reference this
-  // collection's id"; the collection's own `itemIds` array isn't trusted
-  // because it can drift out of sync with the items themselves.
+  // groups. Match the store-level guard by checking live item placement, not
+  // `Collection.itemIds`, which can drift after interrupted writes.
   const editingCollectionIsEmpty = $derived.by(() => {
     if (!editingCollection) return false;
-    for (const section of sections) {
-      const found = section.collections.find(c => c.id === editingCollection!.id);
-      if (found) return found.itemIds.length === 0;
-    }
-    return true;
+    return ($collectionItems[editingCollection.id] ?? []).length === 0;
   });
 </script>
 
@@ -225,12 +208,11 @@
 
   {#each sections as section (section.group.id)}
     {@const isUncat = section.group.id === UNCATEGORIZED_FILTER_ID}
-    {@const addGroupId = isUncat ? undefined : section.group.id}
     {@const realCount = dndByGroup[section.group.id]?.length ?? 0}
     <GroupSection
       group={section.group}
       onedit={isUncat ? undefined : () => editingGroup = section.group}
-      onaddcollection={() => openAddCollection(addGroupId)}
+      onaddcollection={isUncat ? undefined : () => openAddCollection(section.group.id)}
     >
       {#if section.virtualCollection}
         <!-- Virtual Uncategorized bucket — rendered outside the dndzone since
@@ -277,7 +259,7 @@
       {:else if !section.virtualCollection}
         <p class="group-empty">
           No collections in this group yet.
-          <button class="link" onclick={() => openAddCollection(addGroupId)}>Add one</button>.
+          <button class="link" onclick={() => openAddCollection(section.group.id)}>Add one</button>.
         </p>
       {/if}
     </GroupSection>

--- a/packages/web/src/components/GroupFilterBar.svelte
+++ b/packages/web/src/components/GroupFilterBar.svelte
@@ -4,7 +4,6 @@
     sortedGroups, activeGroupIds, toggleGroupFilter, reorderGroups,
     uncategorizedFilterActive, toggleUncategorizedFilter,
     UNCATEGORIZED_FILTER_ID, appConfig, hasUncategorizedItems,
-    ungroupedCollections,
   } from '../lib/stores';
 
   let { onaddgroup, dimmed = false }: {
@@ -30,11 +29,8 @@
   const uncatActive = $derived($uncategorizedFilterActive);
   const groupsOrder = $derived($appConfig.groupsOrder ?? []);
   // Uncategorized is a dynamic pill — it appears only when the system has
-  // something to show there. "Something" means either straggler items (todos
-  // without a collection, or orphaned refs) OR ungrouped collections the user
-  // might want to filter. Without either, the pill would be a confusing
-  // no-op, so we hide it entirely.
-  const showUncat = $derived($hasUncategorizedItems || $ungroupedCollections.length > 0);
+  // straggler items to show there. It is not a group or a collection home.
+  const showUncat = $derived($hasUncategorizedItems);
 
   let isTouchDevice = $state(false);
   $effect(() => {
@@ -66,8 +62,7 @@
     const sentinelIdx = groupsOrder.indexOf(UNCATEGORIZED_FILTER_ID);
     // If the user has never reordered the pills, default to Uncategorized
     // at the end — same visual cadence as a newly-created group. Skip the
-    // sentinel when it has nothing to show (no stragglers, no ungrouped
-    // collections).
+    // sentinel when it has nothing to show.
     if (sentinelIdx < 0) return showUncat ? [...realPills, uncatPill] : realPills;
 
     // Walk the persisted order and rebuild the list so the sentinel's slot

--- a/packages/web/src/components/GroupSection.svelte
+++ b/packages/web/src/components/GroupSection.svelte
@@ -2,13 +2,13 @@
   import type { Snippet } from 'svelte';
   import type { CollectionGroup } from '@inbox-rs/rs-module';
 
-  let { group, onedit, onaddcollection, children }: {
+  let { group, onedit, onaddcollection = undefined, children }: {
     group: CollectionGroup;
     /** Omit for virtual groups (e.g. the Uncategorized section) that have no
         editable backing record — the edit button is hidden when this is
         undefined. */
     onedit?: () => void;
-    onaddcollection: () => void;
+    onaddcollection?: () => void;
     children: Snippet;
   } = $props();
 </script>
@@ -26,12 +26,14 @@
         and keeps the muted flat style intentionally — we want the "+" to
         read louder than "edit".
       -->
-      <button class="btn-add-collection" onclick={onaddcollection} title="Add collection" aria-label="Add collection to {group.name}">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <line x1="12" y1="5" x2="12" y2="19"></line>
-          <line x1="5" y1="12" x2="19" y2="12"></line>
-        </svg>
-      </button>
+      {#if onaddcollection}
+        <button class="btn-add-collection" onclick={onaddcollection} title="Add collection" aria-label="Add collection to {group.name}">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <line x1="12" y1="5" x2="12" y2="19"></line>
+            <line x1="5" y1="12" x2="19" y2="12"></line>
+          </svg>
+        </button>
+      {/if}
       {#if onedit}
         <button class="btn-action" onclick={onedit} title="Edit group" aria-label="Edit {group.name}">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { untrack, onDestroy } from 'svelte';
   import type { InboxItem } from '@inbox-rs/rs-module';
-  import { deleteItem, storeItem, blobUrls, connected, sortedGroups, groupCollections, ungroupedCollections, moveItemToCollection, loadFileBlobUrl, hasUncategorizedItems } from '../lib/stores';
+  import { deleteItem, storeItem, blobUrls, connected, sortedGroups, groupCollections, moveItemToCollection, loadFileBlobUrl, hasUncategorizedItems } from '../lib/stores';
   import rs from '../lib/rs';
   import { transcribeAudio } from '../lib/transcribe';
   import ShareButton from './ShareButton.svelte';
@@ -622,18 +622,7 @@
             </button>
           {/each}
         {/each}
-        <!-- Ungrouped collections — legacy collections from before groups
-             became mandatory, or collections whose parent group was deleted.
-             Without this, a user whose only collection is ungrouped would see
-             an empty picker and the "create a collection first" message
-             despite already having one. -->
-        {#each $ungroupedCollections as col (col.id)}
-          <button class="move-option" onclick={() => convertToTodoInCollection(col.id)} disabled={convertingTodo}>
-            <span class="move-dot" style="background: {col.color || '#6366f1'}"></span>
-            <span class="move-group-prefix" style="color: #9ca3af">Ungrouped</span> : {col.name}
-          </button>
-        {/each}
-        {#if $sortedGroups.every((g) => ($groupCollections[g.id] ?? []).length === 0) && $ungroupedCollections.length === 0}
+        {#if $sortedGroups.every((g) => ($groupCollections[g.id] ?? []).length === 0)}
           <!-- No real collections yet — guide the user instead of silently
                allowing an Uncategorized-only choice, which would undo the
                point of this forced-picker flow. -->
@@ -668,18 +657,7 @@
             {/if}
           {/each}
         {/each}
-        <!-- Ungrouped collections — must be offered as move targets too,
-             otherwise an item can't be moved into a collection whose group
-             was deleted (or a legacy ungrouped collection). -->
-        {#each $ungroupedCollections as col (col.id)}
-          {#if col.id !== item.collectionId}
-            <button class="move-option" onclick={() => { moveItemToCollection(item.id, col.id).catch(e => console.error('Move failed:', e)); closeMoveMenu(); onclose(); }}>
-              <span class="move-dot" style="background: {col.color || '#6366f1'}"></span>
-              <span class="move-group-prefix" style="color: #9ca3af">Ungrouped</span> : {col.name}
-            </button>
-          {/if}
-        {/each}
-        {#if $sortedGroups.length === 0 && $ungroupedCollections.length === 0}
+        {#if $sortedGroups.every((g) => ($groupCollections[g.id] ?? []).every((col) => col.id === item.collectionId))}
           <div class="move-empty">No collections</div>
         {/if}
       </div>

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -51,7 +51,7 @@ vi.mock('./clean-for-storage', () => ({
 import {
   blobUrls, connected, loadFileBlobUrl,
   collections, groups, groupCollections, moveCollectionToGroup,
-  deleteGroup, ungroupedCollections, appConfig,
+  deleteGroup, appConfig,
   storeCollection, createCollection, deleteCollection,
   reorderGroupCollections, items, todoItems, reorderUncategorizedTodos, pendingMigrationCount,
   moveItemToCollection,
@@ -60,7 +60,7 @@ import {
   toggleGroupFilter, setActiveGroupFilters, storeGroup,
   allTodos, openTodos, visibleTodos, reorderTodosGlobal,
   uncategorizedFilterActive, toggleUncategorizedFilter,
-  UNCATEGORIZED_FILTER_ID, reorderUngroupedCollections,
+  UNCATEGORIZED_FILTER_ID,
   UNCATEGORIZED_COLLECTION_ID, uncategorizedVirtualCollection,
 } from './stores';
 import type { Collection, CollectionGroup, InboxItem } from '@inbox-rs/rs-module';
@@ -647,61 +647,6 @@ describe('pendingMigrationCount visibility timing', () => {
   });
 });
 
-describe('ungroupedCollections', () => {
-  beforeEach(() => {
-    collections.set({});
-    groups.set({});
-    appConfig.set({});
-  });
-
-  it('returns collections with no groupId', () => {
-    const col1 = makeCollection('c1');
-    const col2 = makeCollection('c2', 'g1');
-    const group = makeGroup('g1', ['c2']);
-
-    collections.set({ c1: col1, c2: col2 });
-    groups.set({ g1: group });
-
-    const result = get(ungroupedCollections);
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('c1');
-  });
-
-  it('returns collections whose groupId points to a non-existent group', () => {
-    const col = makeCollection('c1', 'g_deleted');
-
-    collections.set({ c1: col });
-    groups.set({});
-
-    const result = get(ungroupedCollections);
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('c1');
-  });
-
-  it('does not include collections with a valid groupId', () => {
-    const col = makeCollection('c1', 'g1');
-    const group = makeGroup('g1', ['c1']);
-
-    collections.set({ c1: col });
-    groups.set({ g1: group });
-
-    const result = get(ungroupedCollections);
-    expect(result).toHaveLength(0);
-  });
-
-  it('returns empty array when all collections belong to groups', () => {
-    const col1 = makeCollection('c1', 'g1');
-    const col2 = makeCollection('c2', 'g1');
-    const group = makeGroup('g1', ['c1', 'c2']);
-
-    collections.set({ c1: col1, c2: col2 });
-    groups.set({ g1: group });
-
-    const result = get(ungroupedCollections);
-    expect(result).toHaveLength(0);
-  });
-});
-
 describe('no group recreation after deletion', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -883,60 +828,10 @@ describe('deleteGroup with non-existent group', () => {
   });
 });
 
-describe('ungroupedCollections reacts to group deletion', () => {
-  beforeEach(() => {
-    collections.set({});
-    groups.set({});
-    appConfig.set({});
-  });
-
-  it('collections appear in ungroupedCollections after their group is deleted', async () => {
-    const col = makeCollection('c1', 'g1');
-    const group = makeGroup('g1', ['c1']);
-
-    collections.set({ c1: col });
-    groups.set({ g1: group });
-
-    // Before deletion: c1 is grouped
-    expect(get(ungroupedCollections)).toHaveLength(0);
-    expect(get(groupCollections)['g1']).toHaveLength(1);
-
-    // Simulate the group being removed from the store (as if deleted on another device)
-    groups.update(current => {
-      const next = { ...current };
-      delete next['g1'];
-      return next;
-    });
-
-    // c1 still has groupId 'g1' but that group no longer exists
-    expect(get(ungroupedCollections)).toHaveLength(1);
-    expect(get(ungroupedCollections)[0].id).toBe('c1');
-  });
-
-  it('collections move from ungrouped to grouped when assigned a valid group', async () => {
-    const col = makeCollection('c1');
-    const group = makeGroup('g1', []);
-
-    collections.set({ c1: col });
-    groups.set({ g1: group });
-
-    // Before: ungrouped
-    expect(get(ungroupedCollections)).toHaveLength(1);
-
-    await moveCollectionToGroup('c1', 'g1');
-
-    // After: grouped
-    expect(get(ungroupedCollections)).toHaveLength(0);
-    expect(get(groupCollections)['g1']).toHaveLength(1);
-  });
-});
-
 // ---- Direct storeCollection writes leave groupId untouched ----
-// `storeCollection` is the low-level write. It does NOT enforce the
-// every-collection-has-a-group invariant — that's `createCollection`'s job
-// (see "createCollection: group assignment" below). These tests pin down the
-// raw store behaviour so other code paths (imports, tests, future callers)
-// know what the primitive does.
+// `storeCollection` is the low-level write. It does not repair legacy
+// collection group membership; the app-load repair path handles that once
+// collections and groups have both been loaded.
 
 describe('storeCollection: raw groupId handling', () => {
   beforeEach(() => {
@@ -946,18 +841,17 @@ describe('storeCollection: raw groupId handling', () => {
     appConfig.set({});
   });
 
-  it('preserves an undefined groupId — collection lands in ungroupedCollections', async () => {
+  it('preserves an undefined groupId without creating a group', async () => {
     const col = makeCollection('c1');
 
     await storeCollection(col);
 
     expect(get(collections)['c1']).toBeDefined();
     expect(get(collections)['c1'].groupId).toBeUndefined();
-    expect(get(ungroupedCollections)).toHaveLength(1);
     expect(mockInbox.storeGroup).not.toHaveBeenCalled();
   });
 
-  it('preserves an empty-string groupId — also treated as ungrouped (falsy)', async () => {
+  it('preserves an empty-string groupId without creating a group', async () => {
     const col: Collection = {
       id: 'c1',
       name: 'Test',
@@ -969,12 +863,10 @@ describe('storeCollection: raw groupId handling', () => {
     await storeCollection(col);
 
     expect(get(collections)['c1'].groupId).toBe('');
-    // ungroupedCollections checks !c.groupId — empty string is falsy, so it's included
-    expect(get(ungroupedCollections)).toHaveLength(1);
   });
 });
 
-describe('ungrouped route: reorder is a no-op', () => {
+describe('reorderGroupCollections with invalid group ids', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     collections.set({});
@@ -983,8 +875,6 @@ describe('ungrouped route: reorder is a no-op', () => {
   });
 
   it('reorderGroupCollections with empty groupId does not modify any group', async () => {
-    // CollectionsPage calls reorderGroupCollections(groupId, newIds) on DnD finalize.
-    // When groupId is "", no group matches, so it should be a no-op.
     const group = makeGroup('g1', ['c1', 'c2']);
     const col1 = makeCollection('c1', 'g1');
     const col2 = makeCollection('c2', 'g1');
@@ -1016,6 +906,7 @@ describe('ungrouped route: reorder is a no-op', () => {
 
 describe('activeGroupIds', () => {
   beforeEach(() => {
+    items.set({});
     collections.set({});
     groups.set({});
     appConfig.set({});
@@ -1062,6 +953,7 @@ describe('activeGroupIds', () => {
 
 describe('visibleGroupedCollections', () => {
   beforeEach(() => {
+    items.set({});
     collections.set({});
     groups.set({});
     appConfig.set({});
@@ -1073,8 +965,7 @@ describe('visibleGroupedCollections', () => {
     collections.set({ c1, c2 });
     groups.set({ g1: makeGroup('g1', ['c2', 'c1']) });
     // Disable the Uncategorized pill so this test stays focused on real-group
-    // behaviour — with the pill on (the default) an empty Uncategorized
-    // section is appended.
+    // behaviour.
     appConfig.set({ uncategorizedFilterActive: false });
 
     const sections = get(visibleGroupedCollections);
@@ -1101,23 +992,14 @@ describe('visibleGroupedCollections', () => {
     expect(get(visibleGroupedCollections)).toHaveLength(0);
   });
 
-  it('appends an Uncategorized section when ungrouped collections exist and the pill is on', () => {
-    const grouped = makeCollection('c1', 'g1');
-    const ungrouped = makeCollection('c2');
-    collections.set({ c1: grouped, c2: ungrouped });
-    groups.set({ g1: makeGroup('g1', ['c1']) });
-
-    const sections = get(visibleGroupedCollections);
-    expect(sections.map(s => s.group.id)).toEqual(['g1', UNCATEGORIZED_FILTER_ID]);
-    expect(sections[1].collections.map(c => c.id)).toEqual(['c2']);
-  });
-
   it('places the Uncategorized section at the sentinel slot in groupsOrder', () => {
     const grouped = makeCollection('c1', 'g1');
-    const ungrouped = makeCollection('c2');
     const grouped2 = makeCollection('c3', 'g2');
-    collections.set({ c1: grouped, c2: ungrouped, c3: grouped2 });
+    collections.set({ c1: grouped, c3: grouped2 });
     groups.set({ g1: makeGroup('g1', ['c1']), g2: makeGroup('g2', ['c3']) });
+    items.set({
+      t1: { id: 't1', type: 'todo', title: 'straggler', createdAt: '2026-01-01T00:00:00Z', completed: false, isTodo: true } as any,
+    });
     // Sentinel placed between g1 and g2
     appConfig.set({ groupsOrder: ['g1', UNCATEGORIZED_FILTER_ID, 'g2'] });
 
@@ -1125,15 +1007,17 @@ describe('visibleGroupedCollections', () => {
     expect(sections.map(s => s.group.id)).toEqual(['g1', UNCATEGORIZED_FILTER_ID, 'g2']);
   });
 
-  it('hides the Uncategorized section when the pill is off even if ungrouped collections exist', () => {
-    collections.set({ c1: makeCollection('c1') });
+  it('hides the Uncategorized section when the pill is off even if straggler items exist', () => {
+    items.set({
+      t1: { id: 't1', type: 'todo', title: 'straggler', createdAt: '2026-01-01T00:00:00Z', completed: false, isTodo: true } as any,
+    });
     groups.set({});
     appConfig.set({ uncategorizedFilterActive: false });
 
     expect(get(visibleGroupedCollections)).toHaveLength(0);
   });
 
-  it('hides the Uncategorized section when there are neither ungrouped collections nor straggler items', () => {
+  it('hides the Uncategorized section when there are no straggler items', () => {
     // Uncategorized is a dynamic surface — unlike a real group, it has no
     // persistent identity for the user to "keep". When everything is filed
     // (all collections have a group, all items have a collection, no
@@ -1146,7 +1030,7 @@ describe('visibleGroupedCollections', () => {
     expect(sections.map(s => s.group.id)).toEqual(['g1']);
   });
 
-  it('renders the Uncategorized section when there are straggler items but no ungrouped collections', () => {
+  it('renders the Uncategorized section when there are straggler items', () => {
     // A loose todo or an orphaned ref is enough to bring the Uncategorized
     // surface back — the straggler needs somewhere to live.
     const grouped = makeCollection('c1', 'g1');
@@ -1160,24 +1044,10 @@ describe('visibleGroupedCollections', () => {
     expect(sections[1].collections).toEqual([]);
   });
 
-  it('treats a collection whose group was deleted as ungrouped in the section', () => {
-    const orphan = makeCollection('c1', 'g_deleted');
-    collections.set({ c1: orphan });
-    groups.set({});
-
-    const sections = get(visibleGroupedCollections);
-    expect(sections.map(s => s.group.id)).toEqual([UNCATEGORIZED_FILTER_ID]);
-    expect(sections[0].collections.map(c => c.id)).toEqual(['c1']);
-  });
-
   it('attaches the virtual Uncategorized collection to the Uncategorized section when stragglers exist', () => {
-    // The virtual collection rides alongside real ungrouped collections on
-    // `section.virtualCollection` so CollectionsPage can render it outside the
-    // reorderable drag zone. Its id is the UNCATEGORIZED_COLLECTION_ID sentinel
-    // — distinct from the group sentinel so items-without-collectionId don't
-    // collide with collections-without-groupId in downstream lookups. The
-    // section only appears when there's something to show, so we seed a
-    // straggler todo to trigger it.
+    // The virtual collection is exposed on `section.virtualCollection` so
+    // CollectionsPage can render straggler items without creating a real
+    // collection or group destination.
     collections.set({});
     groups.set({});
     const straggler: InboxItem = { id: 't1', type: 'todo', title: 'straggler', createdAt: '2026-01-01T00:00:00Z', completed: false, isTodo: true } as any;
@@ -1285,34 +1155,6 @@ describe('collectionItems virtual Uncategorized entry', () => {
     const byCollection = get(collectionItems);
     const uncatItems = byCollection[UNCATEGORIZED_COLLECTION_ID] ?? [];
     expect(uncatItems.map(i => i.id)).toEqual(['t1', 'r1']);
-  });
-});
-
-describe('reorderUngroupedCollections', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    appConfig.set({});
-  });
-
-  it('persists the new order to collectionsOrder', async () => {
-    await reorderUngroupedCollections(['c2', 'c1', 'c3']);
-
-    expect(get(appConfig).collectionsOrder).toEqual(['c2', 'c1', 'c3']);
-    expect(mockInbox.setConfig).toHaveBeenCalledWith(
-      expect.objectContaining({ collectionsOrder: ['c2', 'c1', 'c3'] })
-    );
-  });
-
-  it('reorders ungroupedCollections to match the persisted order', async () => {
-    const c1 = makeCollection('c1');
-    const c2 = makeCollection('c2');
-    const c3 = makeCollection('c3');
-    collections.set({ c1, c2, c3 });
-    groups.set({});
-
-    await reorderUngroupedCollections(['c3', 'c1', 'c2']);
-
-    expect(get(ungroupedCollections).map(c => c.id)).toEqual(['c3', 'c1', 'c2']);
   });
 });
 
@@ -1452,6 +1294,21 @@ describe('moveCollectionToGroup', () => {
 
     expect(get(collections)['c1'].groupId).toBe('g2');
   });
+
+  it('throws without mutating when target group is missing', async () => {
+    const col = makeCollection('c1', 'g1');
+    const group = makeGroup('g1', ['c1']);
+
+    collections.set({ c1: col });
+    groups.set({ g1: group });
+
+    await expect(moveCollectionToGroup('c1', 'missing')).rejects.toThrow('Cannot move collection to missing group');
+
+    expect(get(collections)['c1'].groupId).toBe('g1');
+    expect(get(groups)['g1'].collectionIds).toEqual(['c1']);
+    expect(mockInbox.storeCollection).not.toHaveBeenCalled();
+    expect(mockInbox.storeGroup).not.toHaveBeenCalled();
+  });
 });
 
 describe('allTodos / openTodos', () => {
@@ -1519,7 +1376,8 @@ describe('visibleTodos', () => {
       u1: makeTodo('u1'),
       c1: makeTodo('c1', { collectionId: 'col1' }),
     });
-    collections.set({ col1: makeCollection('col1') });
+    collections.set({ col1: makeCollection('col1', 'g1') });
+    groups.set({ g1: makeGroup('g1', ['col1']) });
     appConfig.set({ uncategorizedFilterActive: false });
 
     expect(get(visibleTodos).map(t => t.id)).toEqual(['c1']);
@@ -1548,7 +1406,7 @@ describe('visibleTodos', () => {
     expect(get(visibleTodos).map(t => t.id)).toEqual(['c1']);
   });
 
-  it('keeps todos from ungrouped collections visible even when no groups are active', () => {
+  it('hides todos from collections without a real group', () => {
     items.set({
       orphan: makeTodo('orphan', { collectionId: 'col-orphan' }),
     });
@@ -1561,7 +1419,7 @@ describe('visibleTodos', () => {
       uncategorizedFilterActive: false,
     });
 
-    expect(get(visibleTodos).map(t => t.id)).toEqual(['orphan']);
+    expect(get(visibleTodos)).toEqual([]);
   });
 
   it('treats a todo whose collection was deleted as uncategorized for filtering purposes', () => {
@@ -1719,13 +1577,6 @@ describe('deleteCollection: empty-only guard', () => {
   });
 });
 
-// ---- createCollection: every-collection-has-a-group invariant ----
-//
-// New collections must end up inside a group. If the form picked one we use
-// it; otherwise we route into an `Uncategorized<N>` group, creating one only
-// if none exists. The numbering is intentionally naive — this is the
-// fallback path for users who haven't yet organised their collections.
-
 describe('createCollection: group assignment', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1749,53 +1600,84 @@ describe('createCollection: group assignment', () => {
     expect(Object.keys(get(groups))).toEqual(['g1']);
   });
 
-  it('creates Uncategorized1 when no Uncategorized group exists', async () => {
-    const col = makeCollection('c1'); // no groupId
+  it('rejects collection creation without a real group', async () => {
+    await expect(createCollection(makeCollection('c1'))).rejects.toThrow('Cannot create collection without a real group');
+    expect(get(collections)['c1']).toBeUndefined();
+    expect(mockInbox.storeGroup).not.toHaveBeenCalled();
+  });
 
-    const stored = await createCollection(col);
+  it('rejects collection creation with a missing group', async () => {
+    await expect(createCollection(makeCollection('c1', 'missing'))).rejects.toThrow('Cannot create collection without a real group');
+    expect(get(collections)['c1']).toBeUndefined();
+  });
+});
 
-    const uncatGroup = Object.values(get(groups)).find(g => g.name === 'Uncategorized1');
+describe('load-time collection group repair', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    items.set({});
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+    mockInbox.getAll.mockResolvedValue({});
+    mockInbox.getConfig.mockResolvedValue({});
+    mockInbox.getUserSettings.mockResolvedValue(undefined);
+  });
+
+  it('creates Uncategorized1 and moves loaded collections without a group into it', async () => {
+    mockInbox.getAllCollections.mockResolvedValue({ c1: makeCollection('c1') });
+    mockInbox.getAllGroups.mockResolvedValue({});
+
+    await rsHandlers['connected']();
+
+    const uncatGroup = Object.values(get(groups)).find((g) => g.name === 'Uncategorized1');
     expect(uncatGroup).toBeDefined();
-    expect(stored.groupId).toBe(uncatGroup!.id);
     expect(get(collections)['c1'].groupId).toBe(uncatGroup!.id);
-    expect(get(groupCollections)[uncatGroup!.id].map(c => c.id)).toEqual(['c1']);
+    expect(get(groups)[uncatGroup!.id].collectionIds).toContain('c1');
   });
 
-  it('reuses an existing Uncategorized1 group instead of creating a new one', async () => {
-    const existing = makeGroup('g-existing');
-    existing.name = 'Uncategorized1';
-    groups.set({ 'g-existing': existing });
-
-    const stored = await createCollection(makeCollection('c1'));
-
-    expect(stored.groupId).toBe('g-existing');
-    // Still only one group — we didn't create Uncategorized2
-    expect(Object.keys(get(groups))).toEqual(['g-existing']);
-  });
-
-  it('picks the lowest-numbered Uncategorized group when several exist', async () => {
+  it('reuses the lowest existing Uncategorized<N> group during load repair', async () => {
     const u3 = makeGroup('g3'); u3.name = 'Uncategorized3';
     const u1 = makeGroup('g1'); u1.name = 'Uncategorized1';
     const u2 = makeGroup('g2'); u2.name = 'Uncategorized2';
-    groups.set({ g3: u3, g1: u1, g2: u2 });
+    mockInbox.getAllCollections.mockResolvedValue({ c1: makeCollection('c1', 'deleted-group') });
+    mockInbox.getAllGroups.mockResolvedValue({ g3: u3, g1: u1, g2: u2 });
 
-    const stored = await createCollection(makeCollection('c1'));
+    await rsHandlers['connected']();
 
-    expect(stored.groupId).toBe('g1');
+    expect(get(collections)['c1'].groupId).toBe('g1');
+    expect(get(groups)['g1'].collectionIds).toContain('c1');
+    expect(Object.values(get(groups)).filter((g) => g.name === 'Uncategorized1')).toHaveLength(1);
   });
 
-  it('ignores groups whose names do not match the Uncategorized<N> pattern', async () => {
-    // "Uncategorized" without a number, or with extra suffix, must NOT be reused.
-    const a = makeGroup('ga'); a.name = 'Uncategorized';
-    const b = makeGroup('gb'); b.name = 'Uncategorized1-archive';
-    groups.set({ ga: a, gb: b });
+  it('does not repair when groups fail to load', async () => {
+    const existing = makeGroup('g1', ['c1']);
+    groups.set({ g1: existing });
+    collections.set({ c1: makeCollection('c1', 'g1') });
+    mockInbox.getAllCollections.mockResolvedValue({ c1: makeCollection('c1', 'g1') });
+    mockInbox.getAllGroups.mockRejectedValue(new Error('temporary groups read failure'));
 
-    const stored = await createCollection(makeCollection('c1'));
+    await rsHandlers['connected']();
 
-    const uncatGroup = Object.values(get(groups)).find(g => g.name === 'Uncategorized1');
+    expect(get(collections)['c1'].groupId).toBe('g1');
+    expect(get(groups)['g1']).toBeDefined();
+    expect(Object.values(get(groups)).some((g) => g.name === 'Uncategorized1')).toBe(false);
+  });
+
+  it('repairs collections when a remote group deletion leaves them orphaned', async () => {
+    collections.set({ c1: makeCollection('c1', 'g1') });
+    groups.set({ g1: makeGroup('g1', ['c1']) });
+
+    emitModuleChange({
+      relativePath: 'groups/g1',
+      oldValue: makeGroup('g1', ['c1']),
+      newValue: undefined,
+    });
+    for (let i = 0; i < 5; i += 1) await Promise.resolve();
+
+    const uncatGroup = Object.values(get(groups)).find((g) => g.name === 'Uncategorized1');
     expect(uncatGroup).toBeDefined();
-    expect(stored.groupId).toBe(uncatGroup!.id);
-    // Original groups are still around — we created a NEW Uncategorized1.
-    expect(Object.keys(get(groups))).toHaveLength(3);
+    expect(get(collections)['c1'].groupId).toBe(uncatGroup!.id);
+    expect(get(groups)[uncatGroup!.id].collectionIds).toContain('c1');
   });
 });

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -103,9 +103,9 @@ async function loadEntities<T extends { id: string }>(
   fetchAll: () => Promise<Record<string, unknown>>,
   store: Writable<Record<string, T>>,
   arrayField?: keyof T,
-): Promise<void> {
+): Promise<boolean> {
   const inbox = getInbox();
-  if (!inbox) return;
+  if (!inbox) return false;
   try {
     const all = await fetchAll.call(inbox);
     const valid: Record<string, T> = {};
@@ -121,8 +121,10 @@ async function loadEntities<T extends { id: string }>(
       }
     }
     store.set(valid);
+    return true;
   } catch {
     // RS sync/fetch error — keep existing data
+    return false;
   }
 }
 
@@ -212,12 +214,37 @@ async function loadUserSettings() {
 
 async function loadCollections() {
   const inbox = getInbox();
-  await loadEntities<Collection>(() => inbox.getAllCollections(), collections, 'itemIds');
+  return loadEntities<Collection>(() => inbox.getAllCollections(), collections, 'itemIds');
 }
 
 async function loadGroups() {
   const inbox = getInbox();
-  await loadEntities<CollectionGroup>(() => inbox.getAllGroups(), groups, 'collectionIds');
+  return loadEntities<CollectionGroup>(() => inbox.getAllGroups(), groups, 'collectionIds');
+}
+
+async function repairCollectionsWithoutValidGroup() {
+  const allGroups = get(groups);
+  const needsRepair = Object.values(get(collections)).filter(col => !col.groupId || !allGroups[col.groupId]);
+  if (needsRepair.length === 0) return;
+
+  const targetGroupId = await findOrCreateUncategorizedGroup();
+  for (const col of needsRepair) {
+    await moveCollectionToGroup(col.id, targetGroupId);
+  }
+}
+
+let repairCollectionsQueued = false;
+function queueCollectionGroupRepair() {
+  if (repairCollectionsQueued) return;
+  repairCollectionsQueued = true;
+  queueMicrotask(async () => {
+    repairCollectionsQueued = false;
+    try {
+      await repairCollectionsWithoutValidGroup();
+    } catch (error) {
+      console.error('[inbox] failed to repair collection group membership:', error);
+    }
+  });
 }
 
 // Debounced sync indicator: stays visible for at least 1 second to avoid flicker
@@ -273,7 +300,16 @@ rs.on('connected', async () => {
     localStorage.getItem('inbox-rs:userAddress') ||
     '';
   userAddress.set(addr);
-  await Promise.all([loadItems(), loadConfig(), loadUserSettings(), loadCollections(), loadGroups()]);
+  const [, , , collectionsLoaded, groupsLoaded] = await Promise.all([
+    loadItems(),
+    loadConfig(),
+    loadUserSettings(),
+    loadCollections(),
+    loadGroups(),
+  ]);
+  if (collectionsLoaded && groupsLoaded) {
+    await repairCollectionsWithoutValidGroup();
+  }
   scheduleMigrationAlertFallback();
 });
 
@@ -377,6 +413,7 @@ if (inboxRef) {
           ...current,
           [key]: { ...col, itemIds: Array.isArray(col.itemIds) ? col.itemIds : [] },
         }));
+        queueCollectionGroupRepair();
       } else if (!value) {
         collections.update(current => {
           const next = { ...current };
@@ -393,12 +430,14 @@ if (inboxRef) {
           ...current,
           [key]: { ...grp, collectionIds: Array.isArray(grp.collectionIds) ? grp.collectionIds : [] },
         }));
+        queueCollectionGroupRepair();
       } else if (!value) {
         groups.update(current => {
           const next = { ...current };
           delete next[key];
           return next;
         });
+        queueCollectionGroupRepair();
       }
     } else if (path === 'config/app') {
       if (value && typeof value === 'object') {
@@ -510,8 +549,6 @@ export const uncategorizedReferenceItems = derived(items, ($items) => {
     .filter(i => !i.isTodo && i.type !== 'todo' && !i.collectionId && i.uncategorized === true)
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 });
-
-export const sortedCollections = orderedDerived<Collection>(collections, 'collectionsOrder');
 
 export const collectionItems = derived(
   [items, collections, todoItems, uncategorizedReferenceItems],
@@ -775,10 +812,6 @@ export async function reorderCollectionItems(collectionId: string, newItemIds: s
   }
 }
 
-export async function reorderCollections(newOrder: string[]) {
-  await updateConfig({ collectionsOrder: newOrder });
-}
-
 /**
  * Expand/collapse helpers for the per-collection expansion state stored in
  * `appConfig.expandedCollections`. Callers pass the set of collection ids the
@@ -812,14 +845,6 @@ export const groupCollections = derived([collections, groups, appConfig], ([$col
   }
   return result;
 });
-
-export const ungroupedCollections = derived(
-  [sortedCollections, groups],
-  ([$sortedCollections, $groups]) => {
-    const groupIds = new Set(Object.keys($groups));
-    return $sortedCollections.filter(c => !c.groupId || !groupIds.has(c.groupId));
-  }
-);
 
 export async function storeGroup(group: CollectionGroup) {
   const inbox = getInbox();
@@ -871,8 +896,11 @@ export async function deleteGroup(id: string): Promise<boolean> {
   }
 }
 
-export async function moveCollectionToGroup(collectionId: string, groupId: string | undefined) {
+export async function moveCollectionToGroup(collectionId: string, groupId: string) {
   const inbox = getInbox();
+  if (!groupId || !get(groups)[groupId]) {
+    throw new Error(`Cannot move collection to missing group: ${groupId}`);
+  }
 
   // Snapshot stores for rollback
   const prevCollections = get(collections);
@@ -886,11 +914,7 @@ export async function moveCollectionToGroup(collectionId: string, groupId: strin
     if (next[collectionId]) {
       oldGroupId = next[collectionId].groupId;
       const updated = { ...next[collectionId] };
-      if (groupId) {
-        updated.groupId = groupId;
-      } else {
-        delete (updated as any).groupId;
-      }
+      updated.groupId = groupId;
       next[collectionId] = updated as Collection;
       col = updated as Collection;
     }
@@ -918,18 +942,16 @@ export async function moveCollectionToGroup(collectionId: string, groupId: strin
     }
 
     // Add to new group
-    if (groupId) {
-      groups.update(current => {
-        const grp = current[groupId];
-        if (grp && !grp.collectionIds.includes(collectionId)) {
-          return { ...current, [groupId]: { ...grp, collectionIds: [...grp.collectionIds, collectionId] } };
-        }
-        return current;
-      });
-      const newGrp = get(groups)[groupId];
-      if (newGrp) {
-        await inbox.storeGroup(cleanForStorage(newGrp));
+    groups.update(current => {
+      const grp = current[groupId];
+      if (grp && !grp.collectionIds.includes(collectionId)) {
+        return { ...current, [groupId]: { ...grp, collectionIds: [...grp.collectionIds, collectionId] } };
       }
+      return current;
+    });
+    const newGrp = get(groups)[groupId];
+    if (newGrp) {
+      await inbox.storeGroup(cleanForStorage(newGrp));
     }
   } catch (e) {
     collections.set(prevCollections);
@@ -941,12 +963,9 @@ export async function moveCollectionToGroup(collectionId: string, groupId: strin
 
 /**
  * Find an existing "Uncategorized<N>" group, or create a fresh one and return
- * its id. Uncategorized<N> groups are auto-created homes for collections the
- * user added without picking a group — every collection needs a group, and we
- * keep these auto-homes obviously distinct from user-named groups by
- * convention. The numbering is naive on purpose (this is an edge case): we
- * scan existing groups for `Uncategorized\d+`, take the lowest number, and
- * create `Uncategorized1` if none exist.
+ * its id. This is only for load-time repair of legacy/homeless collections.
+ * Normal collection creation must pick a real group before it reaches the
+ * store.
  */
 async function findOrCreateUncategorizedGroup(): Promise<string> {
   const allGroups = get(groups);
@@ -970,20 +989,18 @@ async function findOrCreateUncategorizedGroup(): Promise<string> {
 }
 
 /**
- * Create a collection, ensuring it ends up inside a group. If the caller
- * already picked a group (`col.groupId` set), we honour it and wire up the
- * group ↔ collection back-references via `moveCollectionToGroup`. Otherwise
- * we route the collection into an `Uncategorized<N>` group (creating one if
- * needed) so the "every collection has a group" invariant always holds.
- *
- * Returns the stored collection (with `groupId` filled in if we auto-assigned).
+ * Create a collection in an explicit real group. Legacy/homeless collection
+ * repair is handled separately during app load by
+ * `repairCollectionsWithoutValidGroup`; this path should never invent a
+ * background "no group" destination for a new collection.
  */
 export async function createCollection(col: Collection): Promise<Collection> {
-  const targetGroupId = col.groupId ?? await findOrCreateUncategorizedGroup();
-  const withGroup: Collection = { ...col, groupId: targetGroupId };
-  await storeCollection(withGroup);
-  await moveCollectionToGroup(withGroup.id, targetGroupId);
-  return withGroup;
+  if (!col.groupId || !get(groups)[col.groupId]) {
+    throw new Error('Cannot create collection without a real group');
+  }
+  await storeCollection(col);
+  await moveCollectionToGroup(col.id, col.groupId);
+  return col;
 }
 
 export async function reorderGroupCollections(groupId: string, newCollectionIds: string[]) {
@@ -1160,12 +1177,10 @@ export const activeGroupIds = derived(
  * activeGroupIds. Within each group, collections preserve the configured
  * order from groupCollections.
  *
- * A synthetic "Uncategorized" section is folded into this list when there are
- * stragglers AND the uncategorized filter pill is on — identified by
- * `group.id === UNCATEGORIZED_FILTER_ID`. It holds ungrouped collections
- * (collections with no groupId, or with a groupId pointing to a non-existent
- * group). Uncategorized is dynamic: a user with no straggler items (and no
- * ungrouped collections surfaced alongside) never sees this section.
+ * A synthetic "Uncategorized" section is folded into this list only when
+ * there are straggler items AND the uncategorized filter pill is on —
+ * identified by `group.id === UNCATEGORIZED_FILTER_ID`. It is not a group
+ * destination and never hosts real collections.
  */
 export interface VisibleGroupSection {
   group: CollectionGroup;
@@ -1181,39 +1196,26 @@ export interface VisibleGroupSection {
 }
 
 export const visibleGroupedCollections = derived(
-  [sortedGroups, groupCollections, activeGroupIds, ungroupedCollections, uncategorizedFilterActive, uncategorizedVirtualCollection, hasUncategorizedItems, appConfig],
-  ([$sortedGroups, $groupCollections, $activeGroupIds, $ungroupedCollections, $uncatActive, $uncatVirtual, $hasUncat, $config]): VisibleGroupSection[] => {
+  [sortedGroups, groupCollections, activeGroupIds, uncategorizedFilterActive, uncategorizedVirtualCollection, hasUncategorizedItems, appConfig],
+  ([$sortedGroups, $groupCollections, $activeGroupIds, $uncatActive, $uncatVirtual, $hasUncat, $config]): VisibleGroupSection[] => {
     const sections: VisibleGroupSection[] = [];
     const realById = new Map($sortedGroups.map(g => [g.id, g]));
     const order = $config.groupsOrder ?? [];
     const seen = new Set<string>();
 
-    // Uncategorized is a dynamic surface: it only exists when the system has
-    // something to put there. "Something" means either straggler items (todos
-    // without a collection, or orphaned refs) OR ungrouped collections the
-    // user might want to see alongside — without either, the section would be
-    // a confusing empty heading. Real groups keep rendering when active even
-    // if empty because the user created them explicitly; Uncategorized has no
-    // such user intent behind it.
-    const uncatHasContent = $hasUncat || $ungroupedCollections.length > 0;
-
-    // Synthetic group for the Uncategorized section. Uses the same sentinel
+    // Synthetic section for item stragglers only. It uses the same sentinel
     // id as the filter pill so ordering/placement flows through groupsOrder
-    // without any special-casing at consumer sites. The virtual Uncategorized
-    // collection rides along on `virtualCollection` so CollectionsPage can
-    // render it alongside real ungrouped collections.
+    // without any special-casing at consumer sites, but it never owns real
+    // collections.
     const uncatSection: VisibleGroupSection = {
       group: {
         id: UNCATEGORIZED_FILTER_ID,
         name: 'Uncategorized',
-        collectionIds: $ungroupedCollections.map(c => c.id),
+        collectionIds: [],
         createdAt: new Date(0).toISOString(),
       },
-      collections: $ungroupedCollections,
-      // Only attach the virtual pseudo-collection when there are actual
-      // stragglers — otherwise the section just hosts ungrouped collections
-      // and shouldn't add an empty "Uncategorized" pseudo-tile on top.
-      virtualCollection: $hasUncat ? $uncatVirtual : undefined,
+      collections: [],
+      virtualCollection: $uncatVirtual,
     };
 
     const pushReal = (g: CollectionGroup) => {
@@ -1222,7 +1224,7 @@ export const visibleGroupedCollections = derived(
     };
 
     const pushUncat = () => {
-      if (!uncatHasContent) return;
+      if (!$hasUncat) return;
       if ($uncatActive) sections.push(uncatSection);
     };
 
@@ -1290,17 +1292,6 @@ export async function toggleUncategorizedFilter(): Promise<void> {
   await updateConfig({ uncategorizedFilterActive: !current });
 }
 
-/**
- * Persist a new order for the Uncategorized section on the Collections page.
- * Ungrouped collections take their order from `collectionsOrder` (via
- * `sortedCollections` → `ungroupedCollections`); grouped collections rely on
- * `group.collectionIds` for their order, so overwriting `collectionsOrder`
- * with just the ungrouped ids is safe.
- */
-export async function reorderUngroupedCollections(newOrder: string[]) {
-  await updateConfig({ collectionsOrder: newOrder });
-}
-
 // ---- Flat Todos page: all todos across all collections ----
 
 /**
@@ -1324,20 +1315,16 @@ export const openTodos = derived(allTodos, ($allTodos) =>
  * todos are mixed — the page splits them at render time.
  */
 export const visibleTodos = derived(
-  [allTodos, collections, sortedGroups, activeGroupIds, uncategorizedFilterActive, appConfig],
-  ([$allTodos, $collections, $sortedGroups, $activeGroupIds, $uncatActive, $config]) => {
-    const groupIdSet = new Set($sortedGroups.map(g => g.id));
-
+  [allTodos, collections, activeGroupIds, uncategorizedFilterActive, appConfig],
+  ([$allTodos, $collections, $activeGroupIds, $uncatActive, $config]) => {
     // A todo is visible iff:
     //  - it has no collectionId and the uncategorized pill is on, OR
-    //  - it's in a collection whose group is active (or the collection is
-    //    ungrouped / orphan-grouped — those are always visible alongside
-    //    active groups, mirroring CollectionsPage semantics).
+    //  - it's in a collection whose real group is active.
     const filtered = $allTodos.filter(todo => {
       if (!todo.collectionId) return $uncatActive;
       const col = $collections[todo.collectionId];
       if (!col) return $uncatActive; // orphan: the collection was deleted — treat as uncategorized
-      if (!col.groupId || !groupIdSet.has(col.groupId)) return true; // ungrouped collection
+      if (!col.groupId) return false;
       return $activeGroupIds.has(col.groupId);
     });
 


### PR DESCRIPTION
## Summary
- remove the permanent synthetic no-group / Collections bucket from collection and item move UIs
- require collections to belong to a real group during normal create/move flows
- keep load-time repair for legacy or homeless collections by assigning them to a real Uncategorized<N> group
- make collection delete availability use live item placement instead of stale itemIds

## Root cause
The UI and stores treated collections without a valid group as a persistent background destination. That made the collection move menu show a special grey Collections row and let picker logic carry a no-group path that should only exist as legacy repair data.

## Validation
- npm run test --workspace=packages/web
- npm run build --workspace=packages/web

Build still reports existing Svelte warnings unrelated to this change.