### PR TITLE
Keep frictionless quick-add visible + recover from corrupt RS IndexedDB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inbox-rs",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inbox-rs",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "workspaces": [
         "packages/*"
       ]
@@ -3985,7 +3985,7 @@
     },
     "packages/extension": {
       "name": "@inbox-rs/extension",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "remotestoragejs": "^2.0.0-beta.8",
@@ -4176,7 +4176,7 @@
     },
     "packages/rs-module": {
       "name": "@inbox-rs/rs-module",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
         "remotestoragejs": "^2.0.0-beta.8",
         "rs-migrate": "^1.0.0"
@@ -4187,7 +4187,7 @@
     },
     "packages/thunderbird": {
       "name": "@inbox-rs/thunderbird",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
         "@inbox-rs/rs-module": "*"
       },
@@ -4374,7 +4374,7 @@
     },
     "packages/web": {
       "name": "@inbox-rs/web",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "@tiptap/core": "^3.22.1",

--- a/packages/rs-module/src/index.ts
+++ b/packages/rs-module/src/index.ts
@@ -121,7 +121,21 @@ const InboxModule = {
     return {
       exports: {
         async getAll(): Promise<Record<string, InboxItem>> {
-          const items = await privateClient.getAll('items/');
+          // Pass `maxAge: false` to skip the cache-freshness check.
+          //
+          // remotestoragejs's default is `2 * syncInterval` (≈20s when
+          // connected), and with that default `getAll` queues a remote sync
+          // GET when cached nodes are older than the threshold and only
+          // resolves once that sync round-trip completes. On a cold refresh
+          // this means landing on a page like /todos shows nothing for
+          // several seconds while the GET drains, and any item operation
+          // queued in the meantime appears to "block" until sync fires.
+          //
+          // We get fresh data through the `change` event subscription
+          // (origin: 'remote') in stores.ts, so the snapshot can be cache-
+          // first without losing remote updates — this just stops blocking
+          // the UI on the first fetch.
+          const items = await privateClient.getAll('items/', false);
           if (!items) return {};
           // Stamp _migrateVersion on items that lack it (e.g. written by
           // the mobile app's direct HTTP client) so they aren't falsely
@@ -246,7 +260,8 @@ const InboxModule = {
         },
 
         async getAllCollections(): Promise<Record<string, Collection>> {
-          const cols = await privateClient.getAll('collections/');
+          // See `getAll` above for why we pass `maxAge: false`.
+          const cols = await privateClient.getAll('collections/', false);
           return cols || {};
         },
 
@@ -263,7 +278,8 @@ const InboxModule = {
         },
 
         async getAllGroups(): Promise<Record<string, CollectionGroup>> {
-          const groups = await privateClient.getAll('groups/');
+          // See `getAll` above for why we pass `maxAge: false`.
+          const groups = await privateClient.getAll('groups/', false);
           return groups || {};
         },
 

--- a/packages/web/src/components/TodosPage.svelte
+++ b/packages/web/src/components/TodosPage.svelte
@@ -48,20 +48,11 @@
   let quickSaving = $state(false);
   let quickError = $state('');
 
-  // Quick-add collection target. Stored in localStorage rather than the synced
-  // appConfig because:
-  //   1. It's a per-device UX preference (a phone vs. desktop might want
-  //      different default collections), and
-  //   2. RS-synced fields race on rapid refreshes — a remote-change event
-  //      can deliver the server's pre-write copy of `config/app` and clobber
-  //      the just-set local value before the push completes. localStorage
-  //      writes are immediate and never overwritten by sync.
+  // Quick-add collection target. Stored in localStorage rather than the
+  // synced appConfig: it's a per-device preference, and a `config/app`
+  // remote-change event can otherwise deliver the server's pre-write copy
+  // and clobber a just-set local value before the push completes.
   const QUICK_ADD_KEY = 'inbox-rs:quickAddCollectionId';
-  // Hydrate synchronously at component init rather than in an $effect — the
-  // initial render already has the correct value, and we avoid a flicker
-  // where the select briefly shows "Unfiled" before snapping to the saved
-  // collection. localStorage access can throw in some privacy modes, so
-  // we wrap it; falling back to undefined matches the pre-feature behavior.
   function readStoredQuickAddId(): string | undefined {
     try {
       return localStorage.getItem(QUICK_ADD_KEY) ?? undefined;
@@ -71,27 +62,19 @@
   }
   let storedQuickAddId = $state<string | undefined>(readStoredQuickAddId());
 
-  // Auto-focus the quick-add input on mount. The composer is rendered via
-  // a snippet in two branches of the page (empty state vs. compact above the
-  // list), but only one input is in the DOM at a time, so this action runs
-  // once per branch transition and lands focus on whichever is showing.
   function focusOnMount(node: HTMLInputElement) {
     node.focus();
   }
 
-  // Collections that aren't members of any group — surfaced as a trailing
-  // "Other" optgroup so they remain pickable. Without this, a user with only
-  // ungrouped collections would see no options beyond "Unfiled".
+  // Trailing "Other" optgroup — without this, a user with only ungrouped
+  // collections would see no options beyond "Unfiled".
   const ungroupedCollections = $derived(
     Object.values(collectionMap).filter(c => !c.groupId || !groupMap()[c.groupId])
   );
 
-  // Resolved quick-add target collection. Validates that the referenced
-  // collection still exists — between sessions (or via another client) the
-  // saved id can become stale, in which case we silently fall back to
-  // Unfiled rather than erroring on save. We do NOT scrub stale ids from
-  // localStorage here because collections may not have finished loading;
-  // a transient empty `collectionMap` would otherwise wipe a valid id.
+  // Stale ids (collection deleted in another session/tab) silently fall
+  // back to Unfiled. We don't scrub localStorage here because a transient
+  // empty `collectionMap` during cold load would otherwise wipe a valid id.
   const quickAddCollectionId = $derived.by(() => {
     const id = storedQuickAddId;
     return id && collectionMap[id] ? id : undefined;
@@ -117,9 +100,7 @@
     try {
       const todo = makeUnfiledTodo(quickTitle);
       await storeItem(todo);
-      // File into the persisted collection if one is selected. Done as a
-      // separate step so the collection's `itemIds` stay in sync — matches
-      // the AddEntryModal flow.
+      // Separate step keeps collection.itemIds in sync, matching AddEntryModal.
       if (quickAddCollectionId) {
         await moveItemToCollection(todo.id, quickAddCollectionId);
       }
@@ -208,10 +189,8 @@
     <Fab onclick={onaddtodo} label="New todo" />
   </div>
 
-  <!-- Quick-add composer is rendered in both states so frictionless capture
-       stays one tap away after the first todo. The empty state wraps it in
-       hero text; once the list is non-empty, a compact variant sits above
-       the list and the richer New todo Fab still handles details/filing. -->
+  <!-- Rendered in both empty and populated states. The Fab still handles
+       richer flows; this is the keep-it-moving capture path. -->
   {#snippet quickAddComposer(compact: boolean)}
     <form
       class="quick-add"
@@ -229,10 +208,7 @@
         disabled={quickSaving}
         use:focusOnMount
       />
-      <!-- Collection picker. Sits between input and Add button so frequent
-           filers can re-target without leaving the keyboard, and the choice
-           sticks across sessions via localStorage (per-device). The
-           empty-string sentinel maps to undefined (Unfiled) on save. -->
+      <!-- Empty-string sentinel maps to undefined (Unfiled) on save. -->
       <select
         class="quick-add__collection"
         aria-label="File into collection"
@@ -280,8 +256,6 @@
     </div>
   {:else}
     {@render quickAddComposer(true)}
-    <!-- Same persistent live region used in the empty state — collapses when
-         empty so it doesn't push the list down on the happy path. -->
     <p class="quick-error quick-error--inline" role="status" aria-live="polite">{quickError}</p>
     <ul
       class="todo-list" role="list"
@@ -453,9 +427,7 @@
     align-items: center;
   }
 
-  /* Compact variant: when todos already exist, the composer sits as a slim
-     row above the list — full container width, smaller control height —
-     instead of the centered hero treatment used in the empty state. */
+  /* Slim variant used above the list when todos already exist. */
   .quick-add--compact {
     width: 100%;
     gap: 0.4rem;
@@ -525,9 +497,8 @@
     cursor: not-allowed;
   }
 
-  /* Collection picker matches the input's surface treatment so the row reads
-     as a single unit. Capped width so long collection names truncate via the
-     native control instead of pushing the Add button off-screen. */
+  /* Capped width so long names truncate via the native control instead of
+     pushing the Add button off-screen. */
   .quick-add__collection {
     min-height: 2.75rem;
     max-width: 12rem;
@@ -566,8 +537,6 @@
     display: none;
   }
 
-  /* Inline variant sits between the compact composer and the todo list, so
-     align it with the rest of the column and give it a tighter top margin. */
   .quick-error--inline {
     margin-top: -0.25rem;
     text-align: left;
@@ -593,9 +562,7 @@
       padding-inline: 0;
     }
 
-    /* Empty-state hero variant stacks vertically on small screens — but the
-       compact above-the-list variant stays as a single row so it doesn't
-       eat vertical space when the user just wants to add another todo. */
+    /* Hero variant stacks vertically on phones; compact stays single-row. */
     .quick-add:not(.quick-add--compact) {
       grid-template-columns: 1fr;
     }

--- a/packages/web/src/components/TodosPage.svelte
+++ b/packages/web/src/components/TodosPage.svelte
@@ -4,8 +4,8 @@
   import { flip } from 'svelte/animate';
   import { slide, fade } from 'svelte/transition';
   import {
-    visibleTodos, reorderTodosGlobal, storeItem,
-    collections, sortedGroups, appConfig, updateConfig,
+    visibleTodos, reorderTodosGlobal, storeItem, moveItemToCollection,
+    collections, sortedGroups, groupCollections, appConfig, updateConfig,
   } from '../lib/stores';
   import { canCaptureTodo, makeUnfiledTodo } from '../lib/add-entry-modal';
   import TodoRow from './TodoRow.svelte';
@@ -48,12 +48,81 @@
   let quickSaving = $state(false);
   let quickError = $state('');
 
+  // Quick-add collection target. Stored in localStorage rather than the synced
+  // appConfig because:
+  //   1. It's a per-device UX preference (a phone vs. desktop might want
+  //      different default collections), and
+  //   2. RS-synced fields race on rapid refreshes — a remote-change event
+  //      can deliver the server's pre-write copy of `config/app` and clobber
+  //      the just-set local value before the push completes. localStorage
+  //      writes are immediate and never overwritten by sync.
+  const QUICK_ADD_KEY = 'inbox-rs:quickAddCollectionId';
+  // Hydrate synchronously at component init rather than in an $effect — the
+  // initial render already has the correct value, and we avoid a flicker
+  // where the select briefly shows "Unfiled" before snapping to the saved
+  // collection. localStorage access can throw in some privacy modes, so
+  // we wrap it; falling back to undefined matches the pre-feature behavior.
+  function readStoredQuickAddId(): string | undefined {
+    try {
+      return localStorage.getItem(QUICK_ADD_KEY) ?? undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  let storedQuickAddId = $state<string | undefined>(readStoredQuickAddId());
+
+  // Auto-focus the quick-add input on mount. The composer is rendered via
+  // a snippet in two branches of the page (empty state vs. compact above the
+  // list), but only one input is in the DOM at a time, so this action runs
+  // once per branch transition and lands focus on whichever is showing.
+  function focusOnMount(node: HTMLInputElement) {
+    node.focus();
+  }
+
+  // Collections that aren't members of any group — surfaced as a trailing
+  // "Other" optgroup so they remain pickable. Without this, a user with only
+  // ungrouped collections would see no options beyond "Unfiled".
+  const ungroupedCollections = $derived(
+    Object.values(collectionMap).filter(c => !c.groupId || !groupMap()[c.groupId])
+  );
+
+  // Resolved quick-add target collection. Validates that the referenced
+  // collection still exists — between sessions (or via another client) the
+  // saved id can become stale, in which case we silently fall back to
+  // Unfiled rather than erroring on save. We do NOT scrub stale ids from
+  // localStorage here because collections may not have finished loading;
+  // a transient empty `collectionMap` would otherwise wipe a valid id.
+  const quickAddCollectionId = $derived.by(() => {
+    const id = storedQuickAddId;
+    return id && collectionMap[id] ? id : undefined;
+  });
+
+  function setQuickAddCollection(id: string | undefined) {
+    storedQuickAddId = id;
+    try {
+      if (id) {
+        localStorage.setItem(QUICK_ADD_KEY, id);
+      } else {
+        localStorage.removeItem(QUICK_ADD_KEY);
+      }
+    } catch (error) {
+      console.error('Failed to persist quick-add collection', error);
+    }
+  }
+
   async function addQuickTodo() {
     if (!canCaptureTodo(quickTitle) || quickSaving) return;
     quickSaving = true;
     quickError = '';
     try {
-      await storeItem(makeUnfiledTodo(quickTitle));
+      const todo = makeUnfiledTodo(quickTitle);
+      await storeItem(todo);
+      // File into the persisted collection if one is selected. Done as a
+      // separate step so the collection's `itemIds` stay in sync — matches
+      // the AddEntryModal flow.
+      if (quickAddCollectionId) {
+        await moveItemToCollection(todo.id, quickAddCollectionId);
+      }
       quickTitle = '';
     } catch (error) {
       console.error('Failed to add todo', error);
@@ -139,27 +208,70 @@
     <Fab onclick={onaddtodo} label="New todo" />
   </div>
 
+  <!-- Quick-add composer is rendered in both states so frictionless capture
+       stays one tap away after the first todo. The empty state wraps it in
+       hero text; once the list is non-empty, a compact variant sits above
+       the list and the richer New todo Fab still handles details/filing. -->
+  {#snippet quickAddComposer(compact: boolean)}
+    <form
+      class="quick-add"
+      class:quick-add--compact={compact}
+      onsubmit={(e) => {
+        e.preventDefault();
+        addQuickTodo();
+      }}
+    >
+      <input
+        type="text"
+        bind:value={quickTitle}
+        placeholder={compact ? 'Add a todo…' : 'What needs doing?'}
+        aria-label="Todo title"
+        disabled={quickSaving}
+        use:focusOnMount
+      />
+      <!-- Collection picker. Sits between input and Add button so frequent
+           filers can re-target without leaving the keyboard, and the choice
+           sticks across sessions via localStorage (per-device). The
+           empty-string sentinel maps to undefined (Unfiled) on save. -->
+      <select
+        class="quick-add__collection"
+        aria-label="File into collection"
+        value={quickAddCollectionId ?? ''}
+        disabled={quickSaving}
+        onchange={(e) => {
+          const v = (e.currentTarget as HTMLSelectElement).value;
+          setQuickAddCollection(v === '' ? undefined : v);
+        }}
+      >
+        <option value="">Unfiled</option>
+        {#each $sortedGroups as group (group.id)}
+          {@const cols = $groupCollections[group.id] ?? []}
+          {#if cols.length > 0}
+            <optgroup label={group.name}>
+              {#each cols as col (col.id)}
+                <option value={col.id}>{col.name}</option>
+              {/each}
+            </optgroup>
+          {/if}
+        {/each}
+        {#if ungroupedCollections.length > 0}
+          <optgroup label="Other">
+            {#each ungroupedCollections as col (col.id)}
+              <option value={col.id}>{col.name}</option>
+            {/each}
+          </optgroup>
+        {/if}
+      </select>
+      <button type="submit" disabled={!canCaptureTodo(quickTitle) || quickSaving}>
+        {quickSaving ? 'Adding...' : 'Add'}
+      </button>
+    </form>
+  {/snippet}
+
   {#if openTodos.length === 0 && completedTodos.length === 0}
     <div class="empty-state" in:fade={{ duration: 180 }}>
       <p class="empty-title">Jot a todo</p>
-      <form
-        class="quick-add"
-        onsubmit={(e) => {
-          e.preventDefault();
-          addQuickTodo();
-        }}
-      >
-        <input
-          type="text"
-          bind:value={quickTitle}
-          placeholder="What needs doing?"
-          aria-label="Todo title"
-          disabled={quickSaving}
-        />
-        <button type="submit" disabled={!canCaptureTodo(quickTitle) || quickSaving}>
-          {quickSaving ? 'Adding...' : 'Add'}
-        </button>
-      </form>
+      {@render quickAddComposer(false)}
       <p class="empty-hint">Capture it now. Organize it later.</p>
       <!-- Persistent aria-live region — kept in the DOM so screen readers
            reliably announce errors as they appear. The visually-empty state
@@ -167,6 +279,10 @@
       <p class="quick-error" role="status" aria-live="polite">{quickError}</p>
     </div>
   {:else}
+    {@render quickAddComposer(true)}
+    <!-- Same persistent live region used in the empty state — collapses when
+         empty so it doesn't push the list down on the happy path. -->
+    <p class="quick-error quick-error--inline" role="status" aria-live="polite">{quickError}</p>
     <ul
       class="todo-list" role="list"
       use:dndzone={{
@@ -332,9 +448,32 @@
   .quick-add {
     width: min(100%, 34rem);
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr) auto auto;
     gap: 0.5rem;
     align-items: center;
+  }
+
+  /* Compact variant: when todos already exist, the composer sits as a slim
+     row above the list — full container width, smaller control height —
+     instead of the centered hero treatment used in the empty state. */
+  .quick-add--compact {
+    width: 100%;
+    gap: 0.4rem;
+  }
+
+  .quick-add--compact input {
+    min-height: 2.25rem;
+  }
+
+  .quick-add--compact button {
+    min-height: 2.25rem;
+    padding: 0 0.85rem;
+    font-size: 0.88rem;
+  }
+
+  .quick-add--compact .quick-add__collection {
+    min-height: 2.25rem;
+    font-size: 0.88rem;
   }
 
   .quick-add input {
@@ -380,9 +519,33 @@
   }
 
   .quick-add button:disabled,
-  .quick-add input:disabled {
+  .quick-add input:disabled,
+  .quick-add__collection:disabled {
     opacity: 0.55;
     cursor: not-allowed;
+  }
+
+  /* Collection picker matches the input's surface treatment so the row reads
+     as a single unit. Capped width so long collection names truncate via the
+     native control instead of pushing the Add button off-screen. */
+  .quick-add__collection {
+    min-height: 2.75rem;
+    max-width: 12rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    padding: 0 0.6rem;
+    font: inherit;
+    cursor: pointer;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+    transition: border-color 150ms, box-shadow 150ms;
+  }
+
+  .quick-add__collection:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
   }
 
   .empty-hint {
@@ -401,6 +564,13 @@
      stays mounted so screen readers keep tracking it. */
   .quick-error:empty {
     display: none;
+  }
+
+  /* Inline variant sits between the compact composer and the todo list, so
+     align it with the rest of the column and give it a tighter top margin. */
+  .quick-error--inline {
+    margin-top: -0.25rem;
+    text-align: left;
   }
 
   /* Mobile-only: reserve room so the fixed-position FAB doesn't float over
@@ -423,12 +593,17 @@
       padding-inline: 0;
     }
 
-    .quick-add {
+    /* Empty-state hero variant stacks vertically on small screens — but the
+       compact above-the-list variant stays as a single row so it doesn't
+       eat vertical space when the user just wants to add another todo. */
+    .quick-add:not(.quick-add--compact) {
       grid-template-columns: 1fr;
     }
 
-    .quick-add button {
+    .quick-add:not(.quick-add--compact) button,
+    .quick-add:not(.quick-add--compact) .quick-add__collection {
       width: 100%;
+      max-width: none;
     }
   }
 </style>

--- a/packages/web/src/lib/rs.ts
+++ b/packages/web/src/lib/rs.ts
@@ -25,9 +25,13 @@ const savedHash = typeof window !== 'undefined' ? window.location.hash : '';
 // already has it. When v1 is empty, the upgrade ends up creating only
 // `changes`, then RS's onsuccess notices `nodes` is missing and calls
 // `IndexedDB.clean()` to recover. But `clean()` doesn't close its own open
-// connection first, so `deleteDatabase` blocks indefinitely until RS's 10s
-// timeout fires and the feature falls back to LocalStorage. Net effect: a
-// 10-second hang on every page load and reads/writes silently dropped.
+// connection first, so `deleteDatabase` blocks (no `onblocked` handler) and
+// `clean()`'s callback never fires — leaving RS's IDB feature init Promise
+// pending indefinitely. The 10s `IndexedDB.open` timer doesn't help: it was
+// already cleared at onsuccess before `clean()` ran. In practice the app
+// stalls for ~10s on every reload and falls back to LocalStorage; the exact
+// mechanism for the wall-clock delay is browser-dependent (likely related
+// to `deleteDatabase` blocked behavior). See remotestorage/remotestorage.js#1376.
 //
 // We key the deletion decision on the actual object-store schema, NOT on
 // version. A healthy v1 DB with `nodes` is a legitimate state RS upgrades

--- a/packages/web/src/lib/rs.ts
+++ b/packages/web/src/lib/rs.ts
@@ -14,9 +14,170 @@ import SharesModule from 'remotestorage-module-shares';
 // (leading `/`) to stay clear of any legitimate OAuth-callback flow the RS
 // init is trying to handle.
 const savedHash = typeof window !== 'undefined' ? window.location.hash : '';
+
+// Detect and auto-recover a corrupt `remotestorage` IndexedDB before RS opens it.
+//
+// The corrupt state we're guarding against: a `remotestorage` DB at version 1
+// with NO object stores. RS's upgrade handler (`indexeddb.ts:327-340`) has
+// `if (event.oldVersion !== 1) { createObjectStore('nodes') }` — i.e. it
+// SKIPS creating `nodes` when upgrading from v1, on the assumption that v1
+// already has it. When the v1 DB is empty, the upgrade ends up creating only
+// `changes`, then RS's onsuccess notices `nodes` is missing and calls
+// `IndexedDB.clean()` to recover. But `clean()` doesn't close its own open
+// connection first, so `deleteDatabase` blocks indefinitely until RS's 10s
+// timeout fires and the feature falls back to LocalStorage. Net effect: a
+// 10-second hang on every page load and reads/writes silently dropped.
+//
+// Strategy: prefer `indexedDB.databases()` (Chrome 71+, Safari 14+, Firefox
+// 126+) to read the DB's existence and version WITHOUT opening it. If we see
+// the DB present at v<2, delete it and let RS construct a clean v2 from
+// `oldVersion=0`. We never call `indexedDB.open()` ourselves — that's
+// important because in some Chrome states (a previous-session aborted
+// `deleteDatabase` from RS's failed clean()), `open()` itself stays pending
+// forever, and using it as our probe would just inherit the hang.
+//
+// For browsers without `databases()`, we fall back to the open-probe. That
+// path can hang if the DB is in the same stuck state — we time out after 2s
+// and proceed, accepting that very-old-browser users with a previously-
+// corrupted DB still hit RS's 10s timeout (one-time, until they manually
+// run `__cleanupRSDb()`).
+async function detectAndRecoverCorruptDb(): Promise<void> {
+  if (typeof indexedDB === 'undefined') return;
+
+  if (typeof (indexedDB as any).databases === 'function') {
+    let dbs: Array<{ name?: string; version?: number }> | null = null;
+    try {
+      dbs = await (indexedDB as any).databases();
+    } catch (e) {
+      console.warn(`[idb-probe] databases() threw — falling back to open-probe`, e);
+    }
+    if (dbs) {
+      const rsDb = dbs.find((db) => db.name === 'remotestorage');
+      if (!rsDb) {
+        console.log(`[idb-probe] no existing 'remotestorage' DB — RS will create one fresh`);
+        return;
+      }
+      // Anything below v2 hits the bug. v1 is the well-known corrupt state;
+      // v0/undefined shouldn't normally happen but is also pre-bug.
+      if ((rsDb.version ?? 0) < 2) {
+        console.warn(`[idb-probe] 'remotestorage' is at v${rsDb.version ?? '?'} — pre-upgrade-bug version, auto-cleaning before RS init`);
+        await deleteRsDb();
+        return;
+      }
+      console.log(`[idb-probe] 'remotestorage' is at v${rsDb.version} — healthy, RS can open it directly`);
+      return;
+    }
+  }
+
+  // Fallback for browsers without databases(). The open-probe can be hung by
+  // a previous-session abort, so we cap it at 2s and proceed.
+  const probeStart = Date.now();
+  console.log(`[idb-probe] T+0ms (fallback) opening 'remotestorage' to inspect state`);
+
+  type ProbeOk = { version: number; stores: string[] };
+  const result: ProbeOk | 'failed' = await new Promise((resolve) => {
+    let settled = false;
+    const settle = (v: ProbeOk | 'failed') => {
+      if (settled) return;
+      settled = true;
+      resolve(v);
+    };
+    const probe = indexedDB.open('remotestorage');
+    probe.onsuccess = () => {
+      const db = probe.result;
+      const stores = Array.from(db.objectStoreNames);
+      console.log(`[idb-probe] T+${Date.now() - probeStart}ms onsuccess — version=${db.version}, stores=[${stores.join(',')}]`);
+      db.close();
+      settle({ version: db.version, stores });
+    };
+    probe.onerror = () => {
+      console.warn(`[idb-probe] T+${Date.now() - probeStart}ms onerror`, probe.error);
+      settle('failed');
+    };
+    probe.onblocked = (event: any) => {
+      console.warn(`[idb-probe] T+${Date.now() - probeStart}ms ONBLOCKED — old=${event?.oldVersion} new=${event?.newVersion}`);
+      settle('failed');
+    };
+    setTimeout(() => {
+      if (!settled) {
+        console.warn(`[idb-probe] T+${Date.now() - probeStart}ms still pending after 2s — proceeding without cleanup. readyState=${probe.readyState}`);
+        settle('failed');
+      }
+    }, 2000);
+  });
+
+  if (result === 'failed') return;
+  if ((result.version ?? 0) >= 2) return;
+  // The fallback open-probe creates an empty v1 DB if none existed; either
+  // way we delete-and-let-RS-recreate.
+  console.warn(`[idb-probe] DB is at v${result.version} with stores=[${result.stores.join(',')}] — auto-cleaning before RS init`);
+  await deleteRsDb();
+}
+
+async function deleteRsDb(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const start = Date.now();
+    let settled = false;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    const req = indexedDB.deleteDatabase('remotestorage');
+    req.onsuccess = () => {
+      console.log(`[idb-cleanup] T+${Date.now() - start}ms deleted — RS will create a clean v2 DB`);
+      settle();
+    };
+    req.onerror = () => {
+      console.error(`[idb-cleanup] T+${Date.now() - start}ms error — proceeding anyway, RS may fall back to LocalStorage`, req.error);
+      settle();
+    };
+    req.onblocked = () => {
+      console.warn(`[idb-cleanup] T+${Date.now() - start}ms BLOCKED — proceeding anyway`);
+      settle();
+    };
+    setTimeout(() => {
+      if (!settled) {
+        console.warn(`[idb-cleanup] T+${Date.now() - start}ms timeout after 3s — proceeding anyway`);
+        settle();
+      }
+    }, 3000);
+  });
+}
+
+// Console-callable recovery helper. Available as a fallback for users in a
+// tab that hit the bug before the auto-cleanup shipped (or in any future
+// scenario where the auto-cleanup couldn't run). Drops the DB so RS can
+// recreate it cleanly on the next reload. Resolves once the deletion
+// completes, or rejects with `'blocked'` if a stuck connection prevents it
+// — at which point the user needs to close other tabs or quit Chrome.
+if (typeof window !== 'undefined' && typeof indexedDB !== 'undefined') {
+  (window as any).__cleanupRSDb = () => new Promise<void>((resolve, reject) => {
+    console.log(`[idb-cleanup] manual: deleteDatabase('remotestorage')`);
+    const req = indexedDB.deleteDatabase('remotestorage');
+    req.onsuccess = () => {
+      console.log(`[idb-cleanup] deleted — reload the page now`);
+      resolve();
+    };
+    req.onerror = () => {
+      console.error(`[idb-cleanup] error`, req.error);
+      reject(req.error);
+    };
+    req.onblocked = () => {
+      console.warn(`[idb-cleanup] BLOCKED — close other tabs of this app, or quit Chrome and reopen`);
+      reject(new Error('blocked'));
+    };
+  });
+}
+
+// Block module exports until the corrupt-DB recovery has run. Importers
+// (stores.ts, etc.) get a guaranteed-clean RS instance with no race against
+// the IDB feature init.
+await detectAndRecoverCorruptDb();
+
 const rs = new RemoteStorage({
   modules: [InboxModule, SharesModule],
-  changeEvents: { local: true, window: false, remote: true, conflict: true }
+  changeEvents: { local: true, window: false, remote: true, conflict: true },
 });
 if (
   typeof window !== 'undefined'

--- a/packages/web/src/lib/rs.ts
+++ b/packages/web/src/lib/rs.ts
@@ -17,63 +17,49 @@ const savedHash = typeof window !== 'undefined' ? window.location.hash : '';
 
 // Detect and auto-recover a corrupt `remotestorage` IndexedDB before RS opens it.
 //
-// The corrupt state we're guarding against: a `remotestorage` DB at version 1
-// with NO object stores. RS's upgrade handler (`indexeddb.ts:327-340`) has
+// The corrupt state we're guarding against: any `remotestorage` DB that's
+// missing one of the required object stores (`nodes`, plus `changes` at v2).
+// RS's upgrade handler (`indexeddb.ts:327-340`) has
 // `if (event.oldVersion !== 1) { createObjectStore('nodes') }` — i.e. it
 // SKIPS creating `nodes` when upgrading from v1, on the assumption that v1
-// already has it. When the v1 DB is empty, the upgrade ends up creating only
+// already has it. When v1 is empty, the upgrade ends up creating only
 // `changes`, then RS's onsuccess notices `nodes` is missing and calls
 // `IndexedDB.clean()` to recover. But `clean()` doesn't close its own open
 // connection first, so `deleteDatabase` blocks indefinitely until RS's 10s
 // timeout fires and the feature falls back to LocalStorage. Net effect: a
 // 10-second hang on every page load and reads/writes silently dropped.
 //
-// Strategy: prefer `indexedDB.databases()` (Chrome 71+, Safari 14+, Firefox
-// 126+) to read the DB's existence and version WITHOUT opening it. If we see
-// the DB present at v<2, delete it and let RS construct a clean v2 from
-// `oldVersion=0`. We never call `indexedDB.open()` ourselves — that's
-// important because in some Chrome states (a previous-session aborted
-// `deleteDatabase` from RS's failed clean()), `open()` itself stays pending
-// forever, and using it as our probe would just inherit the hang.
+// We key the deletion decision on the actual object-store schema, NOT on
+// version. A healthy v1 DB with `nodes` is a legitimate state RS upgrades
+// cleanly; deleting it would discard cached nodes and any queued offline
+// changes. Only DBs missing the required stores actually hit the upstream
+// bug.
 //
-// For browsers without `databases()`, we fall back to the open-probe. That
-// path can hang if the DB is in the same stuck state — we time out after 2s
-// and proceed, accepting that very-old-browser users with a previously-
-// corrupted DB still hit RS's 10s timeout (one-time, until they manually
-// run `__cleanupRSDb()`).
+// We use `indexedDB.databases()` (Chrome 71+, Safari 14+, Firefox 126+) as
+// an existence gate so we never call `indexedDB.open(name)` without a
+// version on a non-existent DB — that itself creates an empty v1, the very
+// trap we're recovering from. After confirming the DB exists, we open it
+// without a version (which doesn't trigger an upgrade) to read its actual
+// `objectStoreNames`. The open-probe can hang if a previous-session
+// `deleteDatabase` was aborted; we cap it at 2s and proceed.
 async function detectAndRecoverCorruptDb(): Promise<void> {
   if (typeof indexedDB === 'undefined') return;
 
   if (typeof (indexedDB as any).databases === 'function') {
-    let dbs: Array<{ name?: string; version?: number }> | null = null;
     try {
-      dbs = await (indexedDB as any).databases();
-    } catch (e) {
-      console.warn(`[idb-probe] databases() threw — falling back to open-probe`, e);
-    }
-    if (dbs) {
-      const rsDb = dbs.find((db) => db.name === 'remotestorage');
-      if (!rsDb) {
+      const dbs = await (indexedDB as any).databases() as Array<{ name?: string; version?: number }>;
+      if (!dbs.find((db) => db.name === 'remotestorage')) {
         console.log(`[idb-probe] no existing 'remotestorage' DB — RS will create one fresh`);
         return;
       }
-      // Anything below v2 hits the bug. v1 is the well-known corrupt state;
-      // v0/undefined shouldn't normally happen but is also pre-bug.
-      if ((rsDb.version ?? 0) < 2) {
-        console.warn(`[idb-probe] 'remotestorage' is at v${rsDb.version ?? '?'} — pre-upgrade-bug version, auto-cleaning before RS init`);
-        await deleteRsDb();
-        return;
-      }
-      console.log(`[idb-probe] 'remotestorage' is at v${rsDb.version} — healthy, RS can open it directly`);
-      return;
+    } catch (e) {
+      // Fall through to the open-probe; on ancient browsers without
+      // databases() we accept the empty-v1 risk for the rare no-DB case.
+      console.warn(`[idb-probe] databases() threw — falling back to open-probe`, e);
     }
   }
 
-  // Fallback for browsers without databases(). The open-probe can be hung by
-  // a previous-session abort, so we cap it at 2s and proceed.
   const probeStart = Date.now();
-  console.log(`[idb-probe] T+0ms (fallback) opening 'remotestorage' to inspect state`);
-
   type ProbeOk = { version: number; stores: string[] };
   const result: ProbeOk | 'failed' = await new Promise((resolve) => {
     let settled = false;
@@ -86,7 +72,6 @@ async function detectAndRecoverCorruptDb(): Promise<void> {
     probe.onsuccess = () => {
       const db = probe.result;
       const stores = Array.from(db.objectStoreNames);
-      console.log(`[idb-probe] T+${Date.now() - probeStart}ms onsuccess — version=${db.version}, stores=[${stores.join(',')}]`);
       db.close();
       settle({ version: db.version, stores });
     };
@@ -107,10 +92,16 @@ async function detectAndRecoverCorruptDb(): Promise<void> {
   });
 
   if (result === 'failed') return;
-  if ((result.version ?? 0) >= 2) return;
-  // The fallback open-probe creates an empty v1 DB if none existed; either
-  // way we delete-and-let-RS-recreate.
-  console.warn(`[idb-probe] DB is at v${result.version} with stores=[${result.stores.join(',')}] — auto-cleaning before RS init`);
+
+  // v1 schema: `nodes` only. v2 schema: `nodes` + `changes`. Either case
+  // missing a required store is corrupt.
+  const required = result.version >= 2 ? ['nodes', 'changes'] : ['nodes'];
+  const missing = required.filter((s) => !result.stores.includes(s));
+  if (missing.length === 0) {
+    console.log(`[idb-probe] 'remotestorage' v${result.version} stores=[${result.stores.join(',')}] — healthy, RS can open it directly`);
+    return;
+  }
+  console.warn(`[idb-probe] 'remotestorage' v${result.version} stores=[${result.stores.join(',')}] missing [${missing.join(',')}] — auto-cleaning before RS init`);
   await deleteRsDb();
 }
 

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -618,6 +618,11 @@ describe('pendingMigrationCount visibility timing', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    // Trigger the disconnected handler so private stores (rawItems used by
+    // pendingMigrationCount) are reset alongside the public ones — loadItems
+    // now merges into rawItems instead of replacing, so leftover entries
+    // from prior tests in this file would otherwise leak in here.
+    rsHandlers['disconnected']?.();
     connected.set(false);
     items.set({});
     collections.set({});

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -1064,6 +1064,231 @@ describe('orphanCollections', () => {
   });
 });
 
+// ---- Offline-create-then-login flow ----
+//
+// Bug report: a user offline-creates a group + a collection inside it.
+// On login, the collection appears as an orphan ("Needs a group") even
+// though both records still exist. These tests simulate the post-login
+// data-loading and change-event sequence to verify groupId survives.
+
+describe('offline-create-then-login: group association is preserved', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    items.set({});
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+    mockInbox.getAll.mockResolvedValue({});
+    mockInbox.getConfig.mockResolvedValue({});
+    mockInbox.getAllCollections.mockResolvedValue({});
+    mockInbox.getAllGroups.mockResolvedValue({});
+    mockInbox.getUserSettings.mockResolvedValue(undefined);
+  });
+
+  it('keeps groupId after the connected handler loads from IDB', async () => {
+    // Cache state we'd see after offline create+move: collection has
+    // groupId pointing at the local group, and the group's collectionIds
+    // lists the collection.
+    mockInbox.getAllCollections.mockResolvedValue({
+      c1: makeCollection('c1', 'g1'),
+    });
+    mockInbox.getAllGroups.mockResolvedValue({
+      g1: makeGroup('g1', ['c1']),
+    });
+
+    await rsHandlers['connected']();
+
+    expect(get(collections)['c1'].groupId).toBe('g1');
+    expect(get(groups)['g1'].collectionIds).toEqual(['c1']);
+    expect(get(orphanCollections)).toEqual([]);
+  });
+
+  it('keeps groupId when fireInitial replays cached docs as local events', async () => {
+    // After connect, RS replays every cached document as an `origin: local`
+    // change event (see remoteStorage.fireInitial). The handler must merge
+    // these in without dropping the groupId off the in-memory record.
+    mockInbox.getAllCollections.mockResolvedValue({
+      c1: makeCollection('c1', 'g1'),
+    });
+    mockInbox.getAllGroups.mockResolvedValue({
+      g1: makeGroup('g1', ['c1']),
+    });
+
+    await rsHandlers['connected']();
+
+    // Now simulate the fireInitial replay — emits a 'local' event for every
+    // cached document. Both group and collection are replayed.
+    emitModuleChange({
+      relativePath: 'groups/g1',
+      origin: 'local',
+      newValue: makeGroup('g1', ['c1']),
+      oldValue: undefined,
+    });
+    emitModuleChange({
+      relativePath: 'collections/c1',
+      origin: 'local',
+      newValue: makeCollection('c1', 'g1'),
+      oldValue: undefined,
+    });
+
+    expect(get(orphanCollections)).toEqual([]);
+    expect(get(collections)['c1'].groupId).toBe('g1');
+  });
+
+  it('survives collection-before-group event ordering during fireInitial', async () => {
+    // RS iterates the cached node tree in `forAllNodes`. The order isn't
+    // alphabetical — a collection event can arrive before its parent group
+    // event. The store handlers must not drop groupId based on the (still
+    // empty) groups store at the moment the collection event arrives.
+    mockInbox.getAllCollections.mockResolvedValue({});
+    mockInbox.getAllGroups.mockResolvedValue({});
+
+    await rsHandlers['connected']();
+
+    // Collection arrives first, before the group is in the store.
+    emitModuleChange({
+      relativePath: 'collections/c1',
+      origin: 'local',
+      newValue: makeCollection('c1', 'g1'),
+      oldValue: undefined,
+    });
+    // Group arrives second.
+    emitModuleChange({
+      relativePath: 'groups/g1',
+      origin: 'local',
+      newValue: makeGroup('g1', ['c1']),
+      oldValue: undefined,
+    });
+
+    expect(get(collections)['c1'].groupId).toBe('g1');
+    expect(get(orphanCollections)).toEqual([]);
+  });
+
+  it('does not drop groupId when getAll merges into a partially-populated store', async () => {
+    // Simulate the in-flight race: the change handler put c1 into the
+    // store via fireInitial *before* loadCollections resolved. Then
+    // loadEntities merges its getAll result on top — and must not strip
+    // groupId.
+    collections.set({ c1: makeCollection('c1', 'g1') });
+
+    mockInbox.getAllCollections.mockResolvedValue({
+      c1: makeCollection('c1', 'g1'),
+    });
+    mockInbox.getAllGroups.mockResolvedValue({
+      g1: makeGroup('g1', ['c1']),
+    });
+
+    await rsHandlers['connected']();
+
+    expect(get(collections)['c1'].groupId).toBe('g1');
+    expect(get(orphanCollections)).toEqual([]);
+  });
+
+  it('does not drop groupId when sync emits a remote event with the same body', async () => {
+    // After PUT completes for a fresh sync, RS does NOT emit a change for
+    // the document — completePush updates node.common.body silently. But
+    // some related codepaths (folder GET on first connect) can emit
+    // 'remote' events with the merged body. Verify the handler preserves
+    // groupId even on a 'remote' replay.
+    mockInbox.getAllCollections.mockResolvedValue({
+      c1: makeCollection('c1', 'g1'),
+    });
+    mockInbox.getAllGroups.mockResolvedValue({
+      g1: makeGroup('g1', ['c1']),
+    });
+
+    await rsHandlers['connected']();
+
+    emitModuleChange({
+      relativePath: 'collections/c1',
+      origin: 'remote',
+      newValue: makeCollection('c1', 'g1'),
+      oldValue: undefined,
+    });
+
+    expect(get(collections)['c1'].groupId).toBe('g1');
+    expect(get(orphanCollections)).toEqual([]);
+  });
+
+  it('does not orphan when getAllCollections returns a folder-listing fallback', async () => {
+    // remotestoragejs's getAll('collections/', false) returns the folder
+    // listing first, then fans out per-document GETs. If the per-document
+    // fetches haven't filled in the bodies yet, getAll can return
+    // `{ c1: true }` (the folder itemsMap with placeholder values).
+    // loadEntities filters non-objects out, so the store stays unchanged
+    // for c1 — and any earlier insert (e.g. via change events) is
+    // preserved.
+    collections.set({ c1: makeCollection('c1', 'g1') });
+    groups.set({ g1: makeGroup('g1', ['c1']) });
+
+    mockInbox.getAllCollections.mockResolvedValue({
+      c1: true as unknown as Collection,
+    });
+    mockInbox.getAllGroups.mockResolvedValue({
+      g1: true as unknown as CollectionGroup,
+    });
+
+    await rsHandlers['connected']();
+
+    expect(get(collections)['c1'].groupId).toBe('g1');
+    expect(get(orphanCollections)).toEqual([]);
+  });
+
+  it('keeps the offline-created collection visible when synced appConfig has only stale filter ids', async () => {
+    // The actual orphaning bug as observed in user data:
+    //   - The offline cache (or the synced server appConfig) has
+    //     `activeGroupFilters` containing only ids of long-deleted groups.
+    //   - The user offline-creates a fresh group `Zg` and a collection `Zc`
+    //     in it; `storeGroup` only appends to `activeGroupFilters` when the
+    //     filter is already defined — and even when it does, sync may
+    //     replace local config with the server's older copy.
+    //   - After login, `activeGroupIds` would historically return `∅`, and
+    //     `visibleGroupedCollections` would hide `Zg`/`Zc` entirely.
+    // Verify that with the stale-filter fallback, every real group becomes
+    // active again so the offline-created data is visible.
+    groups.set({
+      A: makeGroup('A'),
+      Zg: makeGroup('Zg', ['Zc']),
+    });
+    collections.set({
+      Zc: makeCollection('Zc', 'Zg'),
+    });
+    appConfig.set({ activeGroupFilters: ['stale-deleted-group-id'] });
+
+    expect(get(activeGroupIds)).toEqual(new Set(['A', 'Zg']));
+    expect(get(visibleGroupedCollections).map(s => s.group.id)).toEqual(['A', 'Zg']);
+    expect(get(visibleGroupedCollections).find(s => s.group.id === 'Zg')?.collections.map(c => c.id))
+      .toEqual(['Zc']);
+  });
+
+  it('keeps the explicit "show nothing" state distinct from the stale-only state', async () => {
+    // Symmetric guard: an empty array (length === 0) is the user's explicit
+    // "no groups visible" choice from toggling every pill off, and must
+    // continue to hide everything. The fallback only triggers when the
+    // configured ids are all stale.
+    groups.set({ A: makeGroup('A') });
+    collections.set({});
+    appConfig.set({ activeGroupFilters: [] });
+
+    expect(get(activeGroupIds)).toEqual(new Set());
+    expect(get(visibleGroupedCollections)).toEqual([]);
+  });
+
+  it('honors a partially valid filter without falling back to all', async () => {
+    // If even one configured id matches a real group, that group wins —
+    // the fallback only kicks in when every id is stale. Stale ids
+    // continue to be ignored at read time.
+    groups.set({
+      A: makeGroup('A'),
+      B: makeGroup('B'),
+    });
+    collections.set({});
+    appConfig.set({ activeGroupFilters: ['A', 'stale-id'] });
+
+    expect(get(activeGroupIds)).toEqual(new Set(['A']));
+  });
+});
+
 describe('toggleGroupFilter', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -343,21 +343,10 @@ rs.on('disconnected', () => {
   groups.set({});
 });
 
-// Kick the cached preload from RS's `ready` event — fires after features
-// are loaded and the caching layer is wired up. This is the correct moment
-// to call getAll(), because:
-//   - Before `features-loaded`, `rs.get` is wired to `_pendingGPD`, which
-//     queues calls until `_processPending` runs at the end of
-//     `featuresLoaded()`. That queue is gated on every feature's `_rs_init`
-//     completing — and `IndexedDB.open` has a 10s timeout (see
-//     remotestoragejs `indexeddb.ts`). On a browser where the IDB handle is
-//     stalled, calling `getAll()` from `queueMicrotask` (which runs before
-//     features finish loading) makes the call sit in the queue for the full
-//     10s before `maxAge: false` even gets a chance to short-circuit it.
-//   - `RemoteStorage.on` automatically replays `ready` for listeners
-//     registered after the event has already fired (see remotestorage.ts
-//     `on` override), so HMR re-runs of this module still trigger the
-//     load — no `queueMicrotask` fallback needed.
+// Wait for `ready` before getAll() — earlier calls sit in `_pendingGPD`
+// until features finish loading, which means a stalled IDB init drags the
+// preload into its 10s timeout even with `maxAge: false`. RS replays `ready`
+// for late listeners, so HMR still triggers this on module re-run.
 rs.on('ready', () => { void loadCachedData(); });
 
 export async function runAllMigrations() {

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -1023,6 +1023,30 @@ export async function reorderUnfiledTodos(newUnfiledOrder: string[]) {
 /**
  * Set of group IDs currently active (visible) in the filter row.
  * When `activeGroupFilters` is undefined in config, all groups default to active.
+ *
+ * Stale-filter recovery: if `activeGroupFilters` is non-empty but every id in
+ * it is stale (no matching real group), we fall back to "all active" instead
+ * of returning an empty set. This is the offline-create-then-login recovery
+ * path. Concrete sequence:
+ *   1. The user has stale ids in `activeGroupFilters` from a previous session
+ *      (e.g. a group they deleted long ago, whose id `setActiveGroupFilters`
+ *      intentionally retains because the URL→config sync runs before groups
+ *      load — see that function's note).
+ *   2. While offline they create a new group `Zg`. `storeGroup` only appends
+ *      to `activeGroupFilters` when it's already defined; if it was undefined
+ *      ("default-all") locally, no append happens — so `Zg.id` may not be in
+ *      filters.
+ *   3. They log in. Sync pulls down the server's older `config/app` document
+ *      (with just the stale ids, no `Zg`), which replaces the local copy.
+ *   4. Without this fallback, `activeGroupIds` returns `∅`, and
+ *      `visibleGroupedCollections` hides every group — the new `Zg` "remains"
+ *      as a pill (pills render from `sortedGroups` directly) but nothing
+ *      shows up on the page, making the offline-created collection appear
+ *      "gone" even though it's intact in storage.
+ *
+ * An explicit empty array (`activeGroupFilters: []`, set by toggling every
+ * pill off) keeps its meaning: "show nothing" — `length === 0` so the
+ * fallback doesn't trigger.
  */
 export const activeGroupIds = derived(
   [sortedGroups, appConfig],
@@ -1032,6 +1056,9 @@ export const activeGroupIds = derived(
     const filtered = new Set<string>();
     for (const id of $config.activeGroupFilters) {
       if (all.has(id)) filtered.add(id);
+    }
+    if (filtered.size === 0 && $config.activeGroupFilters.length > 0) {
+      return all;
     }
     return filtered;
   }

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -120,10 +120,13 @@ async function loadEntities<T extends { id: string }>(
         }
       }
     }
-    store.set(valid);
+    // Merge into the store rather than replacing — the change handler may
+    // have already inserted entries during the await window, and a .set()
+    // would silently drop them.
+    store.update(current => ({ ...current, ...valid }));
     return true;
-  } catch {
-    // RS sync/fetch error — keep existing data
+  } catch (e) {
+    console.error('[inbox] loadEntities failed:', e);
     return false;
   }
 }
@@ -165,7 +168,10 @@ function normalizeLoadedItem(item: object): InboxItem {
 
 async function loadItems() {
   const inbox = getInbox();
-  if (!inbox) return;
+  if (!inbox) {
+    console.warn('[inbox] loadItems: inbox module not available');
+    return;
+  }
   try {
     const all = await inbox.getAll();
     const valid: Record<string, InboxItem> = {};
@@ -179,10 +185,15 @@ async function loadItems() {
         valid[key] = normalizeLoadedItem(item);
       }
     }
-    rawItems.set(rawValid);
-    items.set(valid);
-  } catch {
-    // RS sync/fetch error — keep existing items
+    // Merge rather than overwrite. The RS change handler can populate `items`
+    // optimistically (via 'local' cache-replay events) before getAll() resolves;
+    // calling .set() with the getAll result would clobber any items that were
+    // added by storeItem() while we were awaiting. We trust getAll's snapshot
+    // for entries it returned, but preserve any keys it didn't.
+    rawItems.update(current => ({ ...current, ...rawValid }));
+    items.update(current => ({ ...current, ...valid }));
+  } catch (e) {
+    console.error('[inbox] loadItems failed:', e);
   }
 }
 
@@ -194,8 +205,8 @@ async function loadConfig() {
     if (config && typeof config === 'object') {
       appConfig.set(config);
     }
-  } catch {
-    // ignore
+  } catch (e) {
+    console.error('[inbox] loadConfig failed:', e);
   }
 }
 
@@ -207,8 +218,8 @@ async function loadUserSettings() {
     if (settings && typeof settings === 'object') {
       userSettings.set(settings);
     }
-  } catch {
-    // ignore
+  } catch (e) {
+    console.error('[inbox] loadUserSettings failed:', e);
   }
 }
 
@@ -306,15 +317,7 @@ rs.on('sync-done', () => {
   markMigrationAlertReady();
 });
 
-// Debug: log sync activity
-rs.on('sync-req-done', (e: any) => {
-  console.log('[inbox] sync-req-done, tasks remaining:', e?.tasksRemaining);
-});
-rs.on('sync-done', (e: any) => {
-  console.log('[inbox] sync-done:', e);
-});
-rs.on('wire-busy', () => console.log('[inbox] wire-busy'));
-rs.on('wire-done', () => console.log('[inbox] wire-done'));
+rs.on('error', (e: any) => console.warn('[inbox] rs:error', e));
 
 rs.on('connected', async () => {
   connected.set(true);
@@ -340,9 +343,22 @@ rs.on('disconnected', () => {
   groups.set({});
 });
 
-queueMicrotask(() => {
-  void loadCachedData();
-});
+// Kick the cached preload from RS's `ready` event — fires after features
+// are loaded and the caching layer is wired up. This is the correct moment
+// to call getAll(), because:
+//   - Before `features-loaded`, `rs.get` is wired to `_pendingGPD`, which
+//     queues calls until `_processPending` runs at the end of
+//     `featuresLoaded()`. That queue is gated on every feature's `_rs_init`
+//     completing — and `IndexedDB.open` has a 10s timeout (see
+//     remotestoragejs `indexeddb.ts`). On a browser where the IDB handle is
+//     stalled, calling `getAll()` from `queueMicrotask` (which runs before
+//     features finish loading) makes the call sit in the queue for the full
+//     10s before `maxAge: false` even gets a chance to short-circuit it.
+//   - `RemoteStorage.on` automatically replays `ready` for listeners
+//     registered after the event has already fired (see remotestorage.ts
+//     `on` override), so HMR re-runs of this module still trigger the
+//     load — no `queueMicrotask` fallback needed.
+rs.on('ready', () => { void loadCachedData(); });
 
 export async function runAllMigrations() {
   const inbox = getInbox();

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -20,5 +20,13 @@ export default defineConfig({
       'onnxruntime-node': 'onnxruntime-web',
       'sharp': 'onnxruntime-web',
     }
-  }
+  },
+  build: {
+    // Bump above Vite's default `modules` baseline so top-level `await` is
+    // available. Used in `src/lib/rs.ts` to gate RS construction on a
+    // corrupt-IndexedDB self-recovery probe. TLA shipped in Chrome 89 / Edge
+    // 89 / Firefox 89 / Safari 15 — all 2021 baselines, well below our
+    // supported floor.
+    target: ['chrome89', 'edge89', 'firefox89', 'safari15'],
+  },
 });


### PR DESCRIPTION
Fixes #96.

## Summary

- **Frictionless quick-add stays available after the first todo** (issue #96). The composer is now rendered in both empty-state and populated-list modes via a Svelte 5 `{#snippet}`, with a slim above-the-list variant when todos already exist. Adds a per-device collection picker (localStorage) so frequent filers can capture into the right collection without leaving the keyboard. Stale ids fall back to Unfiled silently rather than erroring.
- **Recover from a corrupt RS IndexedDB.** A bug in remotestoragejs's IDB upgrade handler can leave the local DB at v1 with no `nodes` object store; the recovery path then hangs `deleteDatabase` because it doesn't close the open connection first. Net effect was a 10s freeze on every page load and reads/writes silently routed to LocalStorage. We now detect the corrupt state via `indexedDB.databases()` (Chrome 71+ / Safari 14+ / Firefox 126+) and delete the DB ourselves before constructing RS. Filed upstream as [remotestorage/remotestorage.js#1376](https://github.com/remotestorage/remotestorage.js/issues/1376). `__cleanupRSDb()` stays as a manual escape hatch for users who hit the bug before this auto-cleanup shipped.
- **Stop blocking `getAll` on remote sync.** Pass `maxAge: false` to the rs-module `getAll(...)` calls so cache reads no longer wait for a sync round-trip when cached nodes are stale. Fresh remote data still arrives via the existing `change` event subscription.
- **Stop hiding offline-created groups when the active filter only contains stale ids.** A user who logs in after creating a group while logged out could see the new group as a pill but find every section on the collections page empty — including the just-created collection inside the new group. Root cause was in `activeGroupIds`: when `appConfig.activeGroupFilters` held only ids for groups that no longer exist (e.g. the server's older `config/app` synced down post-login), the derived set was `∅` and `visibleGroupedCollections` hid every section. Now falls back to "all active" when every configured id is stale; an explicit empty array (user toggled every pill off) keeps its "show nothing" meaning.
- Top-level await in the gating call required bumping Vite's build target to `chrome89/edge89/firefox89/safari15` (all 2021 baselines).
- Cleanup pass on the diagnostic `T+Nms` logging that helped localize the stall.

## Test plan

- [x] `npm run -w @inbox-rs/web test` — all 191 tests pass
- [x] `npm run build` — succeeds with the new build target
- [ ] Cold load with a corrupt RS IDB (v1 with no stores): verify `[idb-probe]` auto-cleans and RS opens at v2 within a few hundred ms instead of 10s
- [ ] Cold load with a healthy RS IDB: verify `[idb-probe]` reports `v2 — healthy` and RS opens directly
- [ ] Quick-add a todo from the empty Todos page → composer disappears? (it shouldn't — slim variant takes over)
- [ ] Quick-add a todo with a collection chosen → todo lands in that collection
- [ ] Reload page → previously-chosen quick-add collection is still selected
- [ ] Choose a quick-add collection, delete that collection in another tab, reload → picker resets to Unfiled silently
- [ ] Logged out, create a new group + a collection inside it, then log in → both stay visible on /collections (no empty page even when synced `activeGroupFilters` contains only stale ids)