### PR TITLE
refactor(rs-module): extract shared remoteStorage runtime (closes #87)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inbox-rs",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inbox-rs",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "workspaces": [
         "packages/*"
       ]
@@ -3985,7 +3985,7 @@
     },
     "packages/extension": {
       "name": "@inbox-rs/extension",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "remotestoragejs": "^2.0.0-beta.8",
@@ -4176,18 +4176,19 @@
     },
     "packages/rs-module": {
       "name": "@inbox-rs/rs-module",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
         "remotestoragejs": "^2.0.0-beta.8",
         "rs-migrate": "^1.0.0"
       },
       "devDependencies": {
-        "typescript": "^5.4.0"
+        "typescript": "^5.4.0",
+        "vitest": "^4.1.2"
       }
     },
     "packages/thunderbird": {
       "name": "@inbox-rs/thunderbird",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
         "@inbox-rs/rs-module": "*"
       },
@@ -4374,7 +4375,7 @@
     },
     "packages/web": {
       "name": "@inbox-rs/web",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "@tiptap/core": "^3.22.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "package:plugins": "node scripts/package-plugins.mjs",
     "build:extension": "npm run build --workspace=packages/extension",
     "build:thunderbird": "npm run build --workspace=packages/thunderbird",
-    "test": "npm run test --workspace=packages/extension && npm run test --workspace=packages/web"
+    "test": "npm run test --workspace=packages/rs-module && npm run test --workspace=packages/extension && npm run test --workspace=packages/web"
   }
 }

--- a/packages/extension/src/lib/rs.ts
+++ b/packages/extension/src/lib/rs.ts
@@ -1,6 +1,12 @@
 import RemoteStorage from 'remotestoragejs';
