### PR TITLE
Allow frictionless todo capture

### DIFF
--- a/packages/rs-module/src/schemas.ts
+++ b/packages/rs-module/src/schemas.ts
@@ -6,11 +6,8 @@ const todoFields = {
 };
 
 // Shared collection field — any item can belong to a collection.
-// `uncategorized` is the opt-in flag that sends items without a `collectionId`
-// to the Uncategorized bucket instead of the Inbox.
 const collectionFields = {
   collectionId: { type: 'string' },
-  uncategorized: { type: 'boolean' },
 };
 
 // rs-migrate version stamp — must be in every item schema so remoteStorage persists it
@@ -168,7 +165,6 @@ export const appConfigSchema = {
     todosOrder: { type: 'array', items: { type: 'string' } },
     expandedCollections: { type: 'array', items: { type: 'string' } },
     activeGroupFilters: { type: 'array', items: { type: 'string' } },
-    uncategorizedFilterActive: { type: 'boolean' },
     todosGlobalOrder: { type: 'array', items: { type: 'string' } },
     completedTodosExpanded: { type: 'boolean' },
   }

--- a/packages/rs-module/src/types.ts
+++ b/packages/rs-module/src/types.ts
@@ -10,20 +10,7 @@ export interface InboxItemBase {
   isTodo?: boolean;
   completed?: boolean;
   completedAt?: string;
-  collectionId?: string; // undefined = lives in Inbox (or Uncategorized, see `uncategorized`)
-  /**
-   * When true AND `collectionId` is unset, the item belongs to the
-   * Uncategorized bucket on the Collections/Todos pages rather than the
-   * Inbox. Typical sources:
-   *   - user explicitly picks "Uncategorized" in the AddEntryModal picker
-   *   - an item is orphaned when its parent collection is deleted
-   *
-   * Items without a `collectionId` and without this flag default to the Inbox
-   * — they surface only in the Inbox view and never in the Uncategorized
-   * bucket. Ignored when `collectionId` is set (a collection placement always
-   * wins over Uncategorized).
-   */
-  uncategorized?: boolean;
+  collectionId?: string; // undefined = Inbox for refs, unfiled for todos
 }
 
 export interface BookmarkItem extends InboxItemBase {
@@ -108,12 +95,6 @@ export interface AppConfig {
    * When set: only groups in this list are visible/filtered in.
    */
   activeGroupFilters?: string[];
-  /**
-   * Whether uncategorized todos (items without a collectionId) are visible on
-   * the Todos page. Treated as a filter pill alongside group filters.
-   * When undefined: defaults to true (visible).
-   */
-  uncategorizedFilterActive?: boolean;
   /**
    * Ordered list of todo IDs for the flat Todos page. Controls cross-collection
    * drag-sort order on that page only — collection-internal order (used by the

--- a/packages/rs-module/src/types.ts
+++ b/packages/rs-module/src/types.ts
@@ -127,24 +127,11 @@ export interface AppConfig {
    */
   completedTodosExpanded?: boolean;
   /**
-   * Remembered "last picked" destinations for the add-entry modals, so
-   * repeat-create flows don't start on a blank picker every time.
-   *
-   * - `lastSelectedGroupId` — the group the user most recently saved a new
-   *   collection into. When the user opens "New collection" from a neutral
-   *   entry point (page-level Fab), the group picker starts on this value.
-   *   Falls back to the first group in display order if unset or the
-   *   referenced group no longer exists.
-   * - `lastSelectedCollectionId` — same idea for new todos: the collection
-   *   the user most recently filed a todo into. Used only for todos (refs
-   *   keep defaulting to Inbox).
-   *
-   * Both are best-effort hints — callers must validate the referenced id
-   * still exists before using it, because collections/groups can be deleted
-   * between sessions.
+   * Best-effort hint for the group the user most recently saved a new
+   * collection into. Callers must validate the referenced id still exists
+   * before using it, because groups can be deleted between sessions.
    */
   lastSelectedGroupId?: string;
-  lastSelectedCollectionId?: string;
 }
 
 export interface Collection {

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -164,8 +164,6 @@
 
   async function handleCreateCollection(col: Collection) {
     try {
-      // createCollection guarantees the collection ends up inside a group —
-      // either the one the form picked, or a fresh "UncategorizedN" group.
       await createCollection(col);
       showCollectionForm = false;
     } catch (error) {
@@ -183,8 +181,7 @@
   }
 
   // Surface a small badge with open todo count next to the Todos nav item.
-  // Counts every open todo across all collections (not just uncategorized) so
-  // the badge matches what the user sees on the flat Todos page.
+  // Counts every open todo so the badge matches the flat Todos page.
   const openTodoCount = $derived($openTodos.length);
 </script>
 

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -27,6 +27,7 @@
   let viewingItem = $state<InboxItem | null>(null);
   let showCollectionForm = $state(false);
   let showGroupForm = $state(false);
+  let userMenu = $state<InstanceType<typeof UserMenu> | null>(null);
   // Collection to pre-select when opening the add-entry modal. Used by the
   // per-row quick-add on the Todos page so the new todo lands in the same
   // collection as the row the user is adding alongside.
@@ -129,12 +130,8 @@
   }
 
   /** Open the add-todo modal with a specific collection pre-selected.
-      Callers pass a real collection id to target that collection, or the
-      `UNCATEGORIZED_COLLECTION_ID` sentinel (from stores) to target the
-      Uncategorized bucket explicitly — e.g. the quick-add on an uncategorized
-      todo row. `undefined` means "no preselection, use the modal's own
-      default cascade" and should only come from callers that genuinely have
-      no target in mind. */
+      Callers pass a real collection id to target that collection, or
+      `undefined` to keep the new todo unfiled. */
   function openAddTodoInCollection(collectionId: string | undefined) {
     editingItem = undefined;
     preselectedCollectionId = collectionId;
@@ -159,6 +156,10 @@
     activeModal = null;
     editingItem = undefined;
     preselectedCollectionId = undefined;
+  }
+
+  function openConnectMenu() {
+    void userMenu?.openConnectMenu();
   }
 
   async function handleCreateCollection(col: Collection) {
@@ -221,10 +222,10 @@
       >Collections</button>
     </nav>
     <div class="header-right">
-      <UserMenu />
+      <UserMenu bind:this={userMenu} />
     </div>
   </div>
-  {#if $connected && route.page !== 'plugins'}
+  {#if route.page !== 'plugins'}
     <div class="header-filters">
       <div class="header-filters-inner">
         <GroupFilterBar
@@ -239,12 +240,6 @@
 <main>
   {#if route.page === 'plugins'}
     <PluginsPage />
-  {:else if !$connected}
-    <div class="empty-state">
-      <div class="empty-icon">📥</div>
-      <h2>Connect your storage</h2>
-      <p>Enter your remoteStorage address above to view your inbox.</p>
-    </div>
   {:else}
     {#if $pendingMigrationCount > 0}
       <MigrationAlert count={$pendingMigrationCount} onrun={runAllMigrations} />
@@ -253,17 +248,13 @@
     {#if route.page === 'inbox'}
       <div class="page-toolbar">
         <!-- Inbox is a refs-only staging area for unprocessed thoughts.
-             Todos always need a home (a collection), so adding one straight
-             to the Inbox would silently land it in the dynamic Uncategorized
-             bucket — which mixes "I haven't decided what this is" notes with
-             "I committed to doing this" todos. Hide the Todo button here so
-             the only way to create a todo is from a collection or the Todos
-             page picker, both of which force a collection choice. Existing
-             notes can still be converted via `makeTodo` when the user is
-             ready to commit. -->
+             Todos are captured from the dedicated Todos surface so they can
+             be added quickly, then optionally filed into a collection later.
+             Existing notes can still be converted via `makeTodo` when the
+             user is ready to commit. -->
         <AddEntryBar onadd={openAdd} excludeTypes={['todo']} />
       </div>
-      <InboxGrid onselect={openView} />
+      <InboxGrid onselect={openView} onconnect={openConnectMenu} />
     {:else if route.page === 'todos'}
       <TodosPage onselect={openView} onaddtodo={openAddTodo} onaddtodoincollection={openAddTodoInCollection} />
     {:else}
@@ -574,28 +565,4 @@
     letter-spacing: 0.02em;
   }
 
-  .empty-state {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    min-height: 60vh;
-    text-align: center;
-    gap: 0.75rem;
-  }
-
-  .empty-icon {
-    font-size: 3rem;
-    margin-bottom: 0.5rem;
-  }
-
-  .empty-state h2 {
-    font-size: 1.5rem;
-    font-weight: 600;
-  }
-
-  .empty-state p {
-    color: var(--text-muted);
-    max-width: 400px;
-  }
 </style>

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -1,17 +1,23 @@
 <script lang="ts">
   import type { Component } from 'svelte';
   import { onDestroy } from 'svelte';
-  import { get } from 'svelte/store';
   import type { InboxItemType, InboxItem } from '@inbox-rs/rs-module';
   import {
     storeItem, moveItemToCollection,
     sortedGroups, groupCollections,
     hasUncategorizedItems, UNCATEGORIZED_COLLECTION_ID,
-    collections, appConfig, updateConfig,
   } from '../lib/stores';
   import { renderMarkdown } from '../lib/markdown';
   import { transcribeAudio } from '../lib/transcribe';
-  import { loadMarkdownEditorComponent, shouldLoadMarkdownEditor, shouldSubmitAddEntryForm } from '../lib/add-entry-modal';
+  import {
+    canCaptureTodo,
+    loadMarkdownEditorComponent,
+    normalizeInitialCollectionId,
+    shouldLoadMarkdownEditor,
+    shouldMarkUncategorized,
+    shouldShowCollectionPicker,
+    shouldSubmitAddEntryForm,
+  } from '../lib/add-entry-modal';
   import { isInsideCodeBlock, insertIndent, indentSelection, dedentSelection, insertNewlineWithIndent, isOnClosingFence } from '../lib/code-indent';
   import { autofocus } from '../lib/actions';
 
@@ -27,48 +33,17 @@
   let saving = $state(false);
 
   /**
-   * Find the first real collection in display order — iterate groups in
-   * sorted order, then take the first collection from each. Used as the
-   * last-resort default for the todo picker when
-   * there's no explicit `collectionId` prop and no valid
-   * `lastSelectedCollectionId`. Returns `undefined` when the user has no
-   * collections at all (the picker then shows its empty-state hint).
-   */
-  function firstAvailableCollectionId(): string | undefined {
-    for (const group of get(sortedGroups)) {
-      const cols = get(groupCollections)[group.id] ?? [];
-      if (cols.length > 0) return cols[0].id;
-    }
-    return undefined;
-  }
-
-  /**
-   * Pick the initial collection for the todo picker so the user doesn't
-   * land on a blank destination when creating repeat todos. Resolution:
-   *   1. Explicit `collectionId` prop (e.g. quick-add from a collection
-   *      row) — honored verbatim.
-   *   2. `lastSelectedCollectionId` from appConfig, validated against the
-   *      collections store. Deleted collections are ignored and we fall
-   *      through.
-   *   3. First available real collection in display order.
-   *   4. `undefined` — no collections exist yet; the picker surfaces a
-   *      "create a collection first" hint and submit stays disabled.
-   *
-   * Only applied to new todos; refs keep defaulting to the Inbox
-   * (`undefined` here means Inbox), and edits reuse the existing item's
-   * collection context.
+   * Pick the initial collection for new todos. Explicit collection entry
+   * points (for example a collection quick-add button) are honored, but the
+   * generic todo modal starts unfiled. We deliberately don't auto-create or
+   * auto-select organization here: normal capture should stay frictionless.
    */
   function pickInitialCollectionId(): string | undefined {
-    if (collectionId !== undefined) return collectionId;
-    if (isEdit) return undefined;
-    if (type !== 'todo') return undefined;
-    const last = get(appConfig).lastSelectedCollectionId;
-    if (last && get(collections)[last]) return last;
-    return firstAvailableCollectionId();
+    return normalizeInitialCollectionId(type, collectionId, UNCATEGORIZED_COLLECTION_ID);
   }
 
-  // Let the user pick the destination collection from within the modal for
-  // every new item. See `pickInitialCollectionId` for the default cascade.
+  // Let the user pick a destination for new items. See
+  // `pickInitialCollectionId` for the default cascade.
   let selectedCollectionId = $state<string | undefined>(pickInitialCollectionId());
   let collectionPickerOpen = $state(false);
   let collectionPickerEl = $state<HTMLDivElement>();
@@ -78,25 +53,19 @@
   // (note modal) and the modal's rounded border clipping (other modals).
   // Flips upward when there's no room below.
   let pickerMenuStyle = $state('');
-  const showCollectionPicker = $derived(!isEdit);
-
-  // Todos must have a collection — they can't live in the Inbox (refs-only
-  // staging area) and the Uncategorized bucket is reserved for stragglers
-  // produced by deleting a collection. So for todos we surface no
-  // "no-collection" default at all; the user picks a real collection or the
-  // Save button stays disabled. For refs, `undefined` means "Inbox" (the
-  // default landing).
+  // For refs, `undefined` means Inbox. For todos, `undefined` means unfiled:
+  // no collectionId is written, and the todo stays available to organize
+  // later without creating any synthetic group or collection.
   const isTodoType = $derived(type === 'todo');
   const noCollectionLabel = 'Inbox';
 
-  // `undefined` is the non-collection sentinel — for refs it means "Inbox".
-  // Todos never use the `undefined` selection (the picker hides that row),
-  // but we still show a placeholder label until a real collection is picked.
+  // `undefined` is the non-collection sentinel: Inbox for refs, unfiled for
+  // todos.
   const collectionLabel = $derived.by(() => {
     if (selectedCollectionId === undefined) {
-      return isTodoType ? 'Choose a collection…' : noCollectionLabel;
+      return isTodoType ? 'Unfiled' : noCollectionLabel;
     }
-    if (selectedCollectionId === UNCATEGORIZED_COLLECTION_ID) return 'Uncategorized';
+    if (selectedCollectionId === UNCATEGORIZED_COLLECTION_ID) return isTodoType ? 'Unfiled' : 'Uncategorized';
     for (const group of $sortedGroups) {
       const cols = $groupCollections[group.id] ?? [];
       const found = cols.find(c => c.id === selectedCollectionId);
@@ -108,26 +77,24 @@
   // Show an explicit "Uncategorized" picker row for refs only when the bucket
   // already exists (has stragglers). Per the design, Uncategorized is a
   // dynamic surface that appears when items live there — it shouldn't be a
-  // first-class destination unless it's already populated. Todos normally
-  // can't route there (they require a real collection), but when a caller
-  // explicitly preselected Uncategorized (e.g. the quick-add on an
-  // uncategorized todo row) we surface it in the picker so the current
-  // selection is visible and reselectable.
+  // first-class destination unless it's already populated. Todo capture uses
+  // `undefined` for unfiled; the sentinel is normalized away for todos.
   const showUncategorizedInPicker = $derived(
     (!isTodoType && $hasUncategorizedItems)
     || selectedCollectionId === UNCATEGORIZED_COLLECTION_ID
   );
 
-  // Whether the user has any real grouped collections at all.
-  // Used to decide when to surface an empty-state hint in the todo picker —
-  // todos require a real collection, so an empty picker is a dead end without
-  // guidance.
+  // Whether the user has any real grouped collections at all. Todo capture
+  // hides the picker entirely when this is false so an empty account can still
+  // jot things down immediately.
   const hasAnyCollection = $derived.by(() => {
     for (const group of $sortedGroups) {
       if (($groupCollections[group.id] ?? []).length > 0) return true;
     }
     return false;
   });
+
+  const showCollectionPicker = $derived(shouldShowCollectionPicker(isEdit, type, hasAnyCollection, selectedCollectionId, UNCATEGORIZED_COLLECTION_ID));
 
   $effect(() => {
     if (!collectionPickerOpen) return;
@@ -156,21 +123,6 @@
   function selectCollection(id: string | undefined) {
     selectedCollectionId = id;
     collectionPickerOpen = false;
-  }
-
-  /**
-   * Exit the modal and jump to the Collections page. Used from the todo
-   * picker's empty state — the user needs a real collection before they can
-   * save a todo, and there's no in-page affordance to create one without
-   * navigating away. The in-progress form is discarded on `onclose`; that's
-   * acceptable since the Save button is disabled anyway (no collection to
-   * file into).
-   */
-  function goToCollections() {
-    onclose();
-    if (window.location.hash !== '#/collections') {
-      window.location.hash = '#/collections';
-    }
   }
 
   /**
@@ -437,45 +389,26 @@
         // The Uncategorized sentinel is a picker-level id, not a real
         // collection id — writing it to `item.collectionId` would leave a
         // bogus reference in storage. The branch below (selectedCollectionId
-        // === UNCATEGORIZED_COLLECTION_ID) handles the Uncategorized case by
-        // setting the `uncategorized` flag and leaving `collectionId` unset.
+        // === UNCATEGORIZED_COLLECTION_ID) handles the ref Uncategorized case
+        // by setting the `uncategorized` flag and leaving `collectionId` unset.
         item.collectionId = collectionId;
       }
 
       // Picker → storage shape:
       //   undefined + ref         → Inbox (default; no flag, no collectionId)
-      //   undefined + todo        → Uncategorized (no flag needed — todos
-      //                              without a collectionId are uncategorized
-      //                              by definition, see
-      //                              uncategorizedVirtualCollection)
+      //   undefined + todo        → unfiled todo (no collectionId, no fake
+      //                              collection/group written)
       //   UNCATEGORIZED_... + ref → Uncategorized (set `uncategorized: true`
       //                              before storage; no moveItemToCollection
       //                              call since there's no real collection
       //                              record to update)
       //   real id                 → assign via moveItemToCollection after storage
-      if (!isEdit && selectedCollectionId === UNCATEGORIZED_COLLECTION_ID) {
+      if (shouldMarkUncategorized(isEdit, type, selectedCollectionId, UNCATEGORIZED_COLLECTION_ID)) {
         item!.uncategorized = true;
       }
       await storeItem(item!, fileData);
       if (selectedCollectionId && selectedCollectionId !== UNCATEGORIZED_COLLECTION_ID && !isEdit) {
         await moveItemToCollection(item!.id, selectedCollectionId);
-      }
-      // Remember the destination for next time, but only for new todos — the
-      // preference seeds `pickInitialCollectionId`. Refs default to Inbox so
-      // there's nothing useful to remember for them; edits don't expose the
-      // picker. Uncategorized is explicitly excluded so we never bring the
-      // user back to the ref-only bucket as a default.
-      if (
-        !isEdit
-        && type === 'todo'
-        && selectedCollectionId
-        && selectedCollectionId !== UNCATEGORIZED_COLLECTION_ID
-      ) {
-        try {
-          await updateConfig({ lastSelectedCollectionId: selectedCollectionId });
-        } catch (e) {
-          console.error('Failed to persist lastSelectedCollectionId', e);
-        }
       }
       onclose();
     } catch (e) {
@@ -624,7 +557,7 @@
     : type === 'bookmark' ? !!url
     : type === 'note' ? !!(title || body)
     : type === 'email' ? !!body
-    : type === 'todo' ? !!title && !!selectedCollectionId
+    : type === 'todo' ? canCaptureTodo(title)
     : true
   );
 </script>
@@ -840,7 +773,7 @@
 
       {#if showCollectionPicker}
         <div class="field">
-          <span>Collection</span>
+          <span>{isTodoType ? 'File in' : 'Collection'}</span>
           <div class="dest-wrapper" bind:this={collectionPickerEl}>
             <button
               type="button"
@@ -858,11 +791,20 @@
             {#if collectionPickerOpen}
               <div class="dest-menu" role="listbox" aria-label="Destination" style={pickerMenuStyle}>
                 <!--
-                  Default non-collection destination. Refs-only — the row
-                  files the new ref into the Inbox (the default landing).
-                  Hidden for todos, which require a real collection.
+                  Default non-collection destination. For refs this is Inbox;
+                  for todos this is unfiled so they can be organized later.
                 -->
-                {#if !isTodoType}
+                {#if isTodoType && selectedCollectionId !== UNCATEGORIZED_COLLECTION_ID}
+                  <button
+                    type="button"
+                    class="dest-item"
+                    class:selected={selectedCollectionId === undefined}
+                    onclick={() => selectCollection(undefined)}
+                  >
+                    <span class="dest-dot" style="background: #9ca3af" aria-hidden="true"></span>
+                    Unfiled
+                  </button>
+                {:else if !isTodoType}
                   <button
                     type="button"
                     class="dest-item"
@@ -879,11 +821,8 @@
                     (a) refs when the bucket already exists, so the user can
                         file a new ref alongside existing stragglers without
                         first sending it to the Inbox and moving it; and
-                    (b) todos when the caller preselected the Uncategorized
-                        sentinel (e.g. the quick-add on an uncategorized todo
-                        row) — shown so the current selection is visible and
-                        the user can reselect it after browsing real
-                        collections.
+                    (b) legacy/defensive sentinel selections, so the current
+                        selection is visible and reselectable.
                   -->
                   <button
                     type="button"
@@ -892,7 +831,7 @@
                     onclick={() => selectCollection(UNCATEGORIZED_COLLECTION_ID)}
                   >
                     <span class="dest-dot" style="background: #9ca3af" aria-hidden="true"></span>
-                    Uncategorized
+                    {isTodoType ? 'Unfiled' : 'Uncategorized'}
                   </button>
                 {/if}
                 {#each $sortedGroups as group (group.id)}
@@ -915,29 +854,6 @@
                     {/each}
                   {/if}
                 {/each}
-                {#if isTodoType && !hasAnyCollection}
-                  <!--
-                    Todos require a real collection, so when the user has no
-                    collections at all the picker would otherwise render
-                    completely empty. Surface an actionable hint + a jump
-                    button so the user isn't stuck — losing the in-progress
-                    title is acceptable since there's nowhere to save it yet.
-                    Note: the virtual Uncategorized bucket (if present) is a
-                    read-only fallback for stragglers and isn't a real
-                    collection, so it deliberately isn't offered here.
-                  -->
-                  <div class="dest-empty">
-                    <p class="dest-empty-title">No collections yet</p>
-                    <p class="dest-empty-hint">Todos need a collection. Create one to file this todo into.</p>
-                    <button
-                      type="button"
-                      class="dest-empty-cta"
-                      onclick={goToCollections}
-                    >
-                      Go to Collections
-                    </button>
-                  </div>
-                {/if}
               </div>
             {/if}
           </div>
@@ -1323,52 +1239,6 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-  }
-
-  .dest-empty {
-    padding: 0.75rem 0.55rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-    align-items: center;
-    text-align: center;
-  }
-
-  .dest-empty-title {
-    margin: 0;
-    font-size: 0.85rem;
-    color: var(--text);
-    font-weight: 600;
-  }
-
-  .dest-empty-hint {
-    margin: 0;
-    font-size: 0.78rem;
-    color: var(--text-muted);
-    line-height: 1.4;
-  }
-
-  /*
-   * Inline CTA styled as a compact accent button — mirrors the Fab/primary
-   * button look but sized to fit inside the dropdown without dominating it.
-   * Kept tap-target friendly on mobile (36px min height) so it works as the
-   * only escape hatch from the empty state.
-   */
-  .dest-empty-cta {
-    margin-top: 0.2rem;
-    padding: 0.4rem 0.8rem;
-    min-height: 36px;
-    background: var(--accent);
-    color: white;
-    border: none;
-    border-radius: var(--radius);
-    font-size: 0.8rem;
-    font-weight: 600;
-    cursor: pointer;
-  }
-
-  .dest-empty-cta:hover {
-    filter: brightness(1.05);
   }
 
   .dest-dot {

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -29,19 +29,12 @@
   const isEdit = !!editItem;
   let saving = $state(false);
 
-  /**
-   * Pick the initial collection for new todos. Explicit collection entry
-   * points (for example a collection quick-add button) are honored, but the
-   * generic todo modal starts unfiled. We deliberately don't auto-create or
-   * auto-select organization here: normal capture should stay frictionless.
-   */
-  function pickInitialCollectionId(): string | undefined {
-    return collectionId;
-  }
-
-  // Let the user pick a destination for new items. See
-  // `pickInitialCollectionId` for the default cascade.
-  let selectedCollectionId = $state<string | undefined>(pickInitialCollectionId());
+  // Initial destination for new items: honour the caller's explicit
+  // `collectionId` prop (e.g. a collection quick-add button), otherwise leave
+  // unset. For todos, unset means "unfiled" — we deliberately don't
+  // auto-select organization so capture stays frictionless. For refs, unset
+  // means Inbox.
+  let selectedCollectionId = $state<string | undefined>(collectionId);
   let collectionPickerOpen = $state(false);
   let collectionPickerEl = $state<HTMLDivElement>();
   let collectionPickerTriggerEl = $state<HTMLButtonElement>();

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -5,16 +5,13 @@
   import {
     storeItem, moveItemToCollection,
     sortedGroups, groupCollections,
-    hasUncategorizedItems, UNCATEGORIZED_COLLECTION_ID,
   } from '../lib/stores';
   import { renderMarkdown } from '../lib/markdown';
   import { transcribeAudio } from '../lib/transcribe';
   import {
     canCaptureTodo,
     loadMarkdownEditorComponent,
-    normalizeInitialCollectionId,
     shouldLoadMarkdownEditor,
-    shouldMarkUncategorized,
     shouldShowCollectionPicker,
     shouldSubmitAddEntryForm,
   } from '../lib/add-entry-modal';
@@ -39,7 +36,7 @@
    * auto-select organization here: normal capture should stay frictionless.
    */
   function pickInitialCollectionId(): string | undefined {
-    return normalizeInitialCollectionId(type, collectionId, UNCATEGORIZED_COLLECTION_ID);
+    return collectionId;
   }
 
   // Let the user pick a destination for new items. See
@@ -65,24 +62,13 @@
     if (selectedCollectionId === undefined) {
       return isTodoType ? 'Unfiled' : noCollectionLabel;
     }
-    if (selectedCollectionId === UNCATEGORIZED_COLLECTION_ID) return isTodoType ? 'Unfiled' : 'Uncategorized';
     for (const group of $sortedGroups) {
       const cols = $groupCollections[group.id] ?? [];
       const found = cols.find(c => c.id === selectedCollectionId);
       if (found) return found.name;
     }
-    return noCollectionLabel;
+    return isTodoType ? 'Unfiled' : noCollectionLabel;
   });
-
-  // Show an explicit "Uncategorized" picker row for refs only when the bucket
-  // already exists (has stragglers). Per the design, Uncategorized is a
-  // dynamic surface that appears when items live there — it shouldn't be a
-  // first-class destination unless it's already populated. Todo capture uses
-  // `undefined` for unfiled; the sentinel is normalized away for todos.
-  const showUncategorizedInPicker = $derived(
-    (!isTodoType && $hasUncategorizedItems)
-    || selectedCollectionId === UNCATEGORIZED_COLLECTION_ID
-  );
 
   // Whether the user has any real grouped collections at all. Todo capture
   // hides the picker entirely when this is false so an empty account can still
@@ -94,7 +80,7 @@
     return false;
   });
 
-  const showCollectionPicker = $derived(shouldShowCollectionPicker(isEdit, type, hasAnyCollection, selectedCollectionId, UNCATEGORIZED_COLLECTION_ID));
+  const showCollectionPicker = $derived(shouldShowCollectionPicker(isEdit, type, hasAnyCollection));
 
   $effect(() => {
     if (!collectionPickerOpen) return;
@@ -385,29 +371,13 @@
         if (editItem!.completedAt) item.completedAt = editItem!.completedAt;
       }
 
-      if (!isEdit && collectionId && collectionId !== UNCATEGORIZED_COLLECTION_ID) {
-        // The Uncategorized sentinel is a picker-level id, not a real
-        // collection id — writing it to `item.collectionId` would leave a
-        // bogus reference in storage. The branch below (selectedCollectionId
-        // === UNCATEGORIZED_COLLECTION_ID) handles the ref Uncategorized case
-        // by setting the `uncategorized` flag and leaving `collectionId` unset.
-        item.collectionId = collectionId;
-      }
-
       // Picker → storage shape:
       //   undefined + ref         → Inbox (default; no flag, no collectionId)
       //   undefined + todo        → unfiled todo (no collectionId, no fake
       //                              collection/group written)
-      //   UNCATEGORIZED_... + ref → Uncategorized (set `uncategorized: true`
-      //                              before storage; no moveItemToCollection
-      //                              call since there's no real collection
-      //                              record to update)
       //   real id                 → assign via moveItemToCollection after storage
-      if (shouldMarkUncategorized(isEdit, type, selectedCollectionId, UNCATEGORIZED_COLLECTION_ID)) {
-        item!.uncategorized = true;
-      }
       await storeItem(item!, fileData);
-      if (selectedCollectionId && selectedCollectionId !== UNCATEGORIZED_COLLECTION_ID && !isEdit) {
+      if (selectedCollectionId && !isEdit) {
         await moveItemToCollection(item!.id, selectedCollectionId);
       }
       onclose();
@@ -794,7 +764,7 @@
                   Default non-collection destination. For refs this is Inbox;
                   for todos this is unfiled so they can be organized later.
                 -->
-                {#if isTodoType && selectedCollectionId !== UNCATEGORIZED_COLLECTION_ID}
+                {#if isTodoType}
                   <button
                     type="button"
                     class="dest-item"
@@ -813,25 +783,6 @@
                   >
                     <span class="dest-dot inbox" aria-hidden="true"></span>
                     {noCollectionLabel}
-                  </button>
-                {/if}
-                {#if showUncategorizedInPicker}
-                  <!--
-                    Explicit "Uncategorized" destination row. Surfaces for:
-                    (a) refs when the bucket already exists, so the user can
-                        file a new ref alongside existing stragglers without
-                        first sending it to the Inbox and moving it; and
-                    (b) legacy/defensive sentinel selections, so the current
-                        selection is visible and reselectable.
-                  -->
-                  <button
-                    type="button"
-                    class="dest-item"
-                    class:selected={selectedCollectionId === UNCATEGORIZED_COLLECTION_ID}
-                    onclick={() => selectCollection(UNCATEGORIZED_COLLECTION_ID)}
-                  >
-                    <span class="dest-dot" style="background: #9ca3af" aria-hidden="true"></span>
-                    {isTodoType ? 'Unfiled' : 'Uncategorized'}
                   </button>
                 {/if}
                 {#each $sortedGroups as group (group.id)}

--- a/packages/web/src/components/CollectionFormModal.svelte
+++ b/packages/web/src/components/CollectionFormModal.svelte
@@ -85,7 +85,7 @@
   bind:color
   showDescription
   bind:description
-  namePlaceholder="e.g. Sockethub Bugs"
+  namePlaceholder="e.g. Reading List"
   descriptionPlaceholder="What's this collection for?"
   maxWidth="440px"
   {onclose}

--- a/packages/web/src/components/CollectionView.svelte
+++ b/packages/web/src/components/CollectionView.svelte
@@ -4,7 +4,7 @@
     collectionItems,
     deleteItem,
     sortedGroups, moveCollectionToGroup,
-    appConfig, updateConfig, reorderCollectionItems, reorderUncategorizedTodos,
+    appConfig, updateConfig, reorderCollectionItems,
     groups,
   } from '../lib/stores';
   import { makeTodo } from '../lib/item-utils';
@@ -16,24 +16,13 @@
   import AddEntryModal from './AddEntryModal.svelte';
   import TodoRow from './TodoRow.svelte';
 
-  let { collection, expanded = false, onselect, onedit, ontoggle, isTouchDevice = false, isVirtual = false }: {
+  let { collection, expanded = false, onselect, onedit, ontoggle, isTouchDevice = false }: {
     collection: Collection;
     expanded?: boolean;
     onselect: (item: InboxItem) => void;
-    /** Called when the edit button is pressed. Ignored when `isVirtual` — the
-        virtual Uncategorized collection has no backing record to edit. */
     onedit: () => void;
     ontoggle: () => void;
     isTouchDevice?: boolean;
-    /**
-     * Render as the virtual Uncategorized bucket: hides edit / move-to-group
-     * affordances, saves newly-added items with `collectionId: undefined`, and
-     * persists todo reordering via `reorderUncategorizedTodos` (which splices
-     * into `todosGlobalOrder`) rather than the collection's own `itemIds`
-     * list. Using the global order key keeps this view and the flat `/todos`
-     * page in sync — both read the same source of truth.
-     */
-    isVirtual?: boolean;
   } = $props();
 
   // Collection body renders both todos (at the top, drag-sortable) and
@@ -101,20 +90,12 @@
     dndOpen = e.detail.items;
     const newOpenIds = dndOpen.map(t => t.id);
     try {
-      if (isVirtual) {
-        // Virtual bucket: there's no collection record to update. Splice the
-        // new uncategorized order back into `todosGlobalOrder` — the same key
-        // the flat `/todos` page reads — so both surfaces stay in sync and
-        // one view's reorder can't be clobbered by the next drag on the other.
-        await reorderUncategorizedTodos(newOpenIds);
-      } else {
-        // Splice the new open-todo order into itemIds while preserving the
-        // relative order of completed todos and reference items — otherwise a
-        // drag of a single open todo would also scramble the refs grid.
-        const openIds = new Set(openTodos.map(t => t.id));
-        const rest = collection.itemIds.filter(id => !openIds.has(id));
-        await reorderCollectionItems(collection.id, [...newOpenIds, ...rest]);
-      }
+      // Splice the new open-todo order into itemIds while preserving the
+      // relative order of completed todos and reference items — otherwise a
+      // drag of a single open todo would also scramble the refs grid.
+      const openIds = new Set(openTodos.map(t => t.id));
+      const rest = collection.itemIds.filter(id => !openIds.has(id));
+      await reorderCollectionItems(collection.id, [...newOpenIds, ...rest]);
     } catch (error) {
       console.error('Failed to reorder collection todos', error);
       dndOpen = previous;
@@ -166,15 +147,13 @@
       {/if}
     </div>
     <div class="header-actions">
-      {#if !isVirtual}
-        <button class="btn-header" onclick={(e) => { e.stopPropagation(); onedit(); }} aria-label="Edit collection" title="Edit">
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
-          </svg>
-        </button>
-      {/if}
-      {#if !isVirtual && availableGroups.length > 0}
+      <button class="btn-header" onclick={(e) => { e.stopPropagation(); onedit(); }} aria-label="Edit collection" title="Edit">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+          <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+        </svg>
+      </button>
+      {#if availableGroups.length > 0}
         <div class="move-menu-wrapper">
           <button class="btn-header" bind:this={moveButtonEl} aria-label="Move to group" aria-haspopup="menu" aria-expanded={showMoveMenu} title="Move to group" onclick={toggleMoveMenu}>
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -277,12 +256,6 @@
         {/if}
       </section>
 
-      <!-- References section renders for the virtual Uncategorized bucket too.
-           "Uncategorized" is AddEntryModal's label for items saved without a
-           collection — users who file a ref as Uncategorized expect to see it
-           here (alongside the Inbox view). AddEntryBar routes through the
-           modal below; when `isVirtual`, we pass `collectionId: undefined` so
-           new refs land back in the uncategorized bucket. -->
       <section class="references-section" aria-label="References in {collection.name}">
         <div class="section-header">
           <h4>References</h4>
@@ -316,12 +289,9 @@
 </div>
 
 {#if addingType}
-  <!-- Virtual bucket: pass `undefined` so the modal stores the new item as
-       uncategorized (no collectionId). Real collections forward their id so
-       items land inside. -->
   <AddEntryModal
     type={addingType}
-    collectionId={isVirtual ? undefined : collection.id}
+    collectionId={collection.id}
     onclose={() => addingType = null}
     ondelete={async (item) => { await deleteItem(item.id, item); addingType = null; }}
   />

--- a/packages/web/src/components/CollectionsPage.svelte
+++ b/packages/web/src/components/CollectionsPage.svelte
@@ -5,7 +5,7 @@
     createCollection, storeCollection, deleteCollection, moveCollectionToGroup,
     visibleGroupedCollections, sortedGroups, storeGroup, deleteGroup,
     appConfig, updateConfig, reorderGroupCollections, setExpandedCollections,
-    collectionItems, groups,
+    collectionItems, groups, orphanCollections,
   } from '../lib/stores';
   import CollectionView from './CollectionView.svelte';
   import GroupSection from './GroupSection.svelte';
@@ -54,9 +54,15 @@
   }
 
   const sections = $derived($visibleGroupedCollections);
+  const orphans = $derived($orphanCollections);
 
   // Collection ids currently visible on the page — used for expand/collapse all.
-  const visibleIds = $derived(sections.flatMap(s => s.collections.map(c => c.id)));
+  // Includes orphans so the toggle covers every collection rendered on the page,
+  // not just the ones inside real groups.
+  const visibleIds = $derived([
+    ...sections.flatMap(s => s.collections.map(c => c.id)),
+    ...orphans.map(c => c.id),
+  ]);
   const anyExpanded = $derived(visibleIds.some(id => expandedSet.has(id)));
 
   async function toggleExpandAll() {
@@ -240,11 +246,67 @@
     </GroupSection>
   {/each}
 
-  {#if $sortedGroups.length === 0 && sections.length === 0}
+  {#if orphans.length > 0}
+    <!--
+      Advisory section for collections whose groupId is unset or points at a
+      deleted group. Read-only by design: no add, no group edit, no drag.
+      Recovery is per-collection via the existing CollectionView affordances
+      (edit modal lets the user pick a real group, move-to-group dropdown
+      does the same, delete works when the collection is empty). The section
+      disappears reactively as soon as the last orphan is reassigned.
+    -->
+    <section
+      class="orphan-section"
+      aria-labelledby="orphan-collections-heading"
+    >
+      <header class="orphan-header">
+        <svg
+          class="orphan-icon"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+          <line x1="12" y1="9" x2="12" y2="13"></line>
+          <line x1="12" y1="17" x2="12.01" y2="17"></line>
+        </svg>
+        <div class="orphan-text">
+          <h2 id="orphan-collections-heading" class="orphan-title">
+            Needs a group
+            <span class="orphan-count" aria-label="{orphans.length} {orphans.length === 1 ? 'collection' : 'collections'}">{orphans.length}</span>
+          </h2>
+          <p class="orphan-subtitle">
+            {orphans.length === 1 ? 'This collection isn\'t' : 'These collections aren\'t'} in any group.
+            Edit {orphans.length === 1 ? 'it' : 'one'} to assign a group, or delete {orphans.length === 1 ? 'it' : 'them'} if no longer needed.
+          </p>
+        </div>
+      </header>
+      <div class="collection-list orphan-list">
+        {#each orphans as col (col.id)}
+          <CollectionView
+            collection={col}
+            expanded={isExpanded(col)}
+            {onselect}
+            {isTouchDevice}
+            onedit={() => editingCollection = col}
+            ontoggle={() => toggleExpand(col)}
+          />
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  {#if $sortedGroups.length === 0 && sections.length === 0 && orphans.length === 0}
     <p class="page-empty">
       No groups yet. Create one from the filter bar above to organise your collections.
     </p>
-  {:else if sections.length === 0}
+  {:else if sections.length === 0 && orphans.length === 0}
     <p class="page-empty">
       All groups are filtered out. Toggle one on in the filter bar to see collections.
     </p>
@@ -345,6 +407,81 @@
     color: var(--text-muted);
     text-align: center;
     margin-top: 1rem;
+  }
+
+  /* Advisory section for orphan collections. Visually distinct from real
+     GroupSections — dashed top border, muted tint, no group color stripe,
+     no group-level controls — so users read it as a recovery surface, not
+     "another bucket" they can put things into. */
+  .orphan-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    margin-top: 0.5rem;
+    padding-top: 0.85rem;
+    border-top: 1px dashed var(--border);
+  }
+
+  .orphan-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.6rem;
+    padding: 0.65rem 0.85rem;
+    background: var(--surface-tint);
+    border-radius: var(--radius-sm);
+  }
+
+  .orphan-icon {
+    flex-shrink: 0;
+    color: var(--text-muted);
+    margin-top: 0.1rem;
+  }
+
+  .orphan-text {
+    flex: 1;
+    min-width: 0;
+  }
+
+  /* Match other section headings in size/weight but stay neutral — this
+     isn't an error, just a hint, so we deliberately avoid --danger here. */
+  .orphan-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text);
+  }
+
+  .orphan-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.4rem;
+    height: 1.4rem;
+    padding: 0 0.4rem;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    background: var(--surface-tint-hover);
+    border-radius: 999px;
+  }
+
+  .orphan-subtitle {
+    margin: 0.2rem 0 0;
+    font-size: 0.82rem;
+    line-height: 1.4;
+    color: var(--text-muted);
+  }
+
+  /* Static stack — no dndzone, no drag handles. The list reuses
+     CollectionView so the per-card edit/move/delete affordances are the
+     same as anywhere else on the page. */
+  .orphan-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
   }
 
   .link {

--- a/packages/web/src/components/CollectionsPage.svelte
+++ b/packages/web/src/components/CollectionsPage.svelte
@@ -5,7 +5,7 @@
     createCollection, storeCollection, deleteCollection, moveCollectionToGroup,
     visibleGroupedCollections, sortedGroups, storeGroup, deleteGroup,
     appConfig, updateConfig, reorderGroupCollections, setExpandedCollections,
-    UNCATEGORIZED_FILTER_ID, collectionItems, groups,
+    collectionItems, groups,
   } from '../lib/stores';
   import CollectionView from './CollectionView.svelte';
   import GroupSection from './GroupSection.svelte';
@@ -56,12 +56,7 @@
   const sections = $derived($visibleGroupedCollections);
 
   // Collection ids currently visible on the page — used for expand/collapse all.
-  // Includes virtual collections (e.g. the Uncategorized bucket) so the toggle
-  // covers everything the user can see, not just rows backed by stored records.
-  const visibleIds = $derived(sections.flatMap(s => [
-    ...(s.virtualCollection ? [s.virtualCollection.id] : []),
-    ...s.collections.map(c => c.id),
-  ]));
+  const visibleIds = $derived(sections.flatMap(s => s.collections.map(c => c.id)));
   const anyExpanded = $derived(visibleIds.some(id => expandedSet.has(id)));
 
   async function toggleExpandAll() {
@@ -114,8 +109,7 @@
   async function handleCreateCollection(col: Collection) {
     try {
       // The modal enforces an explicit group choice, so `col.groupId` is
-      // always a real group id here — we never route through the store's
-      // Uncategorized fallback from this path.
+      // always a real group id here.
       await createCollection(col);
       creatingCollection = false;
       collectionFormGroupId = undefined;
@@ -207,31 +201,12 @@
   </div>
 
   {#each sections as section (section.group.id)}
-    {@const isUncat = section.group.id === UNCATEGORIZED_FILTER_ID}
     {@const realCount = dndByGroup[section.group.id]?.length ?? 0}
     <GroupSection
       group={section.group}
-      onedit={isUncat ? undefined : () => editingGroup = section.group}
-      onaddcollection={isUncat ? undefined : () => openAddCollection(section.group.id)}
+      onedit={() => editingGroup = section.group}
+      onaddcollection={() => openAddCollection(section.group.id)}
     >
-      {#if section.virtualCollection}
-        <!-- Virtual Uncategorized bucket — rendered outside the dndzone since
-             it's not reorderable and has no backing record. Still participates
-             in the page's expand/collapse state so users can scan their
-             uncategorized items at a glance. -->
-        <div class="collection-list">
-          <CollectionView
-            collection={section.virtualCollection}
-            expanded={isExpanded(section.virtualCollection)}
-            {onselect}
-            {isTouchDevice}
-            isVirtual
-            onedit={() => {}}
-            ontoggle={() => toggleExpand(section.virtualCollection!)}
-          />
-        </div>
-      {/if}
-
       {#if realCount > 0}
         <div
           class="collection-list"
@@ -256,7 +231,7 @@
             />
           {/each}
         </div>
-      {:else if !section.virtualCollection}
+      {:else}
         <p class="group-empty">
           No collections in this group yet.
           <button class="link" onclick={() => openAddCollection(section.group.id)}>Add one</button>.

--- a/packages/web/src/components/GroupFilterBar.svelte
+++ b/packages/web/src/components/GroupFilterBar.svelte
@@ -2,8 +2,7 @@
   import { dndzone } from 'svelte-dnd-action';
   import {
     sortedGroups, activeGroupIds, toggleGroupFilter, reorderGroups,
-    uncategorizedFilterActive, toggleUncategorizedFilter,
-    UNCATEGORIZED_FILTER_ID, appConfig, hasUncategorizedItems,
+    appConfig,
   } from '../lib/stores';
 
   let { onaddgroup, dimmed = false }: {
@@ -12,25 +11,14 @@
     dimmed?: boolean;
   } = $props();
 
-  /**
-   * Row shape used by the dnd zone. Both real groups and the virtual
-   * Uncategorized entry share this so drag-reorder, key-based animation,
-   * and the render template all work without any special casing.
-   */
   type FilterPill = {
     id: string;
     name: string;
     color: string;
-    isUncat: boolean;
   };
 
   const groups = $derived($sortedGroups);
   const active = $derived($activeGroupIds);
-  const uncatActive = $derived($uncategorizedFilterActive);
-  const groupsOrder = $derived($appConfig.groupsOrder ?? []);
-  // Uncategorized is a dynamic pill — it appears only when the system has
-  // straggler items to show there. It is not a group or a collection home.
-  const showUncat = $derived($hasUncategorizedItems);
 
   let isTouchDevice = $state(false);
   $effect(() => {
@@ -41,49 +29,12 @@
     return () => mql.removeEventListener('change', handler);
   });
 
-  // Uncategorized is folded into the pill list as a peer of real groups.
-  // Its position is recorded by writing the sentinel id into `groupsOrder`;
-  // `sortedGroups` filters unknown ids out naturally, so no other consumer
-  // needs to know about the sentinel.
-  const uncatPill: FilterPill = {
-    id: UNCATEGORIZED_FILTER_ID,
-    name: 'Uncategorized',
-    color: 'var(--accent)',
-    isUncat: true,
-  };
-
   const pills = $derived.by<FilterPill[]>(() => {
-    const realPills: FilterPill[] = groups.map(g => ({
+    return groups.map(g => ({
       id: g.id,
       name: g.name,
       color: g.color || 'var(--accent)',
-      isUncat: false,
     }));
-    const sentinelIdx = groupsOrder.indexOf(UNCATEGORIZED_FILTER_ID);
-    // If the user has never reordered the pills, default to Uncategorized
-    // at the end — same visual cadence as a newly-created group. Skip the
-    // sentinel when it has nothing to show.
-    if (sentinelIdx < 0) return showUncat ? [...realPills, uncatPill] : realPills;
-
-    // Walk the persisted order and rebuild the list so the sentinel's slot
-    // is preserved relative to the real groups. Any real groups not yet in
-    // `groupsOrder` (e.g. just-created) are appended afterwards.
-    const byId = new Map(realPills.map(p => [p.id, p]));
-    const placed: FilterPill[] = [];
-    const seen = new Set<string>();
-    for (const id of groupsOrder) {
-      if (id === UNCATEGORIZED_FILTER_ID) {
-        if (showUncat) placed.push(uncatPill);
-        seen.add(id);
-      } else if (byId.has(id)) {
-        placed.push(byId.get(id)!);
-        seen.add(id);
-      }
-    }
-    for (const p of realPills) {
-      if (!seen.has(p.id)) placed.push(p);
-    }
-    return placed;
   });
 
   let dndPills = $state<FilterPill[]>([]);
@@ -97,8 +48,6 @@
     const previous = pills.map(p => ({ ...p }));
     dndPills = e.detail.items;
     try {
-      // Persist every id — including the sentinel — so Uncategorized keeps
-      // its slot across reloads alongside the real group order.
       await reorderGroups(dndPills.map(p => p.id));
     } catch (error) {
       console.error('Failed to reorder filter pills', error);
@@ -109,21 +58,18 @@
   async function handleToggle(e: Event, pill: FilterPill) {
     e.preventDefault();
     try {
-      if (pill.isUncat) await toggleUncategorizedFilter();
-      else await toggleGroupFilter(pill.id);
+      await toggleGroupFilter(pill.id);
     } catch (error) {
       console.error('Failed to toggle filter pill', error);
     }
   }
 
   function isPillActive(pill: FilterPill): boolean {
-    return pill.isUncat ? uncatActive : active.has(pill.id);
+    return active.has(pill.id);
   }
 </script>
 
 <div class="filter-bar" class:dimmed role="toolbar" aria-label="Filters">
-  <!-- Single dnd zone: real groups and Uncategorized are the same shape and
-       participate in the same drag-sort flow. No divider, no special slot. -->
   <div
     class="pills"
     use:dndzone={{

--- a/packages/web/src/components/GroupSection.svelte
+++ b/packages/web/src/components/GroupSection.svelte
@@ -4,9 +4,7 @@
 
   let { group, onedit, onaddcollection = undefined, children }: {
     group: CollectionGroup;
-    /** Omit for virtual groups (e.g. the Uncategorized section) that have no
-        editable backing record — the edit button is hidden when this is
-        undefined. */
+    /** Omit to hide the edit button. */
     onedit?: () => void;
     onaddcollection?: () => void;
     children: Snippet;

--- a/packages/web/src/components/InboxGrid.svelte
+++ b/packages/web/src/components/InboxGrid.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
   import type { InboxItem } from '@inbox-rs/rs-module';
-  import { sortedItems } from '../lib/stores';
+  import { connected, sortedItems } from '../lib/stores';
   import InboxCard from './InboxCard.svelte';
 
-  let { onselect }: { onselect: (item: InboxItem) => void } = $props();
+  let {
+    onselect,
+    onconnect,
+  }: {
+    onselect: (item: InboxItem) => void;
+    onconnect: () => void;
+  } = $props();
   const items = $derived($sortedItems);
 
 </script>
@@ -17,7 +23,14 @@
       </svg>
     </div>
     <h2 class="zero-heading">Inbox zero</h2>
-    <p class="zero-sub">You're all caught up. Nothing to process.</p>
+    {#if $connected}
+      <p class="zero-sub">You're all caught up. Nothing to process.</p>
+    {:else}
+      <p class="zero-sub">
+        <button class="connect-link" type="button" onclick={onconnect}>Connect to your remoteStorage</button>
+        to sync your inbox across devices.
+      </p>
+    {/if}
   </div>
 {:else}
   <div class="status-bar">You've got <span class="status-count">{items.length}</span> {items.length === 1 ? 'thing' : 'things'} waiting</div>
@@ -113,6 +126,30 @@
     font-size: 0.95rem;
     color: var(--text-muted);
     animation: fade-in 0.6s ease-out 0.2s both;
+  }
+
+  .connect-link {
+    display: inline;
+    border: 0;
+    background: none;
+    color: var(--accent);
+    font: inherit;
+    font-weight: 600;
+    padding: 0;
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.16em;
+  }
+
+  .connect-link:hover {
+    color: var(--accent-hover);
+  }
+
+  .connect-link:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+    border-radius: 2px;
   }
 
   @keyframes fade-in {

--- a/packages/web/src/components/TodoRow.svelte
+++ b/packages/web/src/components/TodoRow.svelte
@@ -1,23 +1,20 @@
 <script lang="ts">
   import type { InboxItem, Collection, CollectionGroup } from '@inbox-rs/rs-module';
-  import { storeItem, UNCATEGORIZED_COLLECTION_ID } from '../lib/stores';
+  import { storeItem } from '../lib/stores';
   import { cleanForStorage } from '../lib/clean-for-storage';
   import { typeIconPath } from '../lib/item-utils';
 
   let { todo, collection, group, onselect, onaddincollection }: {
     todo: InboxItem;
-    /** The collection this todo belongs to, or null for uncategorized. */
+    /** The collection this todo belongs to, or null when unfiled. */
     collection: Collection | null;
-    /** The group the collection belongs to, or null if ungrouped / uncategorized. */
+    /** The group the collection belongs to, or null when unfiled. */
     group: CollectionGroup | null;
     onselect: (item: InboxItem) => void;
     /** Optional quick-add handler: opens the add-todo modal pre-targeted at
-        this row's collection. Uncategorized rows send the
-        `UNCATEGORIZED_COLLECTION_ID` sentinel so the modal knows to route the
-        follow-up into Uncategorized rather than falling back to the last
-        selected / first real collection. Omit the handler to hide the
-        affordance. */
-    onaddincollection?: (collectionId: string) => void;
+        this row's collection. Unfiled rows pass `undefined` so the follow-up
+        stays unfiled too. Omit the handler to hide the affordance. */
+    onaddincollection?: (collectionId: string | undefined) => void;
   } = $props();
 
   // Show the underlying item type as an icon for items that are "todos by flag"
@@ -26,10 +23,9 @@
   const showTypeIcon = $derived(todo.type !== 'todo');
   const typeLabel = $derived(todo.type.charAt(0).toUpperCase() + todo.type.slice(1));
   const typeIconSvg = $derived(typeIconPath(todo.type));
-  // TodoRow only renders todos, and todos without a collection always belong
-  // to the Uncategorized bucket — the Inbox is refs-only, so "Inbox" is never
-  // a valid label here (see stores.ts bucket semantics).
-  const collectionName = $derived(collection?.name ?? 'Uncategorized');
+  // TodoRow only renders todos. A todo without a collection is unfiled and can
+  // be organized later.
+  const collectionName = $derived(collection?.name ?? 'Unfiled');
   // Group and collection colours are exposed as separate CSS custom properties
   // so hierarchy is legible at a glance: the pill border and row hover tint
   // take the *group* colour, and the pill dot takes the *collection* colour.
@@ -38,7 +34,7 @@
   // without reading the name. Missing colours degrade to text-muted.
   const groupColor = $derived(group?.color || 'var(--text-muted)');
   const collectionColor = $derived(collection?.color || 'var(--text-muted)');
-  const isUncategorized = $derived(!collection);
+  const isUnfiled = $derived(!collection);
 
   // Human-friendly relative date — "today", "yesterday", "3d ago", or the date.
   // Designed to fit in the horizontal toolbar without wrapping on desktop.
@@ -77,12 +73,7 @@
     onselect(todo);
   }
 
-  // Uncategorized rows send the sentinel so the modal routes the follow-up
-  // into Uncategorized. Passing `undefined` would fall through to the
-  // last-selected / first-real-collection cascade in pickInitialCollectionId,
-  // which creates the new todo in an unrelated bucket — not what the user
-  // meant when they clicked "+" on an uncategorized row.
-  const quickAddTarget = $derived(todo.collectionId ?? UNCATEGORIZED_COLLECTION_ID);
+  const quickAddTarget = $derived(todo.collectionId);
 
   function handleQuickAdd(e: Event) {
     e.stopPropagation();
@@ -116,7 +107,7 @@
 <li
   class="todo-row"
   class:completed={todo.completed}
-  class:uncategorized={isUncategorized}
+  class:unfiled={isUnfiled}
   role="button"
   tabindex="0"
   onclick={handleClick}
@@ -251,7 +242,7 @@
     min-width: 0;
   }
 
-  .uncategorized .collection-pill {
+  .unfiled .collection-pill {
     border-style: dashed;
   }
 

--- a/packages/web/src/components/TodosPage.svelte
+++ b/packages/web/src/components/TodosPage.svelte
@@ -63,6 +63,13 @@
     }
   }
 
+  // Clear any stale error as soon as the user edits the input — they've
+  // acknowledged it and are taking another swing.
+  $effect(() => {
+    quickTitle;
+    if (quickError) quickError = '';
+  });
+
   $effect(() => {
     const mql = window.matchMedia('(pointer: coarse)');
     isTouchDevice = mql.matches;
@@ -154,9 +161,10 @@
         </button>
       </form>
       <p class="empty-hint">Capture it now. Organize it later.</p>
-      {#if quickError}
-        <p class="quick-error" aria-live="polite">{quickError}</p>
-      {/if}
+      <!-- Persistent aria-live region — kept in the DOM so screen readers
+           reliably announce errors as they appear. The visually-empty state
+           collapses via the `:empty` selector below. -->
+      <p class="quick-error" role="status" aria-live="polite">{quickError}</p>
     </div>
   {:else}
     <ul
@@ -387,6 +395,12 @@
     margin: 0;
     color: var(--danger);
     font-size: 0.82rem;
+  }
+
+  /* Collapse the live region visually when there's no message — the element
+     stays mounted so screen readers keep tracking it. */
+  .quick-error:empty {
+    display: none;
   }
 
   /* Mobile-only: reserve room so the fixed-position FAB doesn't float over

--- a/packages/web/src/components/TodosPage.svelte
+++ b/packages/web/src/components/TodosPage.svelte
@@ -4,20 +4,20 @@
   import { flip } from 'svelte/animate';
   import { slide, fade } from 'svelte/transition';
   import {
-    visibleTodos, reorderTodosGlobal,
+    visibleTodos, reorderTodosGlobal, storeItem,
     collections, sortedGroups, appConfig, updateConfig,
   } from '../lib/stores';
+  import { canCaptureTodo, makeUnfiledTodo } from '../lib/add-entry-modal';
   import TodoRow from './TodoRow.svelte';
   import Fab from './Fab.svelte';
 
   let { onselect, onaddtodo, onaddtodoincollection }: {
     onselect: (item: InboxItem) => void;
-    /** Opens the add-todo modal; the modal's built-in collection picker lets
-        the user place the new todo anywhere (including uncategorized). */
+    /** Opens the add-todo modal for richer details and optional filing. */
     onaddtodo: () => void;
     /** Opens the add-todo modal with a specific collection pre-selected.
         Used by the per-row quick-add affordance. Pass `undefined` to target
-        the "Uncategorized" bucket. */
+        an unfiled todo. */
     onaddtodoincollection: (collectionId: string | undefined) => void;
   } = $props();
 
@@ -44,6 +44,25 @@
   const completedExpanded = $derived($appConfig.completedTodosExpanded === true);
 
   let isTouchDevice = $state(false);
+  let quickTitle = $state('');
+  let quickSaving = $state(false);
+  let quickError = $state('');
+
+  async function addQuickTodo() {
+    if (!canCaptureTodo(quickTitle) || quickSaving) return;
+    quickSaving = true;
+    quickError = '';
+    try {
+      await storeItem(makeUnfiledTodo(quickTitle));
+      quickTitle = '';
+    } catch (error) {
+      console.error('Failed to add todo', error);
+      quickError = error instanceof Error ? error.message : 'Failed to add todo';
+    } finally {
+      quickSaving = false;
+    }
+  }
+
   $effect(() => {
     const mql = window.matchMedia('(pointer: coarse)');
     isTouchDevice = mql.matches;
@@ -115,9 +134,29 @@
 
   {#if openTodos.length === 0 && completedTodos.length === 0}
     <div class="empty-state" in:fade={{ duration: 180 }}>
-      <div class="empty-icon" aria-hidden="true">✓</div>
-      <p class="empty-title">Nothing to do.</p>
-      <p class="empty-hint">Tap <strong>+ New todo</strong> to add one — you can pick a collection or leave it in your inbox.</p>
+      <p class="empty-title">Jot a todo</p>
+      <form
+        class="quick-add"
+        onsubmit={(e) => {
+          e.preventDefault();
+          addQuickTodo();
+        }}
+      >
+        <input
+          type="text"
+          bind:value={quickTitle}
+          placeholder="What needs doing?"
+          aria-label="Todo title"
+          disabled={quickSaving}
+        />
+        <button type="submit" disabled={!canCaptureTodo(quickTitle) || quickSaving}>
+          {quickSaving ? 'Adding...' : 'Add'}
+        </button>
+      </form>
+      <p class="empty-hint">Capture it now. Organize it later.</p>
+      {#if quickError}
+        <p class="quick-error" aria-live="polite">{quickError}</p>
+      {/if}
     </div>
   {:else}
     <ul
@@ -264,26 +303,15 @@
     transform: rotate(0);
   }
 
-  /* Empty state mirrors the inbox empty state visually so the Todos page
-     doesn't feel jarringly different when users land on it with nothing to
-     do. */
   .empty-state {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 0.35rem;
+    gap: 0.75rem;
     padding: 3rem 1rem;
     text-align: center;
     color: var(--text-muted);
-  }
-
-  .empty-icon {
-    font-size: 2.5rem;
-    line-height: 1;
-    margin-bottom: 0.5rem;
-    color: var(--accent);
-    opacity: 0.6;
   }
 
   .empty-title {
@@ -293,10 +321,72 @@
     margin: 0;
   }
 
+  .quick-add {
+    width: min(100%, 34rem);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .quick-add input {
+    min-height: 2.75rem;
+    min-width: 0;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    padding: 0 0.9rem;
+    font: inherit;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+    transition: border-color 150ms, box-shadow 150ms;
+  }
+
+  .quick-add input:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
+  }
+
+  .quick-add button {
+    min-height: 2.75rem;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: var(--accent);
+    color: white;
+    padding: 0 1rem;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 150ms, transform 150ms, box-shadow 150ms;
+  }
+
+  .quick-add button:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
+  }
+
+  .quick-add button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+  }
+
+  .quick-add button:disabled,
+  .quick-add input:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
   .empty-hint {
     font-size: 0.85rem;
     max-width: 32rem;
     margin: 0;
+  }
+
+  .quick-error {
+    margin: 0;
+    color: var(--danger);
+    font-size: 0.82rem;
   }
 
   /* Mobile-only: reserve room so the fixed-position FAB doesn't float over
@@ -311,6 +401,20 @@
   @media (max-width: 600px) {
     .todos-page {
       padding-bottom: 4.5rem;
+    }
+
+    .empty-state {
+      align-items: stretch;
+      text-align: left;
+      padding-inline: 0;
+    }
+
+    .quick-add {
+      grid-template-columns: 1fr;
+    }
+
+    .quick-add button {
+      width: 100%;
     }
   }
 </style>

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -10,6 +10,7 @@
   let editingAbbrev = $state(false);
   let abbrevInput = $state('');
   let abbrevInputEl = $state<HTMLInputElement | null>(null);
+  let connectInputEl = $state<HTMLInputElement | null>(null);
   let importExportModal = $state<ReturnType<typeof ImportExportModal>>();
   let importExportOpen = $state(false);
   let fileInputEl = $state<HTMLInputElement | null>(null);
@@ -51,6 +52,17 @@
     open = !open;
   }
 
+  async function focusConnectInput() {
+    if ($connected) return;
+    await tick();
+    connectInputEl?.focus();
+  }
+
+  export async function openConnectMenu() {
+    open = true;
+    await focusConnectInput();
+  }
+
   function closeMenu(e: MouseEvent) {
     const target = e.target as HTMLElement;
     if (!target.closest('.user-menu')) {
@@ -66,6 +78,7 @@
     if (open) {
       document.addEventListener('click', closeMenu, true);
       document.addEventListener('keydown', handleKeydown, true);
+      void focusConnectInput();
     }
     return () => {
       document.removeEventListener('click', closeMenu, true);
@@ -91,6 +104,12 @@
 
   $effect(() => {
     if ($connected) connecting = false;
+  });
+
+  $effect(() => {
+    if (!$connected && !inputAddress && $userAddress) {
+      inputAddress = $userAddress;
+    }
   });
 
   const atIdx = $derived($userAddress.indexOf('@'));
@@ -233,6 +252,7 @@
         <form class="connect-form" onsubmit={(e) => { e.preventDefault(); handleConnect(); }}>
           <input
             type="text"
+            bind:this={connectInputEl}
             bind:value={inputAddress}
             placeholder="user@storage.example"
             disabled={connecting}

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { untrack, onDestroy } from 'svelte';
   import type { InboxItem } from '@inbox-rs/rs-module';
-  import { deleteItem, storeItem, blobUrls, connected, sortedGroups, groupCollections, moveItemToCollection, loadFileBlobUrl, hasUncategorizedItems } from '../lib/stores';
+  import { deleteItem, storeItem, blobUrls, connected, sortedGroups, groupCollections, moveItemToCollection, loadFileBlobUrl } from '../lib/stores';
   import rs from '../lib/rs';
   import { transcribeAudio } from '../lib/transcribe';
   import ShareButton from './ShareButton.svelte';
@@ -23,10 +23,9 @@
   let moveButtonEl = $state<HTMLButtonElement | null>(null);
   let dropdownStyle = $state('');
 
-  // "Make Todo" forces the user to choose a collection up-front — a loose
-  // todo sitting in the Inbox/Uncategorized bucket is almost always an
-  // unintended leak. The picker reuses the move-dropdown styling so it
-  // looks and behaves identically to the existing move affordance.
+  // "Make Todo" can file into a collection when one exists. Without a
+  // collection choice, converted todos stay unfiled and appear on the Todos
+  // page without creating any organization.
   let showMakeTodoMenu = $state(false);
   let makeTodoButtonEl = $state<HTMLButtonElement | null>(null);
   let makeTodoDropdownStyle = $state('');
@@ -137,13 +136,23 @@
 
   let convertingTodo = $state(false);
 
-  /**
-   * Promote the current item to a todo and file it into the chosen collection
-   * atomically. We always route through a collection — loose todos (no
-   * collection) tend to be accidental leaks, so the Make Todo flow now
-   * surfaces an inline collection picker rather than silently dropping the
-   * new todo into Uncategorized.
-   */
+  /** Promote the current item to an unfiled todo. */
+  async function convertToUnfiledTodo() {
+    convertingTodo = true;
+    try {
+      const { completedAt: _, ...rest } = item;
+      await moveItemToCollection(item.id, undefined);
+      const updated = { ...rest, isTodo: true, completed: false };
+      delete (updated as any).collectionId;
+      await storeItem(updated as InboxItem);
+      closeMakeTodoMenu();
+      onclose();
+    } finally {
+      convertingTodo = false;
+    }
+  }
+
+  /** Promote the current item to a todo and file it into the chosen collection. */
   async function convertToTodoInCollection(collectionId: string) {
     convertingTodo = true;
     try {
@@ -163,9 +172,6 @@
       // Now flip the todo flags. storeItem only touches the item doc — the
       // itemIds arrays are already reconciled by the move above.
       const updated = { ...rest, isTodo: true, completed: false, collectionId };
-      // Moving into a real collection should clear any Uncategorized marker
-      // so the item doesn't simultaneously appear in both places.
-      delete (updated as any).uncategorized;
       await storeItem(updated as InboxItem);
       closeMakeTodoMenu();
       onclose();
@@ -176,25 +182,6 @@
 
   const canMakeTodo = $derived(item.type !== 'todo' && !item.isTodo);
   const canMakeRef = $derived(item.isTodo || item.type === 'todo');
-
-  // True when the item already lives in the Uncategorized bucket: a todo without
-  // a collection (todos can't be in the Inbox), or a reference flagged with
-  // `uncategorized: true`. Items in this state shouldn't see an "Uncategorized"
-  // move option — it would be a no-op.
-  const isInUncategorized = $derived(
-    !item.collectionId && (item.uncategorized === true || item.isTodo || item.type === 'todo')
-  );
-
-  // Show the "Uncategorized" entry in the move dropdown when:
-  //   - the item is in a real collection (preserves the existing "remove from
-  //     collection" affordance — items leaving a collection always land in
-  //     Uncategorized rather than the Inbox), OR
-  //   - Uncategorized already exists (has stragglers), so an Inbox ref can be
-  //     filed alongside them. Per design, Uncategorized isn't a first-class
-  //     destination unless it already exists.
-  const showUncategorizedOption = $derived(
-    !isInUncategorized && (!!item.collectionId || $hasUncategorizedItems)
-  );
 
   function toggleMoveMenu() {
     // Only one picker can be open at a time — close Make Todo if it's open
@@ -235,8 +222,7 @@
   // ── Make Todo menu ─────────────────────────────────────────────────────
   // Mirrors the Move menu pattern so the two dropdowns feel identical.
   // Kept as a parallel menu (rather than collapsed into a single generic
-  // picker) to keep the option list semantics crystal clear: Move can send
-  // items to Uncategorized, Make Todo can't.
+  // picker) to keep the option list semantics crystal clear.
 
   function toggleMakeTodoMenu() {
     if (showMoveMenu) closeMoveMenu();
@@ -613,7 +599,14 @@
         onclick={() => closeMakeTodoMenu()}
       ></button>
       <div class="move-dropdown make-todo-dropdown" style={makeTodoDropdownStyle} role="listbox" aria-label="Choose a collection for this todo">
-        <div class="picker-title">Pick a collection</div>
+        <div class="picker-title">File todo</div>
+        <button class="move-option" onclick={convertToUnfiledTodo} disabled={convertingTodo}>
+          <span class="move-dot" style="background: #9ca3af"></span>
+          Unfiled
+        </button>
+        {#if $sortedGroups.some((g) => ($groupCollections[g.id] ?? []).length > 0)}
+          <div class="move-divider"></div>
+        {/if}
         {#each $sortedGroups as group (group.id)}
           {#each ($groupCollections[group.id] ?? []) as col (col.id)}
             <button class="move-option" onclick={() => convertToTodoInCollection(col.id)} disabled={convertingTodo}>
@@ -622,12 +615,6 @@
             </button>
           {/each}
         {/each}
-        {#if $sortedGroups.every((g) => ($groupCollections[g.id] ?? []).length === 0)}
-          <!-- No real collections yet — guide the user instead of silently
-               allowing an Uncategorized-only choice, which would undo the
-               point of this forced-picker flow. -->
-          <div class="move-empty">Create a collection first to file this todo.</div>
-        {/if}
       </div>
     {/if}
 
@@ -640,10 +627,10 @@
         onclick={() => closeMoveMenu()}
       ></button>
       <div class="move-dropdown" style={dropdownStyle}>
-        {#if showUncategorizedOption}
+        {#if item.collectionId}
           <button class="move-option" onclick={() => { moveItemToCollection(item.id, undefined).catch(e => console.error('Move failed:', e)); closeMoveMenu(); onclose(); }}>
             <span class="move-dot" style="background: #9ca3af"></span>
-            Uncategorized
+            {item.isTodo || item.type === 'todo' ? 'Unfile' : 'Inbox'}
           </button>
           <div class="move-divider"></div>
         {/if}

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -135,10 +135,14 @@
   }
 
   let convertingTodo = $state(false);
+  // Surface conversion failures inline. Both Make-Todo paths share this so
+  // either flow can announce its error in the same dropdown.
+  let convertError = $state('');
 
   /** Promote the current item to an unfiled todo. */
   async function convertToUnfiledTodo() {
     convertingTodo = true;
+    convertError = '';
     try {
       const { completedAt: _, ...rest } = item;
       await moveItemToCollection(item.id, undefined);
@@ -147,6 +151,9 @@
       await storeItem(updated as InboxItem);
       closeMakeTodoMenu();
       onclose();
+    } catch (error) {
+      console.error('Failed to convert to unfiled todo', error);
+      convertError = error instanceof Error ? error.message : 'Failed to convert to todo';
     } finally {
       convertingTodo = false;
     }
@@ -155,6 +162,7 @@
   /** Promote the current item to a todo and file it into the chosen collection. */
   async function convertToTodoInCollection(collectionId: string) {
     convertingTodo = true;
+    convertError = '';
     try {
       // Snapshot the rest of the item BEFORE we do any writes — once we move
       // the item, the store reflects the new collectionId and the prop might
@@ -175,6 +183,9 @@
       await storeItem(updated as InboxItem);
       closeMakeTodoMenu();
       onclose();
+    } catch (error) {
+      console.error('Failed to convert to todo', error);
+      convertError = error instanceof Error ? error.message : 'Failed to convert to todo';
     } finally {
       convertingTodo = false;
     }
@@ -600,6 +611,9 @@
       ></button>
       <div class="move-dropdown make-todo-dropdown" style={makeTodoDropdownStyle} role="listbox" aria-label="Choose a collection for this todo">
         <div class="picker-title">File todo</div>
+        {#if convertError}
+          <p class="move-error" role="status" aria-live="polite">{convertError}</p>
+        {/if}
         <button class="move-option" onclick={convertToUnfiledTodo} disabled={convertingTodo}>
           <span class="move-dot" style="background: #9ca3af"></span>
           Unfiled
@@ -1153,5 +1167,12 @@
     padding: 0.4rem 0.5rem;
     font-size: 0.8rem;
     color: var(--text-muted);
+  }
+
+  .move-error {
+    margin: 0 0.2rem 0.4rem;
+    padding: 0.4rem 0.5rem;
+    font-size: 0.8rem;
+    color: var(--danger);
   }
 </style>

--- a/packages/web/src/lib/add-entry-modal.test.ts
+++ b/packages/web/src/lib/add-entry-modal.test.ts
@@ -4,8 +4,6 @@ import {
   canCaptureTodo,
   loadMarkdownEditorComponent,
   makeUnfiledTodo,
-  normalizeInitialCollectionId,
-  shouldMarkUncategorized,
   shouldLoadMarkdownEditor,
   shouldShowCollectionPicker,
   shouldSubmitAddEntryForm,
@@ -88,28 +86,15 @@ describe('todo capture helpers', () => {
 });
 
 describe('collection picker todo capture rules', () => {
-  const uncatId = '__uncategorized_collection';
-
   it('hides the optional file picker for new todos when no real collections exist', () => {
-    expect(shouldShowCollectionPicker(false, 'todo', false, undefined, uncatId)).toBe(false);
+    expect(shouldShowCollectionPicker(false, 'todo', false)).toBe(false);
   });
 
   it('shows the optional file picker for new todos when real collections exist', () => {
-    expect(shouldShowCollectionPicker(false, 'todo', true, undefined, uncatId)).toBe(true);
+    expect(shouldShowCollectionPicker(false, 'todo', true)).toBe(true);
   });
 
   it('keeps the collection picker visible for non-todo refs', () => {
-    expect(shouldShowCollectionPicker(false, 'note', false, undefined, uncatId)).toBe(true);
-  });
-
-  it('does not mark unfiled todos with the ref-only uncategorized flag', () => {
-    expect(shouldMarkUncategorized(false, 'todo', uncatId, uncatId)).toBe(false);
-    expect(shouldMarkUncategorized(false, 'note', uncatId, uncatId)).toBe(true);
-  });
-
-  it('normalizes the virtual uncategorized sentinel away for todo capture', () => {
-    expect(normalizeInitialCollectionId('todo', uncatId, uncatId)).toBeUndefined();
-    expect(normalizeInitialCollectionId('note', uncatId, uncatId)).toBe(uncatId);
-    expect(normalizeInitialCollectionId('todo', 'real-collection', uncatId)).toBe('real-collection');
+    expect(shouldShowCollectionPicker(false, 'note', false)).toBe(true);
   });
 });

--- a/packages/web/src/lib/add-entry-modal.test.ts
+++ b/packages/web/src/lib/add-entry-modal.test.ts
@@ -1,6 +1,15 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
-import { loadMarkdownEditorComponent, shouldLoadMarkdownEditor, shouldSubmitAddEntryForm } from './add-entry-modal';
+import {
+  canCaptureTodo,
+  loadMarkdownEditorComponent,
+  makeUnfiledTodo,
+  normalizeInitialCollectionId,
+  shouldMarkUncategorized,
+  shouldLoadMarkdownEditor,
+  shouldShowCollectionPicker,
+  shouldSubmitAddEntryForm,
+} from './add-entry-modal';
 
 describe('shouldSubmitAddEntryForm', () => {
   it('submits from text-like inputs including bookmark url fields', () => {
@@ -53,5 +62,54 @@ describe('shouldLoadMarkdownEditor', () => {
   it('does not reload after success or failure', () => {
     expect(shouldLoadMarkdownEditor('note', 'visual', true, false)).toBe(false);
     expect(shouldLoadMarkdownEditor('note', 'visual', false, true)).toBe(false);
+  });
+});
+
+describe('todo capture helpers', () => {
+  it('allows todo capture with a title only', () => {
+    expect(canCaptureTodo('Buy milk')).toBe(true);
+    expect(canCaptureTodo('  Buy milk  ')).toBe(true);
+    expect(canCaptureTodo('   ')).toBe(false);
+  });
+
+  it('creates an unfiled todo without a collection id', () => {
+    const todo = makeUnfiledTodo('  Write draft  ', new Date('2026-04-25T12:00:00.000Z'), 'todo-1');
+
+    expect(todo).toEqual({
+      id: 'todo-1',
+      type: 'todo',
+      title: 'Write draft',
+      createdAt: '2026-04-25T12:00:00.000Z',
+      completed: false,
+      isTodo: true,
+    });
+    expect('collectionId' in todo).toBe(false);
+  });
+});
+
+describe('collection picker todo capture rules', () => {
+  const uncatId = '__uncategorized_collection';
+
+  it('hides the optional file picker for new todos when no real collections exist', () => {
+    expect(shouldShowCollectionPicker(false, 'todo', false, undefined, uncatId)).toBe(false);
+  });
+
+  it('shows the optional file picker for new todos when real collections exist', () => {
+    expect(shouldShowCollectionPicker(false, 'todo', true, undefined, uncatId)).toBe(true);
+  });
+
+  it('keeps the collection picker visible for non-todo refs', () => {
+    expect(shouldShowCollectionPicker(false, 'note', false, undefined, uncatId)).toBe(true);
+  });
+
+  it('does not mark unfiled todos with the ref-only uncategorized flag', () => {
+    expect(shouldMarkUncategorized(false, 'todo', uncatId, uncatId)).toBe(false);
+    expect(shouldMarkUncategorized(false, 'note', uncatId, uncatId)).toBe(true);
+  });
+
+  it('normalizes the virtual uncategorized sentinel away for todo capture', () => {
+    expect(normalizeInitialCollectionId('todo', uncatId, uncatId)).toBeUndefined();
+    expect(normalizeInitialCollectionId('note', uncatId, uncatId)).toBe(uncatId);
+    expect(normalizeInitialCollectionId('todo', 'real-collection', uncatId)).toBe('real-collection');
   });
 });

--- a/packages/web/src/lib/add-entry-modal.ts
+++ b/packages/web/src/lib/add-entry-modal.ts
@@ -1,5 +1,5 @@
 import type { Component } from 'svelte';
-import type { InboxItem, InboxItemType } from '@inbox-rs/rs-module';
+import type { InboxItemType, TodoItem } from '@inbox-rs/rs-module';
 
 const SUBMITTABLE_INPUT_TYPES = new Set(['text', 'url', 'email', 'search', 'tel']);
 
@@ -41,7 +41,7 @@ export function makeUnfiledTodo(
   title: string,
   now: Date = new Date(),
   id: string = crypto.randomUUID(),
-): InboxItem {
+): TodoItem {
   return {
     id,
     type: 'todo',
@@ -52,30 +52,10 @@ export function makeUnfiledTodo(
   };
 }
 
-export function normalizeInitialCollectionId(
-  type: InboxItemType,
-  collectionId: string | undefined,
-  uncategorizedCollectionId: string,
-): string | undefined {
-  if (type === 'todo' && collectionId === uncategorizedCollectionId) return undefined;
-  return collectionId;
-}
-
 export function shouldShowCollectionPicker(
   isEdit: boolean,
   type: InboxItemType,
   hasAnyCollection: boolean,
-  selectedCollectionId: string | undefined,
-  uncategorizedCollectionId: string,
 ): boolean {
-  return !isEdit && (type !== 'todo' || hasAnyCollection || selectedCollectionId === uncategorizedCollectionId);
-}
-
-export function shouldMarkUncategorized(
-  isEdit: boolean,
-  type: InboxItemType,
-  selectedCollectionId: string | undefined,
-  uncategorizedCollectionId: string,
-): boolean {
-  return !isEdit && type !== 'todo' && selectedCollectionId === uncategorizedCollectionId;
+  return !isEdit && (type !== 'todo' || hasAnyCollection);
 }

--- a/packages/web/src/lib/add-entry-modal.ts
+++ b/packages/web/src/lib/add-entry-modal.ts
@@ -1,5 +1,5 @@
 import type { Component } from 'svelte';
-import type { InboxItemType } from '@inbox-rs/rs-module';
+import type { InboxItem, InboxItemType } from '@inbox-rs/rs-module';
 
 const SUBMITTABLE_INPUT_TYPES = new Set(['text', 'url', 'email', 'search', 'tel']);
 
@@ -31,4 +31,51 @@ export function shouldLoadMarkdownEditor(
   loadError: boolean,
 ): boolean {
   return type === 'note' && mode === 'visual' && !componentLoaded && !loadError;
+}
+
+export function canCaptureTodo(title: string): boolean {
+  return title.trim().length > 0;
+}
+
+export function makeUnfiledTodo(
+  title: string,
+  now: Date = new Date(),
+  id: string = crypto.randomUUID(),
+): InboxItem {
+  return {
+    id,
+    type: 'todo',
+    title: title.trim(),
+    createdAt: now.toISOString(),
+    completed: false,
+    isTodo: true,
+  };
+}
+
+export function normalizeInitialCollectionId(
+  type: InboxItemType,
+  collectionId: string | undefined,
+  uncategorizedCollectionId: string,
+): string | undefined {
+  if (type === 'todo' && collectionId === uncategorizedCollectionId) return undefined;
+  return collectionId;
+}
+
+export function shouldShowCollectionPicker(
+  isEdit: boolean,
+  type: InboxItemType,
+  hasAnyCollection: boolean,
+  selectedCollectionId: string | undefined,
+  uncategorizedCollectionId: string,
+): boolean {
+  return !isEdit && (type !== 'todo' || hasAnyCollection || selectedCollectionId === uncategorizedCollectionId);
+}
+
+export function shouldMarkUncategorized(
+  isEdit: boolean,
+  type: InboxItemType,
+  selectedCollectionId: string | undefined,
+  uncategorizedCollectionId: string,
+): boolean {
+  return !isEdit && type !== 'todo' && selectedCollectionId === uncategorizedCollectionId;
 }

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -54,15 +54,12 @@ import {
   deleteGroup, appConfig,
   storeCollection, createCollection, deleteCollection,
   storeItem,
-  reorderGroupCollections, items, todoItems, reorderUncategorizedTodos, pendingMigrationCount,
+  reorderGroupCollections, items, todoItems, reorderUnfiledTodos, pendingMigrationCount,
   moveItemToCollection,
   collectionItems, userSettings,
   activeGroupIds, visibleGroupedCollections,
   toggleGroupFilter, setActiveGroupFilters, storeGroup,
   allTodos, openTodos, visibleTodos, reorderTodosGlobal,
-  uncategorizedFilterActive, toggleUncategorizedFilter,
-  UNCATEGORIZED_FILTER_ID,
-  UNCATEGORIZED_COLLECTION_ID, uncategorizedVirtualCollection,
 } from './stores';
 import type { Collection, CollectionGroup, InboxItem } from '@inbox-rs/rs-module';
 
@@ -435,7 +432,7 @@ describe('todoItems ordering', () => {
     expect(get(todoItems).map(todo => todo.id)).toEqual(['open', 'done-newer', 'done-older']);
   });
 
-  it('persists reordered uncategorized todo ids into todosGlobalOrder', async () => {
+  it('persists reordered unfiled todo ids into todosGlobalOrder', async () => {
     appConfig.set({});
     items.set({
       t1: makeTodo('t1'),
@@ -443,17 +440,17 @@ describe('todoItems ordering', () => {
       t3: makeTodo('t3'),
     });
 
-    await reorderUncategorizedTodos(['t3', 't1', 't2']);
+    await reorderUnfiledTodos(['t3', 't1', 't2']);
 
     expect(get(appConfig).todosGlobalOrder).toEqual(['t3', 't1', 't2']);
     expect(mockInbox.setConfig).toHaveBeenCalledWith({ todosGlobalOrder: ['t3', 't1', 't2'] });
   });
 
-  it('splices uncategorized reorders into todosGlobalOrder without moving categorized todos', async () => {
-    // Two categorized todos (c1, c2) flanking three uncategorized (u1, u2, u3).
-    // Reordering the uncategorized subset must preserve c1/c2's global
+  it('splices unfiled reorders into todosGlobalOrder without moving filed todos', async () => {
+    // Two filed todos (c1, c2) flanking three unfiled (u1, u2, u3).
+    // Reordering the unfiled subset must preserve c1/c2's global
     // positions — the flat /todos page relies on that to not scramble the
-    // order of todos it doesn't even see in the Uncategorized view.
+    // order of todos it doesn't see.
     items.set({
       c1: makeTodo('c1', { collectionId: 'col-a' }),
       c2: makeTodo('c2', { collectionId: 'col-b' }),
@@ -463,7 +460,7 @@ describe('todoItems ordering', () => {
     });
     appConfig.set({ todosGlobalOrder: ['u1', 'c1', 'u2', 'c2', 'u3'] });
 
-    await reorderUncategorizedTodos(['u3', 'u1', 'u2']);
+    await reorderUnfiledTodos(['u3', 'u1', 'u2']);
 
     // u1/u2/u3 occupy the same global slots they did before; only their
     // relative order has changed. c1 and c2 stay exactly where they were.
@@ -543,7 +540,7 @@ describe('moveItemToCollection', () => {
     expect(get(items)['t1'].collectionId).toBe('target');
   });
 
-  it('adds to the target collection itemIds when moving from uncategorized', async () => {
+  it('adds to the target collection itemIds when moving from unfiled', async () => {
     const item = makeTodo('t1'); // no collectionId
     const target = { ...makeCollection('target'), itemIds: [] };
 
@@ -554,7 +551,6 @@ describe('moveItemToCollection', () => {
 
     expect(get(collections)['target'].itemIds).toEqual(['t1']);
     expect(get(items)['t1'].collectionId).toBe('target');
-    expect((get(items)['t1'] as any).uncategorized).toBeUndefined();
   });
 });
 
@@ -989,9 +985,6 @@ describe('visibleGroupedCollections', () => {
     const c2 = makeCollection('c2', 'g1');
     collections.set({ c1, c2 });
     groups.set({ g1: makeGroup('g1', ['c2', 'c1']) });
-    // Disable the Uncategorized pill so this test stays focused on real-group
-    // behaviour.
-    appConfig.set({ uncategorizedFilterActive: false });
 
     const sections = get(visibleGroupedCollections);
     expect(sections).toHaveLength(1);
@@ -1005,7 +998,7 @@ describe('visibleGroupedCollections', () => {
       g1: makeGroup('g1', []),
       g2: makeGroup('g2', []),
     });
-    appConfig.set({ activeGroupFilters: ['g2'], uncategorizedFilterActive: false });
+    appConfig.set({ activeGroupFilters: ['g2'] });
 
     const sections = get(visibleGroupedCollections);
     expect(sections.map(s => s.group.id)).toEqual(['g2']);
@@ -1013,173 +1006,8 @@ describe('visibleGroupedCollections', () => {
 
   it('returns empty when all groups are filtered out', () => {
     groups.set({ g1: makeGroup('g1', []) });
-    appConfig.set({ activeGroupFilters: [], uncategorizedFilterActive: false });
+    appConfig.set({ activeGroupFilters: [] });
     expect(get(visibleGroupedCollections)).toHaveLength(0);
-  });
-
-  it('places the Uncategorized section at the sentinel slot in groupsOrder', () => {
-    const grouped = makeCollection('c1', 'g1');
-    const grouped2 = makeCollection('c3', 'g2');
-    collections.set({ c1: grouped, c3: grouped2 });
-    groups.set({ g1: makeGroup('g1', ['c1']), g2: makeGroup('g2', ['c3']) });
-    items.set({
-      t1: { id: 't1', type: 'todo', title: 'straggler', createdAt: '2026-01-01T00:00:00Z', completed: false, isTodo: true } as any,
-    });
-    // Sentinel placed between g1 and g2
-    appConfig.set({ groupsOrder: ['g1', UNCATEGORIZED_FILTER_ID, 'g2'] });
-
-    const sections = get(visibleGroupedCollections);
-    expect(sections.map(s => s.group.id)).toEqual(['g1', UNCATEGORIZED_FILTER_ID, 'g2']);
-  });
-
-  it('hides the Uncategorized section when the pill is off even if straggler items exist', () => {
-    items.set({
-      t1: { id: 't1', type: 'todo', title: 'straggler', createdAt: '2026-01-01T00:00:00Z', completed: false, isTodo: true } as any,
-    });
-    groups.set({});
-    appConfig.set({ uncategorizedFilterActive: false });
-
-    expect(get(visibleGroupedCollections)).toHaveLength(0);
-  });
-
-  it('hides the Uncategorized section when there are no straggler items', () => {
-    // Uncategorized is a dynamic surface — unlike a real group, it has no
-    // persistent identity for the user to "keep". When everything is filed
-    // (all collections have a group, all items have a collection, no
-    // orphans), the Uncategorized section collapses away entirely.
-    const grouped = makeCollection('c1', 'g1');
-    collections.set({ c1: grouped });
-    groups.set({ g1: makeGroup('g1', ['c1']) });
-
-    const sections = get(visibleGroupedCollections);
-    expect(sections.map(s => s.group.id)).toEqual(['g1']);
-  });
-
-  it('renders the Uncategorized section when there are straggler items', () => {
-    // A loose todo or an orphaned ref is enough to bring the Uncategorized
-    // surface back — the straggler needs somewhere to live.
-    const grouped = makeCollection('c1', 'g1');
-    collections.set({ c1: grouped });
-    groups.set({ g1: makeGroup('g1', ['c1']) });
-    const straggler: InboxItem = { id: 't1', type: 'todo', title: 'straggler', createdAt: '2026-01-01T00:00:00Z', completed: false, isTodo: true } as any;
-    items.set({ t1: straggler });
-
-    const sections = get(visibleGroupedCollections);
-    expect(sections.map(s => s.group.id)).toEqual(['g1', UNCATEGORIZED_FILTER_ID]);
-    expect(sections[1].collections).toEqual([]);
-  });
-
-  it('attaches the virtual Uncategorized collection to the Uncategorized section when stragglers exist', () => {
-    // The virtual collection is exposed on `section.virtualCollection` so
-    // CollectionsPage can render straggler items without creating a real
-    // collection or group destination.
-    collections.set({});
-    groups.set({});
-    const straggler: InboxItem = { id: 't1', type: 'todo', title: 'straggler', createdAt: '2026-01-01T00:00:00Z', completed: false, isTodo: true } as any;
-    items.set({ t1: straggler });
-
-    const sections = get(visibleGroupedCollections);
-    const uncat = sections.find(s => s.group.id === UNCATEGORIZED_FILTER_ID);
-    expect(uncat).toBeDefined();
-    expect(uncat!.virtualCollection?.id).toBe(UNCATEGORIZED_COLLECTION_ID);
-    expect(uncat!.virtualCollection?.name).toBe('Uncategorized');
-  });
-});
-
-describe('uncategorizedVirtualCollection', () => {
-  beforeEach(() => {
-    items.set({});
-    appConfig.set({});
-  });
-
-  it('has a stable sentinel id and a placeholder createdAt even with no items', () => {
-    const virt = get(uncategorizedVirtualCollection);
-    expect(virt.id).toBe(UNCATEGORIZED_COLLECTION_ID);
-    expect(virt.itemIds).toEqual([]);
-    // Placeholder createdAt (epoch) — the virtual collection isn't stored, so
-    // there's no real creation timestamp to reference.
-    expect(virt.createdAt).toBe(new Date(0).toISOString());
-  });
-
-  it('includes every straggler — todos without a collection, plus refs explicitly flagged uncategorized', () => {
-    // Todos can't live in the Inbox, so any todo without a `collectionId`
-    // is implicitly a straggler. Refs, by contrast, default to the Inbox and
-    // only land here when explicitly flagged `uncategorized: true` (e.g.
-    // orphaned by a collection deletion). Order: todos first (open then
-    // completed, via todoItems), then refs (newest first, via
-    // uncategorizedReferenceItems).
-    const todo1: InboxItem = { id: 't1', type: 'todo', title: 'first', createdAt: '2026-01-01T00:00:00Z', completed: false, isTodo: true } as any;
-    const note1: InboxItem = { id: 'n1', type: 'note', title: 'note', body: 'x', createdAt: '2026-01-02T00:00:00Z', uncategorized: true } as any;
-    items.set({ t1: todo1, n1: note1 });
-
-    const virt = get(uncategorizedVirtualCollection);
-    expect(virt.itemIds).toEqual(['t1', 'n1']);
-  });
-
-  it('excludes refs without the `uncategorized` flag — those live in the Inbox, not Uncategorized', () => {
-    // Refs without a collectionId and without the `uncategorized` flag are
-    // *Inbox* items, not stragglers. They must not surface in the virtual
-    // Uncategorized collection.
-    const inboxRef: InboxItem = { id: 'n1', type: 'note', title: 'inbox', body: 'x', createdAt: '2026-01-01T00:00:00Z' } as any;
-    items.set({ n1: inboxRef });
-
-    const virt = get(uncategorizedVirtualCollection);
-    expect(virt.itemIds).toEqual([]);
-  });
-
-  it('excludes items that are assigned to a real collection', () => {
-    const uncat: InboxItem = { id: 't1', type: 'todo', title: 'uncat', createdAt: '2026-01-01T00:00:00Z', completed: false, isTodo: true } as any;
-    const assigned: InboxItem = { id: 't2', type: 'todo', title: 'assigned', createdAt: '2026-01-02T00:00:00Z', completed: false, isTodo: true, collectionId: 'c1' } as any;
-    const assignedRef: InboxItem = { id: 'n1', type: 'note', title: 'note', body: 'x', createdAt: '2026-01-03T00:00:00Z', collectionId: 'c1' } as any;
-    items.set({ t1: uncat, t2: assigned, n1: assignedRef });
-
-    const virt = get(uncategorizedVirtualCollection);
-    expect(virt.itemIds).toEqual(['t1']);
-  });
-
-  it('orders todos before refs, with completed todos between the two', () => {
-    // `todoItems` enforces open-first-then-completed for todos;
-    // `uncategorizedReferenceItems` returns refs newest-first. Concatenating
-    // them yields: open todos, completed todos, refs (newest first). Refs
-    // need the `uncategorized: true` flag to surface here — without it they'd
-    // default to the Inbox.
-    const openTodo: InboxItem = { id: 't-open', type: 'todo', title: 'open', createdAt: '2026-01-01T00:00:00Z', completed: false, isTodo: true } as any;
-    const doneTodo: InboxItem = { id: 't-done', type: 'todo', title: 'done', createdAt: '2026-01-02T00:00:00Z', completed: true, isTodo: true, completedAt: '2026-01-02T00:00:00Z' } as any;
-    const oldRef: InboxItem = { id: 'r-old', type: 'note', title: 'old', body: '', createdAt: '2026-01-01T00:00:00Z', uncategorized: true } as any;
-    const newRef: InboxItem = { id: 'r-new', type: 'note', title: 'new', body: '', createdAt: '2026-01-05T00:00:00Z', uncategorized: true } as any;
-    items.set({ 't-open': openTodo, 't-done': doneTodo, 'r-old': oldRef, 'r-new': newRef });
-
-    const virt = get(uncategorizedVirtualCollection);
-    expect(virt.itemIds).toEqual(['t-open', 't-done', 'r-new', 'r-old']);
-  });
-});
-
-describe('collectionItems virtual Uncategorized entry', () => {
-  beforeEach(() => {
-    items.set({});
-    collections.set({});
-  });
-
-  it('surfaces every straggler under UNCATEGORIZED_COLLECTION_ID — todos, and refs flagged uncategorized', () => {
-    // Orphan todo (no collectionId) — every uncollected todo is a straggler
-    // since todos can't live in the Inbox.
-    const todo: InboxItem = { id: 't1', type: 'todo', title: 'orphan todo', createdAt: '2026-01-01T00:00:00Z', completed: false, isTodo: true } as any;
-    // Orphaned reference flagged `uncategorized: true` — set when the user
-    // explicitly chose Uncategorized in the picker, or when an item is moved
-    // out of its collection without picking a new destination
-    // (`moveItemToCollection(id, undefined)`). Refs without this flag default
-    // to the Inbox, not Uncategorized.
-    const orphanRef: InboxItem = { id: 'r1', type: 'note', title: 'orphan ref', body: '', createdAt: '2026-01-02T00:00:00Z', uncategorized: true } as any;
-    // Items assigned to a real collection — must not leak.
-    const assignedTodo: InboxItem = { id: 't2', type: 'todo', title: 'assigned', createdAt: '2026-01-03T00:00:00Z', completed: false, isTodo: true, collectionId: 'c1' } as any;
-    const assignedRef: InboxItem = { id: 'r2', type: 'note', title: 'assigned ref', body: '', createdAt: '2026-01-04T00:00:00Z', collectionId: 'c1' } as any;
-    // Inbox ref (no flag, no collection) — must stay in the Inbox, not leak.
-    const inboxRef: InboxItem = { id: 'r3', type: 'note', title: 'inbox ref', body: '', createdAt: '2026-01-05T00:00:00Z' } as any;
-    items.set({ t1: todo, r1: orphanRef, t2: assignedTodo, r2: assignedRef, r3: inboxRef });
-
-    const byCollection = get(collectionItems);
-    const uncatItems = byCollection[UNCATEGORIZED_COLLECTION_ID] ?? [];
-    expect(uncatItems.map(i => i.id)).toEqual(['t1', 'r1']);
   });
 });
 
@@ -1342,10 +1170,10 @@ describe('allTodos / openTodos', () => {
     appConfig.set({});
   });
 
-  it('returns every todo-like item across collections and uncategorized', () => {
+  it('returns every todo-like item across filed and unfiled items', () => {
     items.set({
       a: makeTodo('a', { collectionId: 'c1' }),
-      b: makeTodo('b'), // uncategorized
+      b: makeTodo('b'), // unfiled
       c: {
         id: 'c',
         type: 'note',
@@ -1386,7 +1214,7 @@ describe('visibleTodos', () => {
     appConfig.set({});
   });
 
-  it('shows uncategorized todos by default (uncategorized filter on)', () => {
+  it('shows unfiled todos', () => {
     items.set({
       u1: makeTodo('u1', { createdAt: '2026-01-01T00:00:00.000Z' }),
       u2: makeTodo('u2', { createdAt: '2026-01-02T00:00:00.000Z' }),
@@ -1394,18 +1222,6 @@ describe('visibleTodos', () => {
 
     // Newest first as the fallback sort
     expect(get(visibleTodos).map(t => t.id)).toEqual(['u2', 'u1']);
-  });
-
-  it('hides uncategorized todos when the uncategorized filter is off', () => {
-    items.set({
-      u1: makeTodo('u1'),
-      c1: makeTodo('c1', { collectionId: 'col1' }),
-    });
-    collections.set({ col1: makeCollection('col1', 'g1') });
-    groups.set({ g1: makeGroup('g1', ['col1']) });
-    appConfig.set({ uncategorizedFilterActive: false });
-
-    expect(get(visibleTodos).map(t => t.id)).toEqual(['c1']);
   });
 
   it('hides collection todos whose group is filtered out', () => {
@@ -1421,11 +1237,8 @@ describe('visibleTodos', () => {
       'g-active': makeGroup('g-active', ['col-active']),
       'g-hidden': makeGroup('g-hidden', ['col-hidden']),
     });
-    // activeGroupFilters = just g-active; uncategorized off so we don't mix
-    // orphan behaviour into this assertion.
     appConfig.set({
       activeGroupFilters: ['g-active'],
-      uncategorizedFilterActive: false,
     });
 
     expect(get(visibleTodos).map(t => t.id)).toEqual(['c1']);
@@ -1441,24 +1254,18 @@ describe('visibleTodos', () => {
     groups.set({ g1: makeGroup('g1', []) });
     appConfig.set({
       activeGroupFilters: [],
-      uncategorizedFilterActive: false,
     });
 
     expect(get(visibleTodos)).toEqual([]);
   });
 
-  it('treats a todo whose collection was deleted as uncategorized for filtering purposes', () => {
+  it('keeps a todo visible when its collection is missing', () => {
     items.set({
       stale: makeTodo('stale', { collectionId: 'deleted' }),
     });
     collections.set({});
-    appConfig.set({ uncategorizedFilterActive: true });
 
     expect(get(visibleTodos).map(t => t.id)).toEqual(['stale']);
-
-    // And disappears when the uncategorized pill is off
-    appConfig.set({ uncategorizedFilterActive: false });
-    expect(get(visibleTodos)).toEqual([]);
   });
 
   it('respects persisted todosGlobalOrder and falls back to newest-first for missing ids', () => {
@@ -1498,49 +1305,12 @@ describe('reorderTodosGlobal', () => {
   });
 });
 
-describe('uncategorizedFilterActive / toggleUncategorizedFilter', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    appConfig.set({});
-  });
-
-  it('defaults to true when the flag is unset', () => {
-    expect(get(uncategorizedFilterActive)).toBe(true);
-  });
-
-  it('reflects the persisted flag when explicitly set', () => {
-    appConfig.set({ uncategorizedFilterActive: false });
-    expect(get(uncategorizedFilterActive)).toBe(false);
-
-    appConfig.set({ uncategorizedFilterActive: true });
-    expect(get(uncategorizedFilterActive)).toBe(true);
-  });
-
-  it('toggle flips from unset-default-true to explicit false', async () => {
-    expect(get(uncategorizedFilterActive)).toBe(true);
-
-    await toggleUncategorizedFilter();
-
-    expect(get(uncategorizedFilterActive)).toBe(false);
-    expect(get(appConfig).uncategorizedFilterActive).toBe(false);
-  });
-
-  it('toggle flips from false back to true', async () => {
-    appConfig.set({ uncategorizedFilterActive: false });
-
-    await toggleUncategorizedFilter();
-
-    expect(get(uncategorizedFilterActive)).toBe(true);
-    expect(get(appConfig).uncategorizedFilterActive).toBe(true);
-  });
-});
-
 // ---- deleteCollection: must-be-empty guard ----
 //
-// Mirrors the deleteGroup rule so the UI can't silently dump filed items into
-// the Uncategorized bucket on an accidental tap. Items are matched by their
-// live `collectionId` rather than the collection's `itemIds` array (which can
-// drift out of sync after partial writes).
+// Mirrors the deleteGroup rule so the UI can't silently orphan filed items on
+// an accidental tap. Items are matched by their live `collectionId` rather
+// than the collection's `itemIds` array, which can drift out of sync after
+// partial writes.
 
 describe('deleteCollection: empty-only guard', () => {
   beforeEach(() => {
@@ -1637,7 +1407,7 @@ describe('createCollection: group assignment', () => {
   });
 });
 
-describe('load-time collection group repair', () => {
+describe('load-time collection/group loading', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     items.set({});
@@ -1649,33 +1419,32 @@ describe('load-time collection group repair', () => {
     mockInbox.getUserSettings.mockResolvedValue(undefined);
   });
 
-  it('creates Uncategorized1 and moves loaded collections without a group into it', async () => {
+  it('loads collections without a group without creating or assigning organization', async () => {
     mockInbox.getAllCollections.mockResolvedValue({ c1: makeCollection('c1') });
     mockInbox.getAllGroups.mockResolvedValue({});
 
     await rsHandlers['connected']();
 
-    const uncatGroup = Object.values(get(groups)).find((g) => g.name === 'Uncategorized1');
-    expect(uncatGroup).toBeDefined();
-    expect(get(collections)['c1'].groupId).toBe(uncatGroup!.id);
-    expect(get(groups)[uncatGroup!.id].collectionIds).toContain('c1');
+    expect(get(collections)['c1'].groupId).toBeUndefined();
+    expect(get(groups)).toEqual({});
+    expect(mockInbox.storeGroup).not.toHaveBeenCalled();
+    expect(mockInbox.storeCollection).not.toHaveBeenCalled();
   });
 
-  it('reuses the lowest existing Uncategorized<N> group during load repair', async () => {
-    const u3 = makeGroup('g3'); u3.name = 'Uncategorized3';
-    const u1 = makeGroup('g1'); u1.name = 'Uncategorized1';
-    const u2 = makeGroup('g2'); u2.name = 'Uncategorized2';
+  it('loads collections with a missing groupId without rewriting them', async () => {
+    const g1 = makeGroup('g1');
     mockInbox.getAllCollections.mockResolvedValue({ c1: makeCollection('c1', 'deleted-group') });
-    mockInbox.getAllGroups.mockResolvedValue({ g3: u3, g1: u1, g2: u2 });
+    mockInbox.getAllGroups.mockResolvedValue({ g1 });
 
     await rsHandlers['connected']();
 
-    expect(get(collections)['c1'].groupId).toBe('g1');
-    expect(get(groups)['g1'].collectionIds).toContain('c1');
-    expect(Object.values(get(groups)).filter((g) => g.name === 'Uncategorized1')).toHaveLength(1);
+    expect(get(collections)['c1'].groupId).toBe('deleted-group');
+    expect(get(groups)).toEqual({ g1 });
+    expect(mockInbox.storeGroup).not.toHaveBeenCalled();
+    expect(mockInbox.storeCollection).not.toHaveBeenCalled();
   });
 
-  it('does not repair when groups fail to load', async () => {
+  it('does not mutate collections when groups fail to load', async () => {
     const existing = makeGroup('g1', ['c1']);
     groups.set({ g1: existing });
     collections.set({ c1: makeCollection('c1', 'g1') });
@@ -1686,14 +1455,7 @@ describe('load-time collection group repair', () => {
 
     expect(get(collections)['c1'].groupId).toBe('g1');
     expect(get(groups)['g1']).toBeDefined();
-    expect(Object.values(get(groups)).some((g) => g.name === 'Uncategorized1')).toBe(false);
+    expect(mockInbox.storeGroup).not.toHaveBeenCalled();
+    expect(mockInbox.storeCollection).not.toHaveBeenCalled();
   });
-
-  // Intentionally NOT auto-repaired: a 'groups/<id>' delete arriving via the
-  // RS change handler can be a transient mid-sync state (e.g. a group write
-  // hasn't landed yet on this device), and rewriting every dependent
-  // collection's groupId is destructive and propagates to all devices. This
-  // is exactly the v2.0.4 regression that wiped users' organization. Repair
-  // only runs at load time, where we can assert both stores are populated
-  // before deciding a collection is genuinely orphaned.
 });

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -1103,12 +1103,17 @@ describe('setActiveGroupFilters', () => {
     expect(get(appConfig).activeGroupFilters).toEqual(['g1', 'g2']);
   });
 
-  it('drops ids that do not correspond to real groups', async () => {
+  it('preserves unknown ids so URL filters survive cold refreshes before groups load', async () => {
+    // Cold-refresh race: URL→config sync runs before `groups` populates from
+    // the cached load. Filtering against the (still-empty) groups set here
+    // would wipe valid filters and immediately rewrite the URL to `?g=`.
+    // `activeGroupIds` filters stale ids at read time, so we keep them in
+    // config.
     groups.set({ g1: makeGroup('g1') });
 
     await setActiveGroupFilters(['g1', 'g_unknown']);
 
-    expect(get(appConfig).activeGroupFilters).toEqual(['g1']);
+    expect(get(appConfig).activeGroupFilters).toEqual(['g1', 'g_unknown']);
   });
 
   it('skips persistence when value is unchanged (avoids URL ↔ config loops)', async () => {

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -53,6 +53,7 @@ import {
   collections, groups, groupCollections, moveCollectionToGroup,
   deleteGroup, appConfig,
   storeCollection, createCollection, deleteCollection,
+  storeItem,
   reorderGroupCollections, items, todoItems, reorderUncategorizedTodos, pendingMigrationCount,
   moveItemToCollection,
   collectionItems, userSettings,
@@ -379,6 +380,30 @@ describe('todoItems ordering', () => {
     vi.clearAllMocks();
     items.set({});
     appConfig.set({});
+  });
+
+  it('stores a new todo while disconnected without groups or collections as unfiled', async () => {
+    connected.set(false);
+    collections.set({});
+    groups.set({});
+    const todo = makeTodo('quick', {
+      title: 'Quick thought',
+      completed: false,
+      isTodo: true,
+    });
+
+    await storeItem(todo);
+
+    expect(mockInbox.store).toHaveBeenCalledWith(todo, undefined);
+    expect(get(items).quick).toMatchObject({
+      id: 'quick',
+      title: 'Quick thought',
+      type: 'todo',
+      completed: false,
+      isTodo: true,
+    });
+    expect(get(items).quick.collectionId).toBeUndefined();
+    expect(get(todoItems).map(t => t.id)).toEqual(['quick']);
   });
 
   it('keeps configured open todo order and falls back to newest-first for new todos', () => {

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -57,7 +57,7 @@ import {
   reorderGroupCollections, items, todoItems, reorderUnfiledTodos, pendingMigrationCount,
   moveItemToCollection,
   collectionItems, userSettings,
-  activeGroupIds, visibleGroupedCollections,
+  activeGroupIds, visibleGroupedCollections, orphanCollections,
   toggleGroupFilter, setActiveGroupFilters, storeGroup,
   allTodos, openTodos, visibleTodos, reorderTodosGlobal,
 } from './stores';
@@ -1008,6 +1008,54 @@ describe('visibleGroupedCollections', () => {
     groups.set({ g1: makeGroup('g1', []) });
     appConfig.set({ activeGroupFilters: [] });
     expect(get(visibleGroupedCollections)).toHaveLength(0);
+  });
+});
+
+describe('orphanCollections', () => {
+  beforeEach(() => {
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+  });
+
+  it('is empty when every collection has a real group', () => {
+    collections.set({
+      c1: makeCollection('c1', 'g1'),
+      c2: makeCollection('c2', 'g1'),
+    });
+    groups.set({ g1: makeGroup('g1', ['c1', 'c2']) });
+
+    expect(get(orphanCollections)).toEqual([]);
+  });
+
+  it('surfaces collections with no groupId', () => {
+    const c1 = makeCollection('c1');
+    delete (c1 as any).groupId;
+    collections.set({ c1 });
+
+    expect(get(orphanCollections).map(c => c.id)).toEqual(['c1']);
+  });
+
+  it('surfaces collections whose groupId points at a deleted group', () => {
+    collections.set({
+      c1: makeCollection('c1', 'g1'),
+      stale: makeCollection('stale', 'g_deleted'),
+    });
+    groups.set({ g1: makeGroup('g1', ['c1']) });
+
+    expect(get(orphanCollections).map(c => c.id)).toEqual(['stale']);
+  });
+
+  it('orders orphans by createdAt for a stable display order', () => {
+    const newer = makeCollection('newer');
+    const older = makeCollection('older');
+    delete (newer as any).groupId;
+    delete (older as any).groupId;
+    newer.createdAt = '2026-03-01T00:00:00.000Z';
+    older.createdAt = '2026-01-01T00:00:00.000Z';
+    collections.set({ newer, older });
+
+    expect(get(orphanCollections).map(c => c.id)).toEqual(['older', 'newer']);
   });
 });
 

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -1056,6 +1056,24 @@ export const visibleGroupedCollections = derived(
 );
 
 /**
+ * Collections whose `groupId` is unset or refers to a group that no longer
+ * exists. Surfaced read-only on the Collections page as an advisory section
+ * so users can edit each one back into a real group (or delete it). We do
+ * NOT auto-rewrite these on load — see the v2.0.4 regression note in the
+ * connect handler — and we do NOT create a synthetic group/collection for
+ * them. The list is empty in the normal case; the UI only renders a section
+ * when this is non-empty. Sorted by createdAt for a stable order.
+ */
+export const orphanCollections = derived(
+  [collections, groups],
+  ([$collections, $groups]): Collection[] => {
+    return Object.values($collections)
+      .filter(col => !col.groupId || !$groups[col.groupId])
+      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  }
+);
+
+/**
  * Toggle a group's filter on/off. Persists to config.
  * If activeGroupFilters was undefined (default-all), this materializes the
  * current set first, then flips the requested id.

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -222,17 +222,6 @@ async function loadGroups() {
   return loadEntities<CollectionGroup>(() => inbox.getAllGroups(), groups, 'collectionIds');
 }
 
-async function repairCollectionsWithoutValidGroup() {
-  const allGroups = get(groups);
-  const needsRepair = Object.values(get(collections)).filter(col => !col.groupId || !allGroups[col.groupId]);
-  if (needsRepair.length === 0) return;
-
-  const targetGroupId = await findOrCreateUncategorizedGroup();
-  for (const col of needsRepair) {
-    await moveCollectionToGroup(col.id, targetGroupId);
-  }
-}
-
 async function loadCachedData() {
   await Promise.all([
     loadItems(),
@@ -246,16 +235,13 @@ async function loadCachedData() {
 
 async function loadConnectedData() {
   resetMigrationAlertReadiness();
-  const [, , , collectionsLoaded, groupsLoaded] = await Promise.all([
+  await Promise.all([
     loadItems(),
     loadConfig(),
     loadUserSettings(),
     loadCollections(),
     loadGroups(),
   ]);
-  if (collectionsLoaded && groupsLoaded) {
-    await repairCollectionsWithoutValidGroup();
-  }
   scheduleMigrationAlertFallback();
 }
 
@@ -490,41 +476,30 @@ function sortWithConfiguredOrder<T extends { id: string }>(
 
 // ---- Derived stores ----
 
-// Bucket semantics:
-//   - **Collection**: item has `collectionId` set → lives in that collection.
-//   - **Inbox** (references only): non-todo item with no `collectionId` and no
-//     `uncategorized` flag. Inbox never holds todos by design — see
-//     AddEntryModal: the todo type's collection picker skips the "Inbox"
-//     option.
-//   - **Uncategorized**: anything with no `collectionId` that's either a todo
-//     (implicit — todos can't live in the Inbox, so a todo without a
-//     collection is always uncategorized) or a ref with `uncategorized: true`
-//     (explicit opt-in from the picker, or orphaned by a collection deletion).
-//
-// The three surfaces are mutually exclusive for any given item.
+// Placement semantics:
+//   - item.collectionId set: item is filed in that real collection.
+//   - reference item without collectionId: item lives in Inbox.
+//   - todo without collectionId: item is unfiled and appears on the Todos page.
+// There is no automatic collection/group bucket for unfiled items.
 
-/** Inbox reference items: non-todos with no collectionId and no `uncategorized` flag. */
+/** Inbox reference items: non-todos with no collectionId. */
 export const sortedItems = derived(items, ($items) => {
   return Object.values($items)
-    .filter(i => !i.isTodo && i.type !== 'todo' && !i.collectionId && !i.uncategorized)
+    .filter(i => !i.isTodo && i.type !== 'todo' && !i.collectionId)
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 });
 
 /**
- * Uncategorized todos — every todo without a `collectionId` qualifies, since
- * todos never live in the Inbox. Sorted open-first (respecting
+ * Unfiled todos — every todo without a `collectionId`. Sorted open-first (respecting
  * `todosGlobalOrder`) then completed (by `completedAt` desc).
  *
  * `todosGlobalOrder` is the single source of truth for todo ordering across
- * every surface — the flat `/todos` page reads it directly (see
- * `visibleTodos`), and the virtual Uncategorized collection funnels through
- * here. Reordering uncategorized todos from either surface goes through
- * `reorderUncategorizedTodos`, which splices only uncategorized slots so the
- * categorized todos keep their global positions.
+ * the flat `/todos` page. Reordering unfiled todos from a focused surface goes
+ * through `reorderUnfiledTodos`, which splices only unfiled slots so the filed
+ * todos keep their global positions.
  *
- * Named `todoItems` rather than `uncategorizedTodoItems` for backwards
- * compatibility with callers (CollectionItemPicker, test suite) that used this
- * name when the Inbox vs Uncategorized distinction didn't exist for todos.
+ * Named `todoItems` for backwards compatibility with callers
+ * (CollectionItemPicker, test suite) that use this store for unfiled todos.
  */
 export const todoItems = derived([items, appConfig], ([$items, $config]) => {
   const all = Object.values($items)
@@ -544,17 +519,9 @@ export const todoItems = derived([items, appConfig], ([$items, $config]) => {
   return [...open, ...completed];
 });
 
-/** Uncategorized reference items: non-todos with no collectionId that opted into
- *  the Uncategorized bucket via the `uncategorized: true` flag. */
-export const uncategorizedReferenceItems = derived(items, ($items) => {
-  return Object.values($items)
-    .filter(i => !i.isTodo && i.type !== 'todo' && !i.collectionId && i.uncategorized === true)
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-});
-
 export const collectionItems = derived(
-  [items, collections, todoItems, uncategorizedReferenceItems],
-  ([$items, $collections, $todoItems, $uncatRefs]) => {
+  [items, collections],
+  ([$items, $collections]) => {
     const result: Record<string, InboxItem[]> = {};
     const itemMap = new Map(Object.values($items).map(i => [i.id, i]));
     for (const [cid, col] of Object.entries($collections)) {
@@ -562,18 +529,6 @@ export const collectionItems = derived(
         .map(id => itemMap.get(id))
         .filter((i): i is InboxItem => i !== undefined && i.collectionId === cid);
     }
-    // Virtual Uncategorized collection — surfaces every uncategorized item
-    // under a sentinel id so CollectionView's existing
-    // `$collectionItems[collection.id]` lookup Just Works for the virtual bucket.
-    //
-    // Inbox refs (no `collectionId`, no `uncategorized` flag) deliberately do
-    // NOT surface here — they belong to the Inbox view only. Todos, however,
-    // all surface here when they have no `collectionId` because todos can't
-    // live in the Inbox (AddEntryModal enforces this — see its picker).
-    //
-    // Order: open todos first (respecting `todosGlobalOrder`), then completed
-    // todos, then reference items newest-first.
-    result[UNCATEGORIZED_COLLECTION_ID] = [...$todoItems, ...$uncatRefs];
     return result;
   }
 );
@@ -662,8 +617,8 @@ export async function storeCollection(collection: Collection) {
  * Delete a collection. Refuses if the collection still contains items — the
  * caller is expected to either move items out (drag/drop, picker) or delete
  * them first. This mirrors `deleteGroup`'s "must be empty" rule and avoids
- * silently orphaning user-filed items into the Uncategorized bucket on a
- * delete tap. Returns `true` on success, `false` when the delete was refused.
+ * silently unfiling user-filed items on a delete tap. Returns `true` on
+ * success, `false` when the delete was refused.
  *
  * Items are matched by the live `collectionId` on each item rather than the
  * collection's `itemIds` array — that array can drift out of sync if a write
@@ -723,18 +678,8 @@ export async function moveItemToCollection(itemId: string, collectionId: string 
         const updated = { ...next[key] };
         if (collectionId) {
           updated.collectionId = collectionId;
-          // Moving into a real collection wipes the Uncategorized marker —
-          // the collection placement wins, and the flag would be meaningless
-          // noise if it lingered.
-          delete (updated as any).uncategorized;
         } else {
           delete (updated as any).collectionId;
-          // Removing a collection placement without another explicit bucket
-          // routes the item to the Uncategorized bucket, mirroring what
-          // happens when a collection is deleted. Inbox is reserved for items
-          // the user has never filed, so we shouldn't silently return
-          // previously-filed items there.
-          updated.uncategorized = true;
         }
         next[key] = updated as InboxItem;
         item = updated as InboxItem;
@@ -964,37 +909,7 @@ export async function moveCollectionToGroup(collectionId: string, groupId: strin
 }
 
 /**
- * Find an existing "Uncategorized<N>" group, or create a fresh one and return
- * its id. This is only for load-time repair of legacy/homeless collections.
- * Normal collection creation must pick a real group before it reaches the
- * store.
- */
-async function findOrCreateUncategorizedGroup(): Promise<string> {
-  const allGroups = get(groups);
-  const matches = Object.values(allGroups)
-    .map(g => {
-      const m = g.name.match(/^Uncategorized(\d+)$/);
-      return m ? { id: g.id, n: Number(m[1]) } : null;
-    })
-    .filter((x): x is { id: string; n: number } => x !== null)
-    .sort((a, b) => a.n - b.n);
-  if (matches.length > 0) return matches[0].id;
-
-  const group: CollectionGroup = {
-    id: crypto.randomUUID(),
-    name: 'Uncategorized1',
-    collectionIds: [],
-    createdAt: new Date().toISOString(),
-  };
-  await storeGroup(group);
-  return group.id;
-}
-
-/**
- * Create a collection in an explicit real group. Legacy/homeless collection
- * repair is handled separately during app load by
- * `repairCollectionsWithoutValidGroup`; this path should never invent a
- * background "no group" destination for a new collection.
+ * Create a collection in an explicit real group.
  */
 export async function createCollection(col: Collection): Promise<Collection> {
   if (!col.groupId || !get(groups)[col.groupId]) {
@@ -1032,34 +947,28 @@ export async function reorderGroups(newOrder: string[]) {
 }
 
 /**
- * Persist a new order for the uncategorized-todo slice of `todosGlobalOrder`.
+ * Persist a new order for the unfiled-todo slice of `todosGlobalOrder`.
  *
- * Two surfaces let the user drag uncategorized todos: the flat `/todos` page
- * (where every todo — categorized and uncategorized — is visible together)
- * and the virtual Uncategorized collection (which only sees the uncategorized
- * subset). Both must agree on a single order, otherwise a reorder on one
- * surface gets clobbered by the next drag on the other.
- *
- * We solve that by keeping a single source of truth — `todosGlobalOrder` —
- * and splicing the new uncategorized order back into their existing slots.
- * Categorized todos' positions in the global order are preserved exactly; only
+ * This keeps a single source of truth — `todosGlobalOrder` — and splices the
+ * new unfiled order back into their existing slots. Filed todos' positions in
+ * the global order are preserved exactly; only
  * the ids that match the new set are replaced, in the order given.
  *
- * The caller passes the full new order of the uncategorized subset (not a
+ * The caller passes the full new order of the unfiled subset (not a
  * delta). Ids not currently in `todosGlobalOrder` are appended at the end.
  */
-export async function reorderUncategorizedTodos(newUncategorizedOrder: string[]) {
+export async function reorderUnfiledTodos(newUnfiledOrder: string[]) {
   const current = get(appConfig).todosGlobalOrder ?? [];
   const allItems = get(items);
-  const isUncategorized = (id: string) => {
+  const isUnfiled = (id: string) => {
     const item = allItems[id];
     return !!item && (item.isTodo || item.type === 'todo') && !item.collectionId;
   };
-  const newSet = new Set(newUncategorizedOrder);
-  const queue = [...newUncategorizedOrder];
+  const newSet = new Set(newUnfiledOrder);
+  const queue = [...newUnfiledOrder];
   const result: string[] = [];
   for (const id of current) {
-    if (isUncategorized(id) || newSet.has(id)) {
+    if (isUnfiled(id) || newSet.has(id)) {
       // Pop the next id from `queue` that's actually in the new set — skip any
       // queue entries that dropped out (shouldn't happen in practice, but
       // keeps the splice resilient to stale callers).
@@ -1079,83 +988,6 @@ export async function reorderUncategorizedTodos(newUncategorizedOrder: string[])
 }
 
 // ---- Group filter (toggle row) ----
-
-/**
- * Sentinel id for the Uncategorized entry in the group filter bar and the
- * Collections page. Both surfaces treat Uncategorized as a peer of real groups
- * (same drag-sort list, same pill styling, same grouped section layout), so we
- * use a reserved id that cannot collide with a real group id and persist it
- * inside `groupsOrder` to record its position.
- *
- * Downstream consumers of `groupsOrder` — `sortedGroups`, `reorderGroups`,
- * `activeGroupIds` — only inspect ids that correspond to real stored groups,
- * so the sentinel is naturally ignored outside the filter bar and the
- * Collections page's `visibleGroupedCollections` derivation.
- */
-export const UNCATEGORIZED_FILTER_ID = '__uncategorized';
-
-/**
- * Sentinel id for the virtual "Uncategorized" collection rendered inside the
- * Uncategorized group section on the Collections page. It surfaces todos and
- * reference items that have no `collectionId` in the same visual shape as a
- * real collection (CollectionView), so users can see and interact with their
- * uncategorized items without the Collections page quietly hiding them.
- *
- * There is no backing Collection record — the virtual collection is computed
- * from the `items` store on the fly. CollectionView renders it in a restricted
- * mode (no edit button, no move-to-group menu, items saved with
- * `collectionId: undefined`) because editing/deleting the virtual bucket has
- * no meaning.
- */
-export const UNCATEGORIZED_COLLECTION_ID = '__uncategorized_collection';
-
-/**
- * Virtual Collection object that backs the Uncategorized bucket's CollectionView.
- * `itemIds` lists every straggler: todos without a `collectionId` (todos can't
- * live in the Inbox, so they all end up here) followed by reference items
- * explicitly marked `uncategorized: true` (typically orphaned by a collection
- * deletion). Inbox refs (no `collectionId`, no flag) never surface here.
- *
- * When there are no stragglers this collection is empty — consumers should
- * check `hasUncategorizedItems` and hide the Uncategorized surface entirely
- * rather than rendering an empty bucket, since Uncategorized is a dynamic
- * artifact of leftover items rather than a first-class collection.
- */
-export const uncategorizedVirtualCollection = derived(
-  [todoItems, uncategorizedReferenceItems],
-  ([$todos, $refs]): Collection => ({
-    id: UNCATEGORIZED_COLLECTION_ID,
-    name: 'Uncategorized',
-    // Muted accent — this bucket is a fallback rather than a user-created
-    // collection, so it shouldn't compete visually with real collections.
-    color: '#9ca3af',
-    itemIds: [...$todos.map(t => t.id), ...$refs.map(r => r.id)],
-    createdAt: new Date(0).toISOString(),
-  })
-);
-
-/**
- * True iff there are any items that belong in the Uncategorized bucket. The
- * Uncategorized pill (GroupFilterBar) and section (CollectionsPage) use this
- * to decide whether to render at all — Uncategorized isn't a persistent
- * category, it only exists when the system has stragglers to surface. A fresh
- * user with no orphaned refs and no uncollected todos sees no Uncategorized
- * surface anywhere.
- */
-export const hasUncategorizedItems = derived(
-  uncategorizedVirtualCollection,
-  ($virtual) => $virtual.itemIds.length > 0
-);
-
-/**
- * Is the "Uncategorized" filter pill currently ON?
- * Defaults to true — when the config flag is unset, uncategorized todos and
- * collections are visible (matches the previous behaviour where the
- * Uncategorized tile was always rendered on the Todos page).
- */
-export const uncategorizedFilterActive = derived(appConfig, ($config) =>
-  $config.uncategorizedFilterActive !== false
-);
 
 /**
  * Set of group IDs currently active (visible) in the filter row.
@@ -1179,83 +1011,20 @@ export const activeGroupIds = derived(
  * activeGroupIds. Within each group, collections preserve the configured
  * order from groupCollections.
  *
- * A synthetic "Uncategorized" section is folded into this list only when
- * there are straggler items AND the uncategorized filter pill is on —
- * identified by `group.id === UNCATEGORIZED_FILTER_ID`. It is not a group
- * destination and never hosts real collections.
  */
 export interface VisibleGroupSection {
   group: CollectionGroup;
   collections: Collection[];
-  /**
-   * Optional virtual collection rendered above the draggable list of real
-   * collections in this section. Currently only populated for the Uncategorized
-   * section, where it surfaces items with no `collectionId` as a pseudo-
-   * collection (read-only, not draggable, cannot be edited or deleted). Consumer
-   * components should render it outside the real-collection drag zone.
-   */
-  virtualCollection?: Collection;
 }
 
 export const visibleGroupedCollections = derived(
-  [sortedGroups, groupCollections, activeGroupIds, uncategorizedFilterActive, uncategorizedVirtualCollection, hasUncategorizedItems, appConfig],
-  ([$sortedGroups, $groupCollections, $activeGroupIds, $uncatActive, $uncatVirtual, $hasUncat, $config]): VisibleGroupSection[] => {
+  [sortedGroups, groupCollections, activeGroupIds],
+  ([$sortedGroups, $groupCollections, $activeGroupIds]): VisibleGroupSection[] => {
     const sections: VisibleGroupSection[] = [];
-    const realById = new Map($sortedGroups.map(g => [g.id, g]));
-    const order = $config.groupsOrder ?? [];
-    const seen = new Set<string>();
-
-    // Synthetic section for item stragglers only. It uses the same sentinel
-    // id as the filter pill so ordering/placement flows through groupsOrder
-    // without any special-casing at consumer sites, but it never owns real
-    // collections.
-    const uncatSection: VisibleGroupSection = {
-      group: {
-        id: UNCATEGORIZED_FILTER_ID,
-        name: 'Uncategorized',
-        collectionIds: [],
-        createdAt: new Date(0).toISOString(),
-      },
-      collections: [],
-      virtualCollection: $uncatVirtual,
-    };
-
-    const pushReal = (g: CollectionGroup) => {
-      if (!$activeGroupIds.has(g.id)) return;
-      sections.push({ group: g, collections: $groupCollections[g.id] ?? [] });
-    };
-
-    const pushUncat = () => {
-      if (!$hasUncat) return;
-      if ($uncatActive) sections.push(uncatSection);
-    };
-
-    // Walk the persisted filter-bar order so the Uncategorized section lines
-    // up with its pill. Real groups not yet in the order (newly created) are
-    // appended afterwards.
-    for (const id of order) {
-      if (seen.has(id)) continue;
-      if (id === UNCATEGORIZED_FILTER_ID) {
-        pushUncat();
-        seen.add(id);
-      } else {
-        const g = realById.get(id);
-        if (g) {
-          pushReal(g);
-          seen.add(id);
-        }
-      }
-    }
     for (const g of $sortedGroups) {
-      if (!seen.has(g.id)) {
-        pushReal(g);
-        seen.add(g.id);
-      }
+      if (!$activeGroupIds.has(g.id)) continue;
+      sections.push({ group: g, collections: $groupCollections[g.id] ?? [] });
     }
-    // Default the Uncategorized slot to the end when the sentinel has never
-    // been persisted — same fallback the filter bar uses for new users.
-    if (!seen.has(UNCATEGORIZED_FILTER_ID)) pushUncat();
-
     return sections;
   }
 );
@@ -1288,18 +1057,11 @@ export async function setActiveGroupFilters(ids: string[]): Promise<void> {
   await updateConfig({ activeGroupFilters: filtered });
 }
 
-/** Flip the Uncategorized filter pill. */
-export async function toggleUncategorizedFilter(): Promise<void> {
-  const current = get(appConfig).uncategorizedFilterActive !== false;
-  await updateConfig({ uncategorizedFilterActive: !current });
-}
-
 // ---- Flat Todos page: all todos across all collections ----
 
 /**
- * Every item that represents a todo — across collections and "uncategorized"
- * (no collectionId). Not sorted or filtered; callers should derive from
- * `visibleTodos` instead when rendering the Todos page.
+ * Every item that represents a todo. Todos without `collectionId` are unfiled
+ * and remain valid todos; they are not routed through a collection/group.
  */
 export const allTodos = derived(items, ($items) => {
   return Object.values($items).filter(i => i.isTodo || i.type === 'todo');
@@ -1311,21 +1073,18 @@ export const openTodos = derived(allTodos, ($allTodos) =>
 );
 
 /**
- * Todos visible on the flat Todos page, honouring both the group-filter row
- * and the uncategorized filter pill. Sorted by `todosGlobalOrder`; ids missing
- * from that order fall back to newest-first on `createdAt`. Completed and open
- * todos are mixed — the page splits them at render time.
+ * Todos visible on the flat Todos page. Unfiled todos are always visible;
+ * filed todos honour the group-filter row. Sorted by `todosGlobalOrder`; ids
+ * missing from that order fall back to newest-first on `createdAt`. Completed
+ * and open todos are mixed — the page splits them at render time.
  */
 export const visibleTodos = derived(
-  [allTodos, collections, activeGroupIds, uncategorizedFilterActive, appConfig],
-  ([$allTodos, $collections, $activeGroupIds, $uncatActive, $config]) => {
-    // A todo is visible iff:
-    //  - it has no collectionId and the uncategorized pill is on, OR
-    //  - it's in a collection whose real group is active.
+  [allTodos, collections, activeGroupIds, appConfig],
+  ([$allTodos, $collections, $activeGroupIds, $config]) => {
     const filtered = $allTodos.filter(todo => {
-      if (!todo.collectionId) return $uncatActive;
+      if (!todo.collectionId) return true;
       const col = $collections[todo.collectionId];
-      if (!col) return $uncatActive; // orphan: the collection was deleted — treat as uncategorized
+      if (!col) return true;
       if (!col.groupId) return false;
       return $activeGroupIds.has(col.groupId);
     });

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -1088,11 +1088,16 @@ export async function toggleGroupFilter(groupId: string): Promise<void> {
   await updateConfig({ activeGroupFilters: next });
 }
 
-/** Set the active group filter list to exactly these IDs. Persists to config. */
+/** Set the active group filter list to exactly these IDs. Persists to config.
+ *
+ * Does not filter against known groups — the URL→config sync runs before
+ * `groups` finishes loading on cold refresh, and dropping ids whose group
+ * hasn't loaded yet would wipe valid filters and immediately rewrite the URL
+ * to `?g=` empty. Stale ids (groups that were deleted) are filtered out at
+ * read time by `activeGroupIds`, so persisting them is harmless.
+ */
 export async function setActiveGroupFilters(ids: string[]): Promise<void> {
-  // Dedupe and only keep ids that correspond to real groups.
-  const allGroupIds = new Set(get(sortedGroups).map(g => g.id));
-  const filtered = Array.from(new Set(ids)).filter(id => allGroupIds.has(id));
+  const filtered = Array.from(new Set(ids));
   const current = get(appConfig).activeGroupFilters;
   // Skip if equal to current (avoids URL ↔ config write loops)
   if (current && current.length === filtered.length && current.every((v, i) => v === filtered[i])) {

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -222,27 +222,53 @@ async function loadGroups() {
   return loadEntities<CollectionGroup>(() => inbox.getAllGroups(), groups, 'collectionIds');
 }
 
-async function loadCachedData() {
-  await Promise.all([
+// Single in-flight load promise so the cached preload (queueMicrotask at
+// module init) and the post-connect reload don't run concurrent loaders
+// against the same five stores. Each entry-point waits for any pending load
+// to settle before kicking off its own.
+let inFlightLoad: Promise<void> | null = null;
+
+function runLoaders(): Promise<void> {
+  return Promise.all([
     loadItems(),
     loadConfig(),
     loadUserSettings(),
     loadCollections(),
     loadGroups(),
-  ]);
-  markMigrationAlertReady();
+  ]).then(() => undefined);
+}
+
+async function loadCachedData() {
+  // Skip if the connect handler has already taken over — its load is
+  // authoritative once we're online.
+  if (get(connected)) return;
+  if (inFlightLoad) {
+    await inFlightLoad;
+    return;
+  }
+  inFlightLoad = runLoaders();
+  try {
+    await inFlightLoad;
+    markMigrationAlertReady();
+  } finally {
+    inFlightLoad = null;
+  }
 }
 
 async function loadConnectedData() {
   resetMigrationAlertReadiness();
-  await Promise.all([
-    loadItems(),
-    loadConfig(),
-    loadUserSettings(),
-    loadCollections(),
-    loadGroups(),
-  ]);
-  scheduleMigrationAlertFallback();
+  if (inFlightLoad) {
+    // Let the cached load settle before starting a fresh one so we don't
+    // double-read the same stores in parallel.
+    try { await inFlightLoad; } catch { /* errors handled inside loaders */ }
+  }
+  inFlightLoad = runLoaders();
+  try {
+    await inFlightLoad;
+    scheduleMigrationAlertFallback();
+  } finally {
+    inFlightLoad = null;
+  }
 }
 
 // Debounced sync indicator: stays visible for at least 1 second to avoid flicker

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -247,6 +247,32 @@ function queueCollectionGroupRepair() {
   });
 }
 
+async function loadCachedData() {
+  await Promise.all([
+    loadItems(),
+    loadConfig(),
+    loadUserSettings(),
+    loadCollections(),
+    loadGroups(),
+  ]);
+  markMigrationAlertReady();
+}
+
+async function loadConnectedData() {
+  resetMigrationAlertReadiness();
+  const [, , , collectionsLoaded, groupsLoaded] = await Promise.all([
+    loadItems(),
+    loadConfig(),
+    loadUserSettings(),
+    loadCollections(),
+    loadGroups(),
+  ]);
+  if (collectionsLoaded && groupsLoaded) {
+    await repairCollectionsWithoutValidGroup();
+  }
+  scheduleMigrationAlertFallback();
+}
+
 // Debounced sync indicator: stays visible for at least 1 second to avoid flicker
 let syncTimeout: ReturnType<typeof setTimeout> | null = null;
 let syncVisibleUntil = 0;
@@ -294,23 +320,12 @@ rs.on('wire-done', () => console.log('[inbox] wire-done'));
 
 rs.on('connected', async () => {
   connected.set(true);
-  resetMigrationAlertReadiness();
   const addr =
     (rs as any).remote?.userAddress ||
     localStorage.getItem('inbox-rs:userAddress') ||
     '';
   userAddress.set(addr);
-  const [, , , collectionsLoaded, groupsLoaded] = await Promise.all([
-    loadItems(),
-    loadConfig(),
-    loadUserSettings(),
-    loadCollections(),
-    loadGroups(),
-  ]);
-  if (collectionsLoaded && groupsLoaded) {
-    await repairCollectionsWithoutValidGroup();
-  }
-  scheduleMigrationAlertFallback();
+  await loadConnectedData();
 });
 
 rs.on('disconnected', () => {
@@ -325,6 +340,10 @@ rs.on('disconnected', () => {
   userSettings.set({});
   collections.set({});
   groups.set({});
+});
+
+queueMicrotask(() => {
+  void loadCachedData();
 });
 
 export async function runAllMigrations() {


### PR DESCRIPTION
## Summary
- allow todos to be saved with only a title, without requiring any existing group or collection
- keep unfiled todos as plain todos without collectionId, visible on the Todos page and never backed by a fake collection/group
- remove the synthetic Uncategorized bucket, filter pill, virtual collection, and automatic load-time collection/group repair path
- stop writing or reading the legacy uncategorized item/config fields in the shared schema and web app
- keep real collection filing unchanged: existing groups/collections still appear as optional filing targets, and items can be moved into them later
- keep the app usable before remoteStorage login by rendering the normal app shell while disconnected
- replace the large disconnected-state banner with a quiet empty-inbox connect link that opens the user menu and focuses the address field
- load cached local data on startup so anonymous/offline data can appear before a remote account is attached

## Migration
- existing items stored with `uncategorized: true` and no `collectionId` now surface in the Inbox view alongside other unfiled refs — uncategorized refs become Inbox refs
- the `uncategorized` field on items and the `uncategorizedFilterActive` field on appConfig are removed from the schema; stale values on existing remoteStorage docs are ignored by the new code

## Review follow-up
- checked extension parity: the browser extension does not expose todo creation, and Thunderbird only saves email, so there is no extension todo-add flow still enforcing collections
- filed follow-up issue for component-level Svelte coverage: #95
- filed follow-up issue for always-available quick-add beyond the empty state: #96
- review pass addressed: dedupe of cached + connect data loads, inlined trivial picker helper in AddEntryModal, conversion-error surfacing in ViewCardModal Make Todo dropdown, quick-add aria-live + clear-on-edit on TodosPage (closes #97)

## Validation
- npm run test --workspace=packages/web
- npm run build --workspace=packages/web