### PR TITLE
fix(web): stop rewriting collection groupId on incoming sync events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inbox-rs",
-  "version": "2.0.0",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inbox-rs",
-      "version": "2.0.0",
+      "version": "2.0.4",
       "workspaces": [
         "packages/*"
       ]
@@ -3985,7 +3985,7 @@
     },
     "packages/extension": {
       "name": "@inbox-rs/extension",
-      "version": "2.0.0",
+      "version": "2.0.4",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "remotestoragejs": "^2.0.0-beta.8",
@@ -4176,7 +4176,7 @@
     },
     "packages/rs-module": {
       "name": "@inbox-rs/rs-module",
-      "version": "2.0.0",
+      "version": "2.0.4",
       "dependencies": {
         "remotestoragejs": "^2.0.0-beta.8",
         "rs-migrate": "^1.0.0"
@@ -4187,7 +4187,7 @@
     },
     "packages/thunderbird": {
       "name": "@inbox-rs/thunderbird",
-      "version": "2.0.0",
+      "version": "2.0.4",
       "dependencies": {
         "@inbox-rs/rs-module": "*"
       },
@@ -4374,7 +4374,7 @@
     },
     "packages/web": {
       "name": "@inbox-rs/web",
-      "version": "2.0.0",
+      "version": "2.0.4",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "@tiptap/core": "^3.22.1",

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -1664,20 +1664,11 @@ describe('load-time collection group repair', () => {
     expect(Object.values(get(groups)).some((g) => g.name === 'Uncategorized1')).toBe(false);
   });
 
-  it('repairs collections when a remote group deletion leaves them orphaned', async () => {
-    collections.set({ c1: makeCollection('c1', 'g1') });
-    groups.set({ g1: makeGroup('g1', ['c1']) });
-
-    emitModuleChange({
-      relativePath: 'groups/g1',
-      oldValue: makeGroup('g1', ['c1']),
-      newValue: undefined,
-    });
-    for (let i = 0; i < 5; i += 1) await Promise.resolve();
-
-    const uncatGroup = Object.values(get(groups)).find((g) => g.name === 'Uncategorized1');
-    expect(uncatGroup).toBeDefined();
-    expect(get(collections)['c1'].groupId).toBe(uncatGroup!.id);
-    expect(get(groups)[uncatGroup!.id].collectionIds).toContain('c1');
-  });
+  // Intentionally NOT auto-repaired: a 'groups/<id>' delete arriving via the
+  // RS change handler can be a transient mid-sync state (e.g. a group write
+  // hasn't landed yet on this device), and rewriting every dependent
+  // collection's groupId is destructive and propagates to all devices. This
+  // is exactly the v2.0.4 regression that wiped users' organization. Repair
+  // only runs at load time, where we can assert both stores are populated
+  // before deciding a collection is genuinely orphaned.
 });

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -233,20 +233,6 @@ async function repairCollectionsWithoutValidGroup() {
   }
 }
 
-let repairCollectionsQueued = false;
-function queueCollectionGroupRepair() {
-  if (repairCollectionsQueued) return;
-  repairCollectionsQueued = true;
-  queueMicrotask(async () => {
-    repairCollectionsQueued = false;
-    try {
-      await repairCollectionsWithoutValidGroup();
-    } catch (error) {
-      console.error('[inbox] failed to repair collection group membership:', error);
-    }
-  });
-}
-
 // Debounced sync indicator: stays visible for at least 1 second to avoid flicker
 let syncTimeout: ReturnType<typeof setTimeout> | null = null;
 let syncVisibleUntil = 0;
@@ -413,7 +399,6 @@ if (inboxRef) {
           ...current,
           [key]: { ...col, itemIds: Array.isArray(col.itemIds) ? col.itemIds : [] },
         }));
-        queueCollectionGroupRepair();
       } else if (!value) {
         collections.update(current => {
           const next = { ...current };
@@ -430,14 +415,12 @@ if (inboxRef) {
           ...current,
           [key]: { ...grp, collectionIds: Array.isArray(grp.collectionIds) ? grp.collectionIds : [] },
         }));
-        queueCollectionGroupRepair();
       } else if (!value) {
         groups.update(current => {
           const next = { ...current };
           delete next[key];
           return next;
         });
-        queueCollectionGroupRepair();
       }
     } else if (path === 'config/app') {
       if (value && typeof value === 'object') {


### PR DESCRIPTION
## Summary

- Surgical fix for the v2.0.4 data-loss bug: removes the three `queueCollectionGroupRepair()` calls in the RS `change` handler (and the now-unused helper), so incoming sync events no longer trigger destructive `groupId` rewrites.
- Keeps the rest of c2b1d79 intact: stricter `createCollection` invariant, simpler `moveCollectionToGroup` signature, cleaner `visibleGroupedCollections`, and the load-time repair (which is guarded by `collectionsLoaded && groupsLoaded` in the `connected` handler).

## Root cause

`repairCollectionsWithoutValidGroup()` filters collections by `!allGroups[col.groupId]` and rewrites the survivors via `moveCollectionToGroup()`. It was queued from the change handler on every `collections/*` and `groups/*` event, with no guard.

RS.js emits change events one item at a time during sync, and collections frequently arrive before their parent groups. The microtask-queued repair ran against a partially-populated `groups` store, declared healthy collections "homeless," and rewrote their `groupId` to point at `Uncategorized<N>` — persisting the bad state back to RS and propagating it to every device.

## What changes

```diff
-let repairCollectionsQueued = false;
-function queueCollectionGroupRepair() { ... }
-
        ...collections.update(...)
-       queueCollectionGroupRepair();
        ...groups.update(...)
-       queueCollectionGroupRepair();
```

That's the entire diff — 17 lines deleted, no new logic.

## Known follow-up

Load-time repair still carries a narrower version of the same risk: `loadCollections`/`loadGroups` read from the local RS cache, which can be inconsistent on a cold start. The `collectionsLoaded && groupsLoaded` guard only checks that `getAll` didn't throw, not that the cache is actually consistent with the server. Worth a follow-up hardening pass — either gate the repair behind an explicit "sync settled" signal, or convert it to a user-initiated cleanup action.

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] `stores.test.ts` suite passes
- [ ] Manual: connect with collections across multiple groups, force a fresh sync (clear cache, reload), confirm `groupId` values are unchanged
- [ ] Manual: create a collection without a group → still routes to `Uncategorized<N>` (createCollection invariant preserved? — check; if c2b1d79 made this throw, this is fine, just noting)
- [ ] Cut as **v2.0.5** via release workflow once merged