-import InboxModule from '@inbox-rs/rs-module';
-import type { RSConfig } from './storage';
+import InboxModule, {
+  connectViaOAuth as sharedConnectViaOAuth,
+  DirectRS,
+  type RSConfig,
+} from '@inbox-rs/rs-module';
+
+export { DirectRS };
+export type { RSConfig };
 
 export function createRS(): RemoteStorage {
   const rs = new RemoteStorage({
@@ -13,75 +19,28 @@ export function createRS(): RemoteStorage {
   return rs;
 }
 
+/** Resolve to whichever identity API is available in this browser. */
+function getIdentityApi() {
+  if (typeof chrome !== 'undefined' && chrome.identity) return chrome.identity;
+  return browser.identity;
+}
+
 /**
- * Discover storage info via WebFinger, then do OAuth via
- * chrome.identity.launchWebAuthFlow so it works in extension context.
+ * WebFinger discovery + OAuth via the WebExtension identity API.
+ *
+ * Discovery, OAuth params, and token extraction all live in the shared
+ * `@inbox-rs/rs-module` runtime — this wrapper supplies the platform glue
+ * (the identity API, the redirect URL the browser whitelists for this
+ * extension, and a client id derived from that redirect's origin).
  */
 export async function connectViaOAuth(userAddress: string): Promise<RSConfig> {
-  // 1. WebFinger discovery
-  const parts = userAddress.split('@');
-  if (parts.length !== 2 || !parts[0] || !parts[1]) {
-    throw new Error('Invalid remoteStorage address. Expected format: user@host');
-  }
-  const host = parts[1];
-  const scheme = (host === 'localhost' || host.startsWith('localhost:')) ? 'http' : 'https';
-  const webfingerUrl = `${scheme}://${host}/.well-known/webfinger?resource=acct:${encodeURIComponent(userAddress)}`;
-  const wfResp = await fetch(webfingerUrl);
-  if (!wfResp.ok) throw new Error(`WebFinger failed: ${wfResp.status}`);
-  const wfData = await wfResp.json();
-
-  // Find remoteStorage link
-  const rsLink = wfData.links?.find((l: any) =>
-    l.rel === 'http://tools.ietf.org/id/draft-dejong-remotestorage' ||
-    l.rel === 'remotestorage'
-  );
-  if (!rsLink) throw new Error('No remoteStorage link found in WebFinger');
-
-  const href = rsLink.href;
-  const storageApi = rsLink.type || rsLink.properties?.['http://remotestorage.io/spec/version'];
-  const props = rsLink.properties || {};
-  const authUrl = props['http://tools.ietf.org/html/rfc6749#section-4.2']
-    || props['http://tools.ietf.org/html/rfc6749#section-4.2.1']
-    || props['auth-endpoint']
-    || props['auth-url'];
-  if (!authUrl) throw new Error('No OAuth endpoint found');
-
-  // 2. Build OAuth URL
-  const redirectUrl = typeof chrome !== 'undefined' && chrome.identity
-    ? chrome.identity.getRedirectURL()
-    : browser.identity.getRedirectURL();
-
-  const oauthParams = new URLSearchParams({
-    client_id: new URL(redirectUrl).origin,
-    redirect_uri: redirectUrl,
-    response_type: 'token',
-    scope: 'inbox:rw'
+  const identity = getIdentityApi();
+  const redirectUrl = identity.getRedirectURL();
+  return sharedConnectViaOAuth(userAddress, {
+    clientId: new URL(redirectUrl).origin,
+    redirectUrl,
+    launchAuthFlow: (url) => identity.launchWebAuthFlow({ url, interactive: true }) as Promise<string>,
   });
-  const fullAuthUrl = `${authUrl}?${oauthParams}`;
-
-  // 3. Launch OAuth flow in a browser window
-  const api = (typeof chrome !== 'undefined' && chrome.identity) ? chrome.identity : browser.identity;
-  const resultUrl = await api.launchWebAuthFlow({
-    url: fullAuthUrl,
-    interactive: true
-  });
-
-  // 4. Extract token from redirect URL
-  const redirectParsed = new URL(resultUrl);
-  const hashParams = new URLSearchParams(redirectParsed.hash.substring(1));
-  const queryParams = redirectParsed.searchParams;
-
-  // Check for OAuth error first
-  const oauthError = hashParams.get('error') || queryParams.get('error');
-  if (oauthError) {
-    const desc = hashParams.get('error_description') || queryParams.get('error_description') || '';
-    throw new Error(`OAuth error: ${oauthError}${desc ? ` — ${desc}` : ''}`);
-  }
-
-  const token = hashParams.get('access_token') || queryParams.get('access_token');
-  if (!token) throw new Error('No access token in OAuth response');
-
-  return { userAddress, token, href, storageApi };
 }
 
 /**
@@ -95,45 +54,4 @@ export function configureRS(rs: RemoteStorage, config: RSConfig): void {
     token: config.token!,
     properties: undefined
   });
-}
-
-/**
- * Direct HTTP client for RS storage operations.
- * More reliable than the full RS stack in service worker context.
- */
-export class DirectRS {
-  constructor(private config: RSConfig) {}
-
-  private get headers() {
-    return { 'Authorization': `Bearer ${this.config.token}` };
-  }
-
-  private url(path: string): string {
-    return `${this.config.href}/inbox/${path}`;
-  }
-
-  async storeObject(path: string, obj: object): Promise<void> {
-    const resp = await fetch(this.url(path), {
-      method: 'PUT',
-      headers: { ...this.headers, 'Content-Type': 'application/json' },
-      body: JSON.stringify(obj)
-    });
-    if (!resp.ok) throw new Error(`Store failed: ${resp.status}`);
-  }
-
-  async storeFile(path: string, data: ArrayBuffer, mimeType: string): Promise<void> {
-    const resp = await fetch(this.url(path), {
-      method: 'PUT',
-      headers: { ...this.headers, 'Content-Type': mimeType },
-      body: data
-    });
-    if (!resp.ok) throw new Error(`Store file failed: ${resp.status}`);
-  }
-
-  async store(item: any, fileData?: ArrayBuffer): Promise<void> {
-    if (fileData && item.filePath) {
-      await this.storeFile(item.filePath, fileData, item.mimeType);
-    }
-    await this.storeObject(`items/${item.id}`, item);
-  }
 }

--- a/packages/extension/src/lib/storage.ts
+++ b/packages/extension/src/lib/storage.ts
@@ -1,23 +1,18 @@
 import browser from 'webextension-polyfill';
+import { createConfigStore, type RSConfig } from '@inbox-rs/rs-module';
 
-const STORAGE_KEY = 'inbox-rs-config';
+export type { RSConfig };
 
-export interface RSConfig {
-  userAddress: string;
-  token?: string;
-  href?: string;
-  storageApi?: string;
-}
+const store = createConfigStore(browser.storage.local);
 
 export async function getConfig(): Promise<RSConfig | null> {
-  const result = await browser.storage.local.get(STORAGE_KEY);
-  return result[STORAGE_KEY] || null;
+  return store.get();
 }
 
 export async function saveConfig(config: RSConfig): Promise<void> {
-  await browser.storage.local.set({ [STORAGE_KEY]: config });
+  await store.save(config);
 }
 
 export async function clearConfig(): Promise<void> {
-  await browser.storage.local.remove(STORAGE_KEY);
+  await store.clear();
 }

--- a/packages/rs-module/package.json
+++ b/packages/rs-module/package.json
@@ -10,13 +10,15 @@
   ],
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "vitest run"
   },
   "dependencies": {
     "remotestoragejs": "^2.0.0-beta.8",
     "rs-migrate": "^1.0.0"
   },
   "devDependencies": {
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vitest": "^4.1.2"
   }
 }

--- a/packages/rs-module/src/index.ts
+++ b/packages/rs-module/src/index.ts
@@ -4,6 +4,23 @@ import type { MigrateResult } from 'rs-migrate';
 import { migrator, legacySchemas } from './migrations.js';
 export { migrator } from './migrations.js';
 export { wrapCodeBlock } from './migrations.js';
+export {
+  DirectRS,
+  connectViaOAuth,
+  createConfigStore,
+  discoverStorage,
+  extractTokenFromRedirect,
+  parseUserAddress,
+  schemeForHost,
+  DEFAULT_CONFIG_STORAGE_KEY,
+} from './runtime.js';
+export type {
+  BrowserStorageArea,
+  ConfigStore,
+  ConnectViaOAuthOptions,
+  RSConfig,
+  RSDiscovery,
+} from './runtime.js';
 
 /** Current item types — legacy types like 'voice-memo' are excluded */
 const CURRENT_TYPES: Set<string> = new Set<string>([

--- a/packages/rs-module/src/runtime.test.ts
+++ b/packages/rs-module/src/runtime.test.ts
@@ -1,0 +1,510 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  DirectRS,
+  connectViaOAuth,
+  createConfigStore,
+  discoverStorage,
+  extractTokenFromRedirect,
+  parseUserAddress,
+  schemeForHost,
+  DEFAULT_CONFIG_STORAGE_KEY,
+  type BrowserStorageArea,
+  type RSConfig,
+} from './runtime.js';
+
+/** Build a minimal `Response`-like stub for fetch mocks. */
+function jsonResponse(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function emptyResponse(init: { ok?: boolean; status?: number } = {}) {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+  } as unknown as Response;
+}
+
+const REMOTESTORAGE_REL = 'http://tools.ietf.org/id/draft-dejong-remotestorage';
+const AUTH_PROP_KEY = 'http://tools.ietf.org/html/rfc6749#section-4.2';
+const SPEC_VERSION_KEY = 'http://remotestorage.io/spec/version';
+
+function webfingerBody(overrides?: { authProp?: string; href?: string; rel?: string; type?: string }) {
+  const props: Record<string, string> = {};
+  const authKey = overrides?.authProp ?? AUTH_PROP_KEY;
+  props[authKey] = 'https://storage.example.com/oauth';
+  return {
+    links: [
+      {
+        rel: overrides?.rel ?? REMOTESTORAGE_REL,
+        href: overrides?.href ?? 'https://storage.example.com/storage/alice',
+        type: overrides?.type ?? 'draft-dejong-remotestorage-12',
+        properties: props,
+      },
+    ],
+  };
+}
+
+describe('parseUserAddress', () => {
+  it('splits a valid address into user and host', () => {
+    expect(parseUserAddress('alice@example.com')).toEqual({ user: 'alice', host: 'example.com' });
+  });
+
+  it('preserves a port in the host', () => {
+    expect(parseUserAddress('alice@localhost:8000')).toEqual({ user: 'alice', host: 'localhost:8000' });
+  });
+
+  it.each([
+    ['no @ sign', 'invalid'],
+    ['empty user', '@example.com'],
+    ['empty host', 'alice@'],
+    ['empty string', ''],
+  ])('throws on %s', (_label, address) => {
+    expect(() => parseUserAddress(address)).toThrow(/Invalid remoteStorage address/);
+  });
+});
+
+describe('schemeForHost', () => {
+  it('uses http for localhost and localhost:<port>', () => {
+    expect(schemeForHost('localhost')).toBe('http');
+    expect(schemeForHost('localhost:8000')).toBe('http');
+  });
+
+  it('uses https for everything else', () => {
+    expect(schemeForHost('example.com')).toBe('https');
+    expect(schemeForHost('5apps.com')).toBe('https');
+  });
+});
+
+describe('discoverStorage', () => {
+  it('returns href, storageApi, and authUrl from a valid WebFinger response', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(webfingerBody()));
+
+    const result = await discoverStorage('alice@example.com', fetchImpl);
+
+    expect(result).toEqual({
+      href: 'https://storage.example.com/storage/alice',
+      storageApi: 'draft-dejong-remotestorage-12',
+      authUrl: 'https://storage.example.com/oauth',
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://example.com/.well-known/webfinger?resource=acct:alice%40example.com',
+    );
+  });
+
+  it('uses http scheme for localhost addresses', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(webfingerBody()));
+
+    await discoverStorage('alice@localhost:8000', fetchImpl);
+
+    const calledUrl = fetchImpl.mock.calls[0]![0] as string;
+    expect(calledUrl.startsWith('http://localhost:8000/')).toBe(true);
+  });
+
+  it('URL-encodes the user address in the resource parameter', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(webfingerBody()));
+
+    await discoverStorage('user+tag@example.com', fetchImpl);
+
+    const calledUrl = fetchImpl.mock.calls[0]![0] as string;
+    expect(calledUrl).toContain('resource=acct:user%2Btag%40example.com');
+  });
+
+  it('falls back to spec-version property when type is missing', async () => {
+    const body = webfingerBody();
+    delete (body.links[0] as any).type;
+    body.links[0].properties[SPEC_VERSION_KEY] = 'draft-dejong-remotestorage-05';
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(body));
+
+    const result = await discoverStorage('alice@example.com', fetchImpl);
+
+    expect(result.storageApi).toBe('draft-dejong-remotestorage-05');
+  });
+
+  it('accepts the legacy `remotestorage` rel', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(webfingerBody({ rel: 'remotestorage' })));
+
+    const result = await discoverStorage('alice@example.com', fetchImpl);
+
+    expect(result.href).toBe('https://storage.example.com/storage/alice');
+  });
+
+  it('accepts auth URL via auth-endpoint property as fallback', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(webfingerBody({ authProp: 'auth-endpoint' })));
+
+    const result = await discoverStorage('alice@example.com', fetchImpl);
+
+    expect(result.authUrl).toBe('https://storage.example.com/oauth');
+  });
+
+  it('throws when WebFinger returns a non-2xx', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({}, { ok: false, status: 404 }));
+
+    await expect(discoverStorage('alice@example.com', fetchImpl)).rejects.toThrow('WebFinger failed: 404');
+  });
+
+  it('throws when no remoteStorage link is present', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ links: [{ rel: 'http://other' }] }));
+
+    await expect(discoverStorage('alice@example.com', fetchImpl)).rejects.toThrow(
+      /No remoteStorage link found/,
+    );
+  });
+
+  it('throws when remoteStorage link has no auth URL', async () => {
+    const body = webfingerBody();
+    body.links[0].properties = {};
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(body));
+
+    await expect(discoverStorage('alice@example.com', fetchImpl)).rejects.toThrow(
+      /No OAuth endpoint found/,
+    );
+  });
+
+  it('throws when remoteStorage link has no href', async () => {
+    const body = webfingerBody();
+    delete (body.links[0] as any).href;
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(body));
+
+    await expect(discoverStorage('alice@example.com', fetchImpl)).rejects.toThrow(
+      /remoteStorage link missing href/,
+    );
+  });
+
+  it('throws on a malformed user address before fetching', async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(discoverStorage('bogus', fetchImpl)).rejects.toThrow(/Invalid remoteStorage address/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('extractTokenFromRedirect', () => {
+  it('reads access_token from the URL fragment', () => {
+    const token = extractTokenFromRedirect('https://callback.example/#access_token=abc123&token_type=bearer');
+    expect(token).toBe('abc123');
+  });
+
+  it('reads access_token from the query string', () => {
+    const token = extractTokenFromRedirect('https://callback.example/?access_token=xyz789');
+    expect(token).toBe('xyz789');
+  });
+
+  it('prefers fragment over query when both present', () => {
+    const token = extractTokenFromRedirect(
+      'https://callback.example/?access_token=query#access_token=fragment',
+    );
+    expect(token).toBe('fragment');
+  });
+
+  it('throws on OAuth error in fragment with description', () => {
+    expect(() =>
+      extractTokenFromRedirect(
+        'https://callback.example/#error=access_denied&error_description=user%20declined',
+      ),
+    ).toThrow('OAuth error: access_denied — user declined');
+  });
+
+  it('throws on OAuth error in query', () => {
+    expect(() =>
+      extractTokenFromRedirect('https://callback.example/?error=invalid_scope'),
+    ).toThrow('OAuth error: invalid_scope');
+  });
+
+  it('throws when no token and no error are present', () => {
+    expect(() => extractTokenFromRedirect('https://callback.example/')).toThrow(
+      'No access token in OAuth response',
+    );
+  });
+});
+
+describe('connectViaOAuth', () => {
+  it('runs discovery, launches the flow, and returns a populated RSConfig', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(webfingerBody()));
+    const launchAuthFlow = vi
+      .fn()
+      .mockResolvedValue('https://callback.example/#access_token=token-abc');
+
+    const config = await connectViaOAuth('alice@example.com', {
+      clientId: 'inbox-rs-test',
+      redirectUrl: 'https://callback.example/',
+      launchAuthFlow,
+      fetchImpl,
+    });
+
+    expect(config).toEqual({
+      userAddress: 'alice@example.com',
+      token: 'token-abc',
+      href: 'https://storage.example.com/storage/alice',
+      storageApi: 'draft-dejong-remotestorage-12',
+    });
+  });
+
+  it('passes the discovered authUrl + OAuth params to the launcher', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(webfingerBody()));
+    const launchAuthFlow = vi
+      .fn()
+      .mockResolvedValue('https://callback.example/#access_token=t');
+
+    await connectViaOAuth('alice@example.com', {
+      clientId: 'my-client',
+      redirectUrl: 'https://callback.example/',
+      scope: 'inbox:rw shares:rw',
+      launchAuthFlow,
+      fetchImpl,
+    });
+
+    const calledUrl = launchAuthFlow.mock.calls[0]![0] as string;
+    const parsed = new URL(calledUrl);
+    expect(parsed.origin + parsed.pathname).toBe('https://storage.example.com/oauth');
+    expect(parsed.searchParams.get('client_id')).toBe('my-client');
+    expect(parsed.searchParams.get('redirect_uri')).toBe('https://callback.example/');
+    expect(parsed.searchParams.get('response_type')).toBe('token');
+    expect(parsed.searchParams.get('scope')).toBe('inbox:rw shares:rw');
+  });
+
+  it('uses inbox:rw as the default scope', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(webfingerBody()));
+    const launchAuthFlow = vi
+      .fn()
+      .mockResolvedValue('https://callback.example/#access_token=t');
+
+    await connectViaOAuth('alice@example.com', {
+      clientId: 'c',
+      redirectUrl: 'https://callback.example/',
+      launchAuthFlow,
+      fetchImpl,
+    });
+
+    const parsed = new URL(launchAuthFlow.mock.calls[0]![0] as string);
+    expect(parsed.searchParams.get('scope')).toBe('inbox:rw');
+  });
+
+  it('propagates errors from the launcher', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(webfingerBody()));
+    const launchAuthFlow = vi.fn().mockRejectedValue(new Error('user cancelled'));
+
+    await expect(
+      connectViaOAuth('alice@example.com', {
+        clientId: 'c',
+        redirectUrl: 'https://callback.example/',
+        launchAuthFlow,
+        fetchImpl,
+      }),
+    ).rejects.toThrow('user cancelled');
+  });
+
+  it('propagates OAuth errors from the redirect URL', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(webfingerBody()));
+    const launchAuthFlow = vi
+      .fn()
+      .mockResolvedValue('https://callback.example/#error=access_denied');
+
+    await expect(
+      connectViaOAuth('alice@example.com', {
+        clientId: 'c',
+        redirectUrl: 'https://callback.example/',
+        launchAuthFlow,
+        fetchImpl,
+      }),
+    ).rejects.toThrow('OAuth error: access_denied');
+  });
+});
+
+describe('DirectRS', () => {
+  const config: RSConfig = {
+    userAddress: 'alice@example.com',
+    token: 'tok',
+    href: 'https://storage.example.com/storage/alice',
+    storageApi: 'draft-dejong-remotestorage-12',
+  };
+
+  it('throws when constructed without href', () => {
+    expect(() => new DirectRS({ userAddress: 'a@b', token: 't' })).toThrow(/href/);
+  });
+
+  it('throws when constructed without token', () => {
+    expect(
+      () => new DirectRS({ userAddress: 'a@b', href: 'https://x' }),
+    ).toThrow(/token/);
+  });
+
+  describe('storeObject', () => {
+    it('PUTs JSON with bearer auth and returns void on 2xx', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse());
+      const rs = new DirectRS(config, fetchImpl);
+
+      await rs.storeObject('items/abc', { id: 'abc', type: 'note' });
+
+      expect(fetchImpl).toHaveBeenCalledWith(
+        'https://storage.example.com/storage/alice/inbox/items/abc',
+        expect.objectContaining({
+          method: 'PUT',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer tok',
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify({ id: 'abc', type: 'note' }),
+        }),
+      );
+    });
+
+    it('throws on non-2xx', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse({ ok: false, status: 401 }));
+      const rs = new DirectRS(config, fetchImpl);
+
+      await expect(rs.storeObject('items/x', {})).rejects.toThrow('Store failed: 401');
+    });
+  });
+
+  describe('storeFile', () => {
+    it('PUTs binary body with the supplied MIME type', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse());
+      const rs = new DirectRS(config, fetchImpl);
+      const data = new ArrayBuffer(8);
+
+      await rs.storeFile('files/abc.png', data, 'image/png');
+
+      expect(fetchImpl).toHaveBeenCalledWith(
+        'https://storage.example.com/storage/alice/inbox/files/abc.png',
+        expect.objectContaining({
+          method: 'PUT',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer tok',
+            'Content-Type': 'image/png',
+          }),
+          body: data,
+        }),
+      );
+    });
+
+    it('throws on non-2xx', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse({ ok: false, status: 500 }));
+      const rs = new DirectRS(config, fetchImpl);
+
+      await expect(rs.storeFile('files/x.png', new ArrayBuffer(0), 'image/png')).rejects.toThrow(
+        'Store file failed: 500',
+      );
+    });
+  });
+
+  describe('store', () => {
+    it('PUTs only the metadata when no fileData is supplied', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse());
+      const rs = new DirectRS(config, fetchImpl);
+
+      await rs.store({ id: 'note-1' } as any);
+
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      const calledUrl = fetchImpl.mock.calls[0]![0] as string;
+      expect(calledUrl).toContain('/inbox/items/note-1');
+    });
+
+    it('uploads file before metadata when both are present', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse());
+      const rs = new DirectRS(config, fetchImpl);
+
+      const item = { id: 'img-1', filePath: 'files/img-1.jpg', mimeType: 'image/jpeg' };
+      await rs.store(item, new ArrayBuffer(16));
+
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      const fileUrl = fetchImpl.mock.calls[0]![0] as string;
+      const metaUrl = fetchImpl.mock.calls[1]![0] as string;
+      expect(fileUrl).toContain('/inbox/files/img-1.jpg');
+      expect(metaUrl).toContain('/inbox/items/img-1');
+    });
+
+    it('does not call storeFile when item lacks filePath/mimeType, even with fileData', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse());
+      const rs = new DirectRS(config, fetchImpl);
+
+      await rs.store({ id: 'note-2' } as any, new ArrayBuffer(8));
+
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      const calledUrl = fetchImpl.mock.calls[0]![0] as string;
+      expect(calledUrl).toContain('/inbox/items/note-2');
+    });
+
+    it('skips file upload when fileData is undefined even if filePath is present', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse());
+      const rs = new DirectRS(config, fetchImpl);
+
+      await rs.store({ id: 'img-2', filePath: 'files/img-2.jpg', mimeType: 'image/jpeg' });
+
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('createConfigStore', () => {
+  let storage: BrowserStorageArea;
+  let store: Map<string, unknown>;
+
+  beforeEach(() => {
+    store = new Map();
+    storage = {
+      get: vi.fn(async (key: string) => {
+        const result: Record<string, unknown> = {};
+        if (store.has(key)) result[key] = store.get(key);
+        return result;
+      }),
+      set: vi.fn(async (items: Record<string, unknown>) => {
+        for (const [k, v] of Object.entries(items)) store.set(k, v);
+      }),
+      remove: vi.fn(async (key: string) => {
+        store.delete(key);
+      }),
+    };
+  });
+
+  it('returns null when no config has been saved', async () => {
+    const cfg = createConfigStore(storage);
+
+    expect(await cfg.get()).toBeNull();
+    expect(storage.get).toHaveBeenCalledWith(DEFAULT_CONFIG_STORAGE_KEY);
+  });
+
+  it('round-trips a saved RSConfig under the default key', async () => {
+    const cfg = createConfigStore(storage);
+    const config: RSConfig = {
+      userAddress: 'alice@example.com',
+      token: 't',
+      href: 'https://storage.example.com',
+      storageApi: 'draft-dejong-remotestorage-12',
+    };
+
+    await cfg.save(config);
+    expect(store.get(DEFAULT_CONFIG_STORAGE_KEY)).toEqual(config);
+    expect(await cfg.get()).toEqual(config);
+  });
+
+  it('clears the saved config', async () => {
+    const cfg = createConfigStore(storage);
+    await cfg.save({ userAddress: 'x@y' });
+
+    await cfg.clear();
+
+    expect(await cfg.get()).toBeNull();
+    expect(storage.remove).toHaveBeenCalledWith(DEFAULT_CONFIG_STORAGE_KEY);
+  });
+
+  it('honors a custom storage key', async () => {
+    const cfg = createConfigStore(storage, 'custom-key');
+    await cfg.save({ userAddress: 'x@y' });
+
+    expect(store.has('custom-key')).toBe(true);
+    expect(store.has(DEFAULT_CONFIG_STORAGE_KEY)).toBe(false);
+  });
+
+  it('returns null when stored value is missing (e.g. after partial clear)', async () => {
+    const cfg = createConfigStore(storage);
+
+    await cfg.save({ userAddress: 'x@y' });
+    store.set(DEFAULT_CONFIG_STORAGE_KEY, undefined);
+
+    expect(await cfg.get()).toBeNull();
+  });
+});

--- a/packages/rs-module/src/runtime.ts
+++ b/packages/rs-module/src/runtime.ts
@@ -1,0 +1,283 @@
+/**
+ * Shared remoteStorage runtime helpers.
+ *
+ * Browser-extension environments (Chrome MV3, Firefox WebExtensions, Thunderbird)
+ * share the same end-to-end flow: WebFinger discovery → implicit-grant OAuth →
+ * direct HTTP PUTs against the storage API. The full `remotestoragejs` stack
+ * isn't a great fit there — service workers are short-lived, sync state can't
+ * persist across wake-ups, and we only ever need a few storage operations.
+ *
+ * This module captures that shared flow as small, environment-agnostic
+ * primitives. Each app surface (extension, thunderbird) supplies the platform
+ * glue (a launcher for `*.identity.launchWebAuthFlow`, a client id, and a
+ * `browser.storage.local`-shaped storage area). Everything else — discovery,
+ * token extraction, the direct-PUT client, and config persistence — lives here
+ * so it stays consistent across packages and is independently testable.
+ */
+
+/** Persisted storage configuration. */
+export interface RSConfig {
+  userAddress: string;
+  token?: string;
+  href?: string;
+  storageApi?: string;
+}
+
+/** Result of WebFinger discovery for a remoteStorage user address. */
+export interface RSDiscovery {
+  /** Storage root URL (no trailing slash). */
+  href: string;
+  /** Reported RS spec version, when present. */
+  storageApi?: string;
+  /** OAuth authorization endpoint. */
+  authUrl: string;
+}
+
+/** Subset of the `fetch` API we use — narrow so it's easy to stub in tests. */
+type FetchLike = typeof fetch;
+
+/** Default storage key used by `createConfigStore`. */
+export const DEFAULT_CONFIG_STORAGE_KEY = 'inbox-rs-config';
+
+const RS_LINK_RELS = new Set([
+  'http://tools.ietf.org/id/draft-dejong-remotestorage',
+  'remotestorage',
+]);
+
+const AUTH_URL_PROPS = [
+  'http://tools.ietf.org/html/rfc6749#section-4.2',
+  'http://tools.ietf.org/html/rfc6749#section-4.2.1',
+  'auth-endpoint',
+  'auth-url',
+] as const;
+
+/**
+ * Validate and split a remoteStorage user address into its `[user, host]`
+ * components. Throws if the address isn't of the form `user@host`.
+ */
+export function parseUserAddress(userAddress: string): { user: string; host: string } {
+  const parts = userAddress.split('@');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error('Invalid remoteStorage address. Expected format: user@host');
+  }
+  return { user: parts[0], host: parts[1] };
+}
+
+/**
+ * Pick the right URL scheme for a host. Localhost dev servers don't have TLS,
+ * so we fall back to plain HTTP for them — every other host gets HTTPS.
+ */
+export function schemeForHost(host: string): 'http' | 'https' {
+  return host === 'localhost' || host.startsWith('localhost:') ? 'http' : 'https';
+}
+
+/**
+ * Run WebFinger discovery for a remoteStorage user address.
+ *
+ * Returns the storage root URL, the reported RS spec version (if any), and
+ * the OAuth authorization endpoint. Throws on any malformed input or response.
+ */
+export async function discoverStorage(
+  userAddress: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<RSDiscovery> {
+  const { host } = parseUserAddress(userAddress);
+  const scheme = schemeForHost(host);
+  const webfingerUrl = `${scheme}://${host}/.well-known/webfinger?resource=acct:${encodeURIComponent(userAddress)}`;
+
+  const response = await fetchImpl(webfingerUrl);
+  if (!response.ok) throw new Error(`WebFinger failed: ${response.status}`);
+  const data = await response.json();
+
+  const rsLink = Array.isArray(data?.links)
+    ? data.links.find((link: any) => RS_LINK_RELS.has(link?.rel))
+    : undefined;
+  if (!rsLink) throw new Error('No remoteStorage link found in WebFinger');
+
+  const href: string | undefined = rsLink.href;
+  if (!href) throw new Error('remoteStorage link missing href');
+
+  const props = rsLink.properties ?? {};
+  const storageApi: string | undefined = rsLink.type ?? props['http://remotestorage.io/spec/version'];
+
+  let authUrl: string | undefined;
+  for (const key of AUTH_URL_PROPS) {
+    if (typeof props[key] === 'string') {
+      authUrl = props[key];
+      break;
+    }
+  }
+  if (!authUrl) throw new Error('No OAuth endpoint found');
+
+  return { href, storageApi, authUrl };
+}
+
+/**
+ * Extract the access token from an OAuth implicit-grant redirect URL.
+ *
+ * remoteStorage providers may put the token in either the URL fragment
+ * (`#access_token=...`) or the query string (`?access_token=...`). Errors
+ * follow the same convention. Throws on any error response or missing token.
+ */
+export function extractTokenFromRedirect(resultUrl: string): string {
+  const parsed = new URL(resultUrl);
+  const hashParams = new URLSearchParams(parsed.hash.startsWith('#') ? parsed.hash.substring(1) : parsed.hash);
+  const queryParams = parsed.searchParams;
+
+  const oauthError = hashParams.get('error') || queryParams.get('error');
+  if (oauthError) {
+    const desc = hashParams.get('error_description') || queryParams.get('error_description') || '';
+    throw new Error(`OAuth error: ${oauthError}${desc ? ` — ${desc}` : ''}`);
+  }
+
+  const token = hashParams.get('access_token') || queryParams.get('access_token');
+  if (!token) throw new Error('No access token in OAuth response');
+  return token;
+}
+
+/** Options accepted by {@link connectViaOAuth}. */
+export interface ConnectViaOAuthOptions {
+  /** OAuth `client_id` to send. Extension uses the redirect origin; Thunderbird uses a static id. */
+  clientId: string;
+  /** OAuth `redirect_uri` to send. Should match what `launchAuthFlow` will receive. */
+  redirectUrl: string;
+  /** OAuth scope. Defaults to `inbox:rw`. */
+  scope?: string;
+  /** Launches the OAuth flow at `authUrl` and resolves with the redirect URL. */
+  launchAuthFlow: (authUrl: string) => Promise<string>;
+  /** Override `fetch` for testing or for environments without a global. */
+  fetchImpl?: FetchLike;
+}
+
+const DEFAULT_OAUTH_SCOPE = 'inbox:rw';
+
+/**
+ * End-to-end OAuth connect: discovery → implicit-grant flow → token extraction.
+ *
+ * The caller supplies the platform-specific bits (client id, redirect URL,
+ * launcher) — everything else is shared across extensions.
+ */
+export async function connectViaOAuth(
+  userAddress: string,
+  options: ConnectViaOAuthOptions,
+): Promise<RSConfig> {
+  const discovery = await discoverStorage(userAddress, options.fetchImpl);
+
+  const oauthParams = new URLSearchParams({
+    client_id: options.clientId,
+    redirect_uri: options.redirectUrl,
+    response_type: 'token',
+    scope: options.scope ?? DEFAULT_OAUTH_SCOPE,
+  });
+  const fullAuthUrl = `${discovery.authUrl}?${oauthParams.toString()}`;
+
+  const resultUrl = await options.launchAuthFlow(fullAuthUrl);
+  const token = extractTokenFromRedirect(resultUrl);
+
+  return {
+    userAddress,
+    token,
+    href: discovery.href,
+    storageApi: discovery.storageApi,
+  };
+}
+
+/**
+ * Direct HTTP client for remoteStorage object/file PUTs.
+ *
+ * Used in extension/Thunderbird contexts where the full remotestoragejs sync
+ * stack is impractical. Operates against the configured `inbox/` namespace.
+ */
+export class DirectRS {
+  private readonly fetchImpl: FetchLike;
+
+  constructor(private readonly config: RSConfig, fetchImpl: FetchLike = fetch) {
+    if (!config.href) throw new Error('DirectRS requires config.href');
+    if (!config.token) throw new Error('DirectRS requires config.token');
+    this.fetchImpl = fetchImpl;
+  }
+
+  private get headers(): Record<string, string> {
+    return { Authorization: `Bearer ${this.config.token!}` };
+  }
+
+  private url(path: string): string {
+    return `${this.config.href}/inbox/${path}`;
+  }
+
+  /** PUT a JSON object to `inbox/<path>`. Throws on non-2xx. */
+  async storeObject(path: string, obj: object): Promise<void> {
+    const response = await this.fetchImpl(this.url(path), {
+      method: 'PUT',
+      headers: { ...this.headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify(obj),
+    });
+    if (!response.ok) throw new Error(`Store failed: ${response.status}`);
+  }
+
+  /** PUT raw bytes to `inbox/<path>`. Throws on non-2xx. */
+  async storeFile(path: string, data: ArrayBuffer, mimeType: string): Promise<void> {
+    const response = await this.fetchImpl(this.url(path), {
+      method: 'PUT',
+      headers: { ...this.headers, 'Content-Type': mimeType },
+      body: data,
+    });
+    if (!response.ok) throw new Error(`Store file failed: ${response.status}`);
+  }
+
+  /**
+   * Store an inbox item. If `fileData` is provided and the item declares a
+   * `filePath`/`mimeType`, the file is uploaded first, then the item metadata.
+   */
+  async store(item: { id: string; filePath?: string; mimeType?: string }, fileData?: ArrayBuffer): Promise<void> {
+    if (fileData && item.filePath && item.mimeType) {
+      await this.storeFile(item.filePath, fileData, item.mimeType);
+    }
+    await this.storeObject(`items/${item.id}`, item);
+  }
+}
+
+/**
+ * Subset of `browser.storage.local` (and `chrome.storage.local`) we use.
+ * Defining it here lets `createConfigStore` accept either polyfilled or
+ * native storage areas without dragging in a webextension-polyfill dep.
+ *
+ * Only single-string keys are required because that's all the config store
+ * ever passes — keeping the interface narrow lets it match Thunderbird's
+ * stricter type declarations as well as the more permissive polyfill types.
+ */
+export interface BrowserStorageArea {
+  get(key: string): Promise<Record<string, unknown>>;
+  set(items: Record<string, unknown>): Promise<void>;
+  remove(key: string): Promise<void>;
+}
+
+/** Persistence wrapper for {@link RSConfig} on top of a browser storage area. */
+export interface ConfigStore {
+  get(): Promise<RSConfig | null>;
+  save(config: RSConfig): Promise<void>;
+  clear(): Promise<void>;
+}
+
+/**
+ * Build a {@link ConfigStore} on top of a browser-storage area. Each app
+ * surface wires this up once with its preferred storage backend.
+ */
+export function createConfigStore(
+  storage: BrowserStorageArea,
+  storageKey: string = DEFAULT_CONFIG_STORAGE_KEY,
+): ConfigStore {
+  return {
+    async get(): Promise<RSConfig | null> {
+      const result = await storage.get(storageKey);
+      const value = result?.[storageKey];
+      return (value as RSConfig | undefined) ?? null;
+    },
+    async save(config: RSConfig): Promise<void> {
+      await storage.set({ [storageKey]: config });
+    },
+    async clear(): Promise<void> {
+      await storage.remove(storageKey);
+    },
+  };
+}

--- a/packages/rs-module/tsconfig.json
+++ b/packages/rs-module/tsconfig.json
@@ -10,5 +10,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/rs-module/vitest.config.ts
+++ b/packages/rs-module/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+// rs-module is built with `tsc` for production; vitest runs the same .ts
+// sources directly so tests don't depend on a prior build step.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/thunderbird/src/lib/rs.ts
+++ b/packages/thunderbird/src/lib/rs.ts
@@ -1,92 +1,28 @@
-import type { RSConfig } from './storage';
+import {
+  connectViaOAuth as sharedConnectViaOAuth,
+  DirectRS,
+  type RSConfig,
+} from '@inbox-rs/rs-module';
+
+export { DirectRS };
+export type { RSConfig };
+
+/** Static OAuth client id — Thunderbird does not provide a redirect-derived origin. */
+const THUNDERBIRD_CLIENT_ID = 'inbox-rs-thunderbird';
 
 /**
- * Discover storage info via WebFinger, then do OAuth via
- * browser.identity.launchWebAuthFlow.
+ * WebFinger discovery + OAuth via Thunderbird's identity API.
+ *
+ * Discovery, OAuth params, and token extraction live in the shared
+ * `@inbox-rs/rs-module` runtime; this wrapper supplies Thunderbird-specific
+ * glue (the global `browser.identity` API and a static client id).
  */
 export async function connectViaOAuth(userAddress: string): Promise<RSConfig> {
-  const parts = userAddress.split('@');
-  if (parts.length !== 2 || !parts[0] || !parts[1]) {
-    throw new Error('Invalid remoteStorage address. Expected format: user@host');
-  }
-  const host = parts[1];
-  const scheme = (host === 'localhost' || host.startsWith('localhost:')) ? 'http' : 'https';
-  const webfingerUrl = `${scheme}://${host}/.well-known/webfinger?resource=acct:${encodeURIComponent(userAddress)}`;
-  const wfResp = await fetch(webfingerUrl);
-  if (!wfResp.ok) throw new Error(`WebFinger failed: ${wfResp.status}`);
-  const wfData = await wfResp.json();
-
-  const rsLink = wfData.links?.find((l: any) =>
-    l.rel === 'http://tools.ietf.org/id/draft-dejong-remotestorage' ||
-    l.rel === 'remotestorage'
-  );
-  if (!rsLink) throw new Error('No remoteStorage link found in WebFinger');
-
-  const href = rsLink.href;
-  const storageApi = rsLink.type || rsLink.properties?.['http://remotestorage.io/spec/version'];
-  const props = rsLink.properties || {};
-  const authUrl = props['http://tools.ietf.org/html/rfc6749#section-4.2']
-    || props['http://tools.ietf.org/html/rfc6749#section-4.2.1']
-    || props['auth-endpoint']
-    || props['auth-url'];
-  if (!authUrl) throw new Error('No OAuth endpoint found');
-
   const redirectUrl = browser.identity.getRedirectURL();
-  const oauthParams = new URLSearchParams({
-    client_id: 'inbox-rs-thunderbird',
-    redirect_uri: redirectUrl,
-    response_type: 'token',
-    scope: 'inbox:rw'
+  return sharedConnectViaOAuth(userAddress, {
+    clientId: THUNDERBIRD_CLIENT_ID,
+    redirectUrl,
+    launchAuthFlow: (url) =>
+      browser.identity.launchWebAuthFlow({ url, interactive: true }) as Promise<string>,
   });
-  const fullAuthUrl = `${authUrl}?${oauthParams}`;
-
-  const resultUrl = await browser.identity.launchWebAuthFlow({
-    url: fullAuthUrl,
-    interactive: true
-  });
-
-  // Extract token from redirect URL
-  const redirectParsed = new URL(resultUrl);
-  const hashParams = new URLSearchParams(redirectParsed.hash.substring(1));
-  const queryParams = redirectParsed.searchParams;
-
-  // Check for OAuth error first
-  const oauthError = hashParams.get('error') || queryParams.get('error');
-  if (oauthError) {
-    const desc = hashParams.get('error_description') || queryParams.get('error_description') || '';
-    throw new Error(`OAuth error: ${oauthError}${desc ? ` — ${desc}` : ''}`);
-  }
-
-  const token = hashParams.get('access_token') || queryParams.get('access_token');
-  if (!token) throw new Error('No access token in OAuth response');
-
-  return { userAddress, token, href, storageApi };
-}
-
-/**
- * Direct HTTP client for RS storage operations.
- */
-export class DirectRS {
-  constructor(private config: RSConfig) {}
-
-  private get headers() {
-    return { 'Authorization': `Bearer ${this.config.token}` };
-  }
-
-  private url(path: string): string {
-    return `${this.config.href}/inbox/${path}`;
-  }
-
-  async storeObject(path: string, obj: object): Promise<void> {
-    const resp = await fetch(this.url(path), {
-      method: 'PUT',
-      headers: { ...this.headers, 'Content-Type': 'application/json' },
-      body: JSON.stringify(obj)
-    });
-    if (!resp.ok) throw new Error(`Store failed: ${resp.status}`);
-  }
-
-  async store(item: any): Promise<void> {
-    await this.storeObject(`items/${item.id}`, item);
-  }
 }

--- a/packages/thunderbird/src/lib/storage.ts
+++ b/packages/thunderbird/src/lib/storage.ts
@@ -1,21 +1,17 @@
-const STORAGE_KEY = 'inbox-rs-config';
+import { createConfigStore, type RSConfig } from '@inbox-rs/rs-module';
 
-export interface RSConfig {
-  userAddress: string;
-  token?: string;
-  href?: string;
-  storageApi?: string;
-}
+export type { RSConfig };
+
+const store = createConfigStore(browser.storage.local);
 
 export async function getConfig(): Promise<RSConfig | null> {
-  const result = await browser.storage.local.get(STORAGE_KEY);
-  return result[STORAGE_KEY] || null;
+  return store.get();
 }
 
 export async function saveConfig(config: RSConfig): Promise<void> {
-  await browser.storage.local.set({ [STORAGE_KEY]: config });
+  await store.save(config);
 }
 
 export async function clearConfig(): Promise<void> {
-  await browser.storage.local.remove(STORAGE_KEY);
+  await store.clear();
 }


### PR DESCRIPTION
## Summary
- Extract WebFinger discovery, OAuth implicit-grant, direct-PUT HTTP client, and config persistence from the duplicated `extension/lib/rs.ts`, `extension/lib/storage.ts`, `thunderbird/lib/rs.ts`, `thunderbird/lib/storage.ts` into a single shared module: `@inbox-rs/rs-module/runtime`.
- Each app surface keeps only environment glue (which identity API to call, which client id to use, which `browser.storage.local` to wrap).
- Add 45 new unit tests covering `parseUserAddress`, `schemeForHost`, `discoverStorage`, `extractTokenFromRedirect`, `connectViaOAuth`, `DirectRS`, and `createConfigStore` — all driven through injected `fetch` / `launchAuthFlow` / storage adapters so no browser-extension mocks are needed.

## What this addresses (issue #87)
- ✅ shared remoteStorage / OAuth logic lives in one place (`packages/rs-module/src/runtime.ts`)
- ✅ extension and thunderbird stop carrying near-identical copies of the same logic (~135 lines of duplicated logic deleted)
- ✅ behavior remains identical for connect / save / disconnect flows — existing extension tests (30) pass unchanged
- ✅ documentation: package boundary unchanged, only adding a new sub-area inside the existing shared rs-module package

## API surface added (re-exported from `@inbox-rs/rs-module`)
- `discoverStorage(userAddress, fetchImpl?)` → `{ href, storageApi, authUrl }`
- `extractTokenFromRedirect(resultUrl)` → `string`
- `connectViaOAuth(userAddress, { clientId, redirectUrl, scope?, launchAuthFlow, fetchImpl? })` → `RSConfig`
- `class DirectRS(config, fetchImpl?)` with `storeObject` / `storeFile` / `store`
- `createConfigStore(storage, key?)` returning `{ get, save, clear }`
- Shared `RSConfig` / `RSDiscovery` / `BrowserStorageArea` / `ConnectViaOAuthOptions` types

## Test plan
- [x] `npm run test --workspace=packages/rs-module` — 45 new tests pass
- [x] `npm run test --workspace=packages/extension` — 30 existing tests still pass (unchanged behavior through re-exported `DirectRS`)
- [x] `npm run test --workspace=packages/web` — 188 tests pass
- [x] `npm test` (root) — full suite green (now includes rs-module)
- [x] `npm run build --workspace=packages/rs-module` — clean tsc
- [x] `npm run build --workspace=packages/extension` — clean Chrome MV3 build
- [x] `BROWSER=firefox npm run build --workspace=packages/extension` — clean Firefox build
- [x] `npm run build --workspace=packages/thunderbird` — clean build

Closes #87