### PR TITLE
fix(extensions): repair auth + save flows across Chrome/Firefox/Thunderbird

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inbox-rs",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inbox-rs",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "workspaces": [
         "packages/*",
         "tests/e2e"
@@ -4051,7 +4051,7 @@
     },
     "packages/extension": {
       "name": "@inbox-rs/extension",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "remotestoragejs": "^2.0.0-beta.9",
@@ -4242,7 +4242,7 @@
     },
     "packages/rs-module": {
       "name": "@inbox-rs/rs-module",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "remotestoragejs": "^2.0.0-beta.9",
         "rs-migrate": "^1.0.0"
@@ -4254,7 +4254,7 @@
     },
     "packages/thunderbird": {
       "name": "@inbox-rs/thunderbird",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@inbox-rs/rs-module": "*"
       },
@@ -4262,7 +4262,8 @@
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "svelte": "^5.0.0",
         "typescript": "^5.4.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^4.1.2"
       }
     },
     "packages/thunderbird/node_modules/@esbuild/darwin-arm64": {
@@ -4441,7 +4442,7 @@
     },
     "packages/web": {
       "name": "@inbox-rs/web",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "@tiptap/core": "^3.22.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "package:plugins": "node scripts/package-plugins.mjs",
     "build:extension": "npm run build --workspace=packages/extension",
     "build:thunderbird": "npm run build --workspace=packages/thunderbird",
-    "test": "npm run test --workspace=packages/rs-module && npm run test --workspace=packages/extension && npm run test --workspace=packages/web",
+    "test": "npm run test --workspace=packages/rs-module && npm run test --workspace=packages/extension && npm run test --workspace=packages/thunderbird && npm run test --workspace=packages/web",
     "test:e2e": "npm run test --workspace=@inbox-rs/e2e",
     "test:e2e:install": "npm run test:install --workspace=@inbox-rs/e2e"
   }

--- a/packages/extension/src/lib/rs.test.ts
+++ b/packages/extension/src/lib/rs.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * `lib/rs.ts` is a thin glue layer that:
+ *   1. picks the right identity API (`chrome.identity` for Chrome,
+ *      `browser.identity` for Firefox / WebExtensions polyfill),
+ *   2. resolves `getRedirectURL()` for the OAuth `redirect_uri`,
+ *   3. forwards `launchWebAuthFlow` as the launcher,
+ *   4. derives the OAuth `client_id` from the redirect URL's origin
+ *      (the remoteStorage spec convention; servers like Armadietto reject
+ *      anything else with `OAuth error: invalid_client`),
+ *   5. delegates the rest to the shared `connectViaOAuth` in
+ *      `@inbox-rs/rs-module`.
+ *
+ * Each of those wirings, if broken, causes a different production failure
+ * (no auth at all, wrong scope, wrong client_id, hung popup). These tests
+ * pin every one of them down so the same regression class can't recur in
+ * Chrome the way it just did in Thunderbird.
+ */
+
+const {
+  mockChromeGetRedirectURL,
+  mockChromeLaunchWebAuthFlow,
+  mockBrowserGetRedirectURL,
+  mockBrowserLaunchWebAuthFlow,
+  mockFetch,
+} = vi.hoisted(() => ({
+  mockChromeGetRedirectURL: vi.fn<() => string>(),
+  mockChromeLaunchWebAuthFlow: vi.fn<(args: { url: string; interactive: boolean }) => Promise<string>>(),
+  mockBrowserGetRedirectURL: vi.fn<() => string>(),
+  mockBrowserLaunchWebAuthFlow: vi.fn<(args: { url: string; interactive: boolean }) => Promise<string>>(),
+  mockFetch: vi.fn(),
+}));
+
+// `lib/rs.ts` uses a bare `browser` global (no `import browser from
+// 'webextension-polyfill'` in that file specifically) — in production the
+// polyfill loads elsewhere in the bundle and assigns `globalThis.browser`.
+// The polyfill mock here covers files that DO import it; the global stub
+// at the top covers `lib/rs.ts`'s direct use.
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    identity: {
+      getRedirectURL: mockBrowserGetRedirectURL,
+      launchWebAuthFlow: mockBrowserLaunchWebAuthFlow,
+    },
+  },
+}));
+
+vi.stubGlobal('fetch', mockFetch);
+vi.stubGlobal('browser', {
+  identity: {
+    getRedirectURL: mockBrowserGetRedirectURL,
+    launchWebAuthFlow: mockBrowserLaunchWebAuthFlow,
+  },
+});
+
+const REMOTESTORAGE_REL = 'http://tools.ietf.org/id/draft-dejong-remotestorage';
+const AUTH_PROP_KEY = 'http://tools.ietf.org/html/rfc6749#section-4.2';
+
+function webfingerResponse() {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      links: [
+        {
+          rel: REMOTESTORAGE_REL,
+          href: 'https://storage.example.com/storage/alice',
+          type: 'draft-dejong-remotestorage-12',
+          properties: { [AUTH_PROP_KEY]: 'https://storage.example.com/oauth' },
+        },
+      ],
+    }),
+  } as unknown as Response;
+}
+
+// Import once for module-resolution; tests stub the chrome global before
+// each invocation since `getIdentityApi` reads it lazily.
+import { connectViaOAuth, DirectRS } from './rs';
+
+describe('connectViaOAuth (chrome/firefox)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue(webfingerResponse());
+  });
+
+  afterEach(() => {
+    // Each test sets up `chrome` itself; clear it after so the next test's
+    // setup is the only signal. Re-stub the always-needed globals.
+    vi.unstubAllGlobals();
+    vi.stubGlobal('fetch', mockFetch);
+    vi.stubGlobal('browser', {
+      identity: {
+        getRedirectURL: mockBrowserGetRedirectURL,
+        launchWebAuthFlow: mockBrowserLaunchWebAuthFlow,
+      },
+    });
+  });
+
+  describe('identity API selection', () => {
+    it('uses chrome.identity when present (Chrome)', async () => {
+      vi.stubGlobal('chrome', {
+        identity: {
+          getRedirectURL: mockChromeGetRedirectURL,
+          launchWebAuthFlow: mockChromeLaunchWebAuthFlow,
+        },
+      });
+      mockChromeGetRedirectURL.mockReturnValue('https://abc.chromiumapp.org/');
+      mockChromeLaunchWebAuthFlow.mockResolvedValue(
+        'https://abc.chromiumapp.org/#access_token=tok-chrome',
+      );
+
+      const config = await connectViaOAuth('alice@example.com');
+
+      expect(config.token).toBe('tok-chrome');
+      expect(mockChromeGetRedirectURL).toHaveBeenCalled();
+      expect(mockChromeLaunchWebAuthFlow).toHaveBeenCalledWith(
+        expect.objectContaining({ interactive: true }),
+      );
+      // The Firefox/polyfill API must NOT have been used.
+      expect(mockBrowserGetRedirectURL).not.toHaveBeenCalled();
+      expect(mockBrowserLaunchWebAuthFlow).not.toHaveBeenCalled();
+    });
+
+    it('falls back to browser.identity when chrome is undefined (Firefox)', async () => {
+      // Don't stub `chrome` — `typeof chrome !== 'undefined'` will be false
+      // and the wrapper falls through to the polyfilled `browser.identity`.
+      mockBrowserGetRedirectURL.mockReturnValue('https://abc.allizom.org/');
+      mockBrowserLaunchWebAuthFlow.mockResolvedValue(
+        'https://abc.allizom.org/#access_token=tok-firefox',
+      );
+
+      const config = await connectViaOAuth('alice@example.com');
+
+      expect(config.token).toBe('tok-firefox');
+      expect(mockBrowserGetRedirectURL).toHaveBeenCalled();
+      expect(mockBrowserLaunchWebAuthFlow).toHaveBeenCalledWith(
+        expect.objectContaining({ interactive: true }),
+      );
+      expect(mockChromeGetRedirectURL).not.toHaveBeenCalled();
+    });
+
+    it('falls back to browser.identity when chrome is defined but lacks identity', async () => {
+      // Some old MV2 polyfill setups expose `chrome` without `identity`.
+      vi.stubGlobal('chrome', { runtime: {} } as any);
+      mockBrowserGetRedirectURL.mockReturnValue('https://abc.allizom.org/');
+      mockBrowserLaunchWebAuthFlow.mockResolvedValue(
+        'https://abc.allizom.org/#access_token=t',
+      );
+
+      await connectViaOAuth('alice@example.com');
+
+      expect(mockBrowserGetRedirectURL).toHaveBeenCalled();
+      expect(mockChromeGetRedirectURL).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('OAuth parameters', () => {
+    beforeEach(() => {
+      vi.stubGlobal('chrome', {
+        identity: {
+          getRedirectURL: mockChromeGetRedirectURL,
+          launchWebAuthFlow: mockChromeLaunchWebAuthFlow,
+        },
+      });
+      mockChromeGetRedirectURL.mockReturnValue('https://abcdef.chromiumapp.org/');
+      mockChromeLaunchWebAuthFlow.mockResolvedValue(
+        'https://abcdef.chromiumapp.org/#access_token=t',
+      );
+    });
+
+    /**
+     * REGRESSION: a previous version of the Thunderbird wrapper passed a
+     * static identifier as `client_id` and Armadietto rejected it as
+     * `invalid_client`. The Chrome wrapper has always derived it from the
+     * redirect origin — pin that down here so it can't regress to a static
+     * value the way Thunderbird did.
+     */
+    it('derives client_id from the redirect_uri origin', async () => {
+      await connectViaOAuth('alice@example.com');
+
+      const launchedUrl = mockChromeLaunchWebAuthFlow.mock.calls[0]![0].url;
+      const params = new URL(launchedUrl).searchParams;
+      const clientId = params.get('client_id');
+      const redirectUri = params.get('redirect_uri');
+
+      expect(redirectUri).toBe('https://abcdef.chromiumapp.org/');
+      expect(clientId).toBe('https://abcdef.chromiumapp.org');
+      expect(clientId).toBe(new URL(redirectUri!).origin);
+    });
+
+    it('uses a different client_id when the redirect URL changes', async () => {
+      mockChromeGetRedirectURL.mockReturnValueOnce('https://other.chromiumapp.org/cb');
+      mockChromeLaunchWebAuthFlow.mockResolvedValueOnce(
+        'https://other.chromiumapp.org/cb#access_token=t',
+      );
+
+      await connectViaOAuth('alice@example.com');
+
+      const launchedUrl = mockChromeLaunchWebAuthFlow.mock.calls[0]![0].url;
+      const params = new URL(launchedUrl).searchParams;
+      expect(params.get('client_id')).toBe('https://other.chromiumapp.org');
+      expect(params.get('redirect_uri')).toBe('https://other.chromiumapp.org/cb');
+    });
+
+    it('uses inbox:rw as the OAuth scope', async () => {
+      await connectViaOAuth('alice@example.com');
+
+      const launchedUrl = mockChromeLaunchWebAuthFlow.mock.calls[0]![0].url;
+      expect(new URL(launchedUrl).searchParams.get('scope')).toBe('inbox:rw');
+    });
+
+    it('uses implicit-grant response_type', async () => {
+      await connectViaOAuth('alice@example.com');
+
+      const launchedUrl = mockChromeLaunchWebAuthFlow.mock.calls[0]![0].url;
+      expect(new URL(launchedUrl).searchParams.get('response_type')).toBe('token');
+    });
+
+    it('passes interactive:true to launchWebAuthFlow', async () => {
+      await connectViaOAuth('alice@example.com');
+
+      expect(mockChromeLaunchWebAuthFlow).toHaveBeenCalledWith({
+        url: expect.any(String),
+        interactive: true,
+      });
+    });
+  });
+
+  describe('discovery + token extraction wiring', () => {
+    beforeEach(() => {
+      vi.stubGlobal('chrome', {
+        identity: {
+          getRedirectURL: mockChromeGetRedirectURL,
+          launchWebAuthFlow: mockChromeLaunchWebAuthFlow,
+        },
+      });
+      mockChromeGetRedirectURL.mockReturnValue('https://abc.chromiumapp.org/');
+    });
+
+    it('issues the WebFinger request to the user-supplied host', async () => {
+      mockChromeLaunchWebAuthFlow.mockResolvedValue(
+        'https://abc.chromiumapp.org/#access_token=t',
+      );
+
+      await connectViaOAuth('alice@example.com');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://example.com/.well-known/webfinger?resource=acct:alice%40example.com',
+      );
+    });
+
+    it('uses http for localhost addresses (dev server case)', async () => {
+      mockChromeLaunchWebAuthFlow.mockResolvedValue(
+        'https://abc.chromiumapp.org/#access_token=t',
+      );
+
+      await connectViaOAuth('alice@localhost:8000');
+
+      const url = mockFetch.mock.calls[0]![0] as string;
+      expect(url.startsWith('http://localhost:8000/')).toBe(true);
+    });
+
+    it('returns a populated RSConfig on success', async () => {
+      mockChromeLaunchWebAuthFlow.mockResolvedValue(
+        'https://abc.chromiumapp.org/#access_token=tok-success',
+      );
+
+      const config = await connectViaOAuth('alice@example.com');
+
+      expect(config).toEqual({
+        userAddress: 'alice@example.com',
+        token: 'tok-success',
+        href: 'https://storage.example.com/storage/alice',
+        storageApi: 'draft-dejong-remotestorage-12',
+      });
+    });
+
+    it('propagates a WebFinger failure (does not silently succeed)', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 0 } as Response);
+
+      await expect(connectViaOAuth('alice@example.com')).rejects.toThrow(/WebFinger failed/);
+    });
+
+    it('propagates an OAuth error in the redirect URL', async () => {
+      mockChromeLaunchWebAuthFlow.mockResolvedValueOnce(
+        'https://abc.chromiumapp.org/#error=access_denied',
+      );
+
+      await expect(connectViaOAuth('alice@example.com')).rejects.toThrow(/access_denied/);
+    });
+
+    it('propagates an invalid_client OAuth error (the bug class that just bit Thunderbird)', async () => {
+      mockChromeLaunchWebAuthFlow.mockResolvedValueOnce(
+        'https://abc.chromiumapp.org/#error=invalid_client&error_description=client%20not%20registered',
+      );
+
+      await expect(connectViaOAuth('alice@example.com')).rejects.toThrow(/invalid_client/);
+    });
+
+    it('rejects on a malformed user address before any network or OAuth call', async () => {
+      await expect(connectViaOAuth('not-a-user-address')).rejects.toThrow(
+        /Invalid remoteStorage address/,
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockChromeLaunchWebAuthFlow).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('DirectRS export (chrome/firefox)', () => {
+  it('re-exports DirectRS from @inbox-rs/rs-module', () => {
+    expect(DirectRS).toBeDefined();
+    expect(typeof DirectRS).toBe('function');
+  });
+});

--- a/packages/extension/src/lib/storage.test.ts
+++ b/packages/extension/src/lib/storage.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * `lib/storage.ts` is a thin wrapper around `createConfigStore()` from
+ * `@inbox-rs/rs-module`. The wrapper itself doesn't have logic — it just
+ * binds the store to `browser.storage.local`. These tests pin the wiring
+ * so an accidental change (wrong storage area, wrong key, missing await)
+ * is caught immediately.
+ */
+
+const { mockStorage, mockGet, mockSet, mockRemove } = vi.hoisted(() => {
+  const mockGet = vi.fn();
+  const mockSet = vi.fn();
+  const mockRemove = vi.fn();
+  return {
+    mockGet,
+    mockSet,
+    mockRemove,
+    mockStorage: {
+      local: { get: mockGet, set: mockSet, remove: mockRemove },
+    },
+  };
+});
+
+vi.mock('webextension-polyfill', () => ({
+  default: { storage: mockStorage },
+}));
+
+import { getConfig, saveConfig, clearConfig } from './storage';
+import type { RSConfig } from '@inbox-rs/rs-module';
+
+const sampleConfig: RSConfig = {
+  userAddress: 'alice@example.com',
+  token: 'tok-abc',
+  href: 'https://storage.example.com/storage/alice',
+  storageApi: 'draft-dejong-remotestorage-12',
+};
+
+describe('storage wrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue({});
+    mockSet.mockResolvedValue(undefined);
+    mockRemove.mockResolvedValue(undefined);
+  });
+
+  describe('getConfig', () => {
+    it('reads from browser.storage.local under the canonical key', async () => {
+      mockGet.mockResolvedValue({ 'inbox-rs-config': sampleConfig });
+
+      const config = await getConfig();
+
+      expect(config).toEqual(sampleConfig);
+      expect(mockGet).toHaveBeenCalledWith('inbox-rs-config');
+    });
+
+    it('returns null when no config has been saved', async () => {
+      mockGet.mockResolvedValue({});
+
+      expect(await getConfig()).toBeNull();
+    });
+
+    it('returns null when the stored value is undefined (e.g. partial clear)', async () => {
+      mockGet.mockResolvedValue({ 'inbox-rs-config': undefined });
+
+      expect(await getConfig()).toBeNull();
+    });
+  });
+
+  describe('saveConfig', () => {
+    it('writes to browser.storage.local under the canonical key', async () => {
+      await saveConfig(sampleConfig);
+
+      expect(mockSet).toHaveBeenCalledWith({ 'inbox-rs-config': sampleConfig });
+    });
+
+    it('round-trips with getConfig', async () => {
+      // Simulate a real storage area with a Map.
+      const store = new Map<string, unknown>();
+      mockGet.mockImplementation(async (key: string) => {
+        const out: Record<string, unknown> = {};
+        if (store.has(key)) out[key] = store.get(key);
+        return out;
+      });
+      mockSet.mockImplementation(async (items: Record<string, unknown>) => {
+        for (const [k, v] of Object.entries(items)) store.set(k, v);
+      });
+
+      await saveConfig(sampleConfig);
+      expect(await getConfig()).toEqual(sampleConfig);
+    });
+  });
+
+  describe('clearConfig', () => {
+    it('removes the canonical key from browser.storage.local', async () => {
+      await clearConfig();
+
+      expect(mockRemove).toHaveBeenCalledWith('inbox-rs-config');
+    });
+
+    it('makes getConfig return null afterwards', async () => {
+      const store = new Map<string, unknown>([
+        ['inbox-rs-config', sampleConfig],
+      ]);
+      mockGet.mockImplementation(async (key: string) => {
+        const out: Record<string, unknown> = {};
+        if (store.has(key)) out[key] = store.get(key);
+        return out;
+      });
+      mockRemove.mockImplementation(async (key: string) => {
+        store.delete(key);
+      });
+
+      await clearConfig();
+      expect(await getConfig()).toBeNull();
+    });
+  });
+});

--- a/packages/extension/src/manifest.test.ts
+++ b/packages/extension/src/manifest.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Manifest invariants for the Chrome (MV3) and Firefox (MV3) WebExtensions.
+ *
+ * The popup and service worker depend on `host_permissions: <all_urls>` to
+ * make cross-origin `fetch()` calls (WebFinger discovery, RS PUTs to
+ * arbitrary remote storage hosts, image downloads in the SW round-trip).
+ * If host permissions disappear, the popup save will fail in production but
+ * type-check + build cleanly — exactly the kind of silent breakage tests
+ * should catch. Both manifest variants are pinned here.
+ */
+
+const chromeManifestPath = resolve(__dirname, '..', 'manifest.json');
+const firefoxManifestPath = resolve(__dirname, '..', 'manifest.firefox.json');
+
+const chromeManifest = JSON.parse(readFileSync(chromeManifestPath, 'utf-8'));
+const firefoxManifest = JSON.parse(readFileSync(firefoxManifestPath, 'utf-8'));
+
+const variants: Array<[string, any]> = [
+  ['chrome (manifest.json)', chromeManifest],
+  ['firefox (manifest.firefox.json)', firefoxManifest],
+];
+
+describe.each(variants)('extension manifest — %s', (_label, manifest) => {
+  it('targets MV3', () => {
+    expect(manifest.manifest_version).toBe(3);
+  });
+
+  describe('permissions', () => {
+    it('declares activeTab so the popup can read the active page', () => {
+      expect(manifest.permissions).toContain('activeTab');
+    });
+
+    it('declares contextMenus so the right-click "Save to Inbox" menus work', () => {
+      expect(manifest.permissions).toContain('contextMenus');
+    });
+
+    it('declares storage so the RS config is persisted in browser.storage.local', () => {
+      expect(manifest.permissions).toContain('storage');
+    });
+
+    it('declares identity so OAuth via launchWebAuthFlow works', () => {
+      expect(manifest.permissions).toContain('identity');
+    });
+  });
+
+  /**
+   * REGRESSION: the popup's save flow PUTs to the user's arbitrary RS host.
+   * Without host_permissions declared, MV3 enforces CORS preflight against
+   * unrelated origins and the PUT (or its OPTIONS preflight) gets rejected.
+   * The user reported "save just hangs" — this is one of the underlying
+   * triggers we hardened the popup against.
+   */
+  it('declares host_permissions broad enough to reach any RS host', () => {
+    const hostPerms: string[] = manifest.host_permissions ?? [];
+    const hasAllUrls = hostPerms.includes('<all_urls>');
+    const hasWildcardHttps = hostPerms.some(
+      (p) => p === 'https://*/*' || p === 'http://*/*',
+    );
+    expect(hasAllUrls || hasWildcardHttps).toBe(true);
+  });
+
+  it('declares an action with a popup', () => {
+    expect(manifest.action?.default_popup).toBe('src/popup/index.html');
+  });
+
+  it('declares an options page (so the user can set up RS auth)', () => {
+    expect(manifest.options_page).toBe('src/options/index.html');
+  });
+
+  it('declares a content script that runs on all URLs at document_idle', () => {
+    const cs = manifest.content_scripts?.[0];
+    expect(cs?.matches).toContain('<all_urls>');
+    expect(cs?.run_at).toBe('document_idle');
+    expect(cs?.js).toContain('content-metadata.js');
+  });
+
+  it('declares a service worker as the background script', () => {
+    // Chrome MV3 requires `service_worker`; Firefox MV3 accepts the
+    // `scripts` array form. Either is fine — what matters is that *some*
+    // background entrypoint is declared so the SW message handlers run.
+    const bg = manifest.background;
+    const hasServiceWorker = typeof bg?.service_worker === 'string';
+    const hasScripts = Array.isArray(bg?.scripts) && bg.scripts.length > 0;
+    expect(hasServiceWorker || hasScripts).toBe(true);
+  });
+});
+
+describe('firefox-specific manifest invariants', () => {
+  it('declares browser_specific_settings.gecko.id (required by AMO)', () => {
+    expect(firefoxManifest.browser_specific_settings?.gecko?.id).toMatch(/^[\w.+-]+@[\w.-]+$/);
+  });
+});

--- a/packages/extension/src/popup/Popup.svelte
+++ b/packages/extension/src/popup/Popup.svelte
@@ -2,14 +2,15 @@
   import browser from 'webextension-polyfill';
   import { DirectRS } from '../lib/rs';
   import { getConfig } from '../lib/storage';
-  import { isImageUrl, saveAsImage, saveAsBookmark } from './save-logic';
-  import type { NoteItem } from '@inbox-rs/rs-module';
+  import { isImageUrl } from './save-logic';
+  import { runSavePage, runSaveNote } from './save-orchestrator';
 
   type Mode = 'page' | 'note';
 
   let connected = $state(false);
   let saving = $state(false);
   let saved = $state(false);
+  let saveError = $state('');
   let rs: DirectRS | null = null;
   let tabId: number | null = null;
   let mode = $state<Mode>('page');
@@ -80,53 +81,38 @@
   async function savePage() {
     if (!rs || saving || !pageUrl) return;
     saving = true;
-
-    const id = crypto.randomUUID();
-    const createdAt = new Date().toISOString();
-
-    // Direct image page: save as ImageItem instead of BookmarkItem
-    if (isDirectImage) {
-      try {
-        const result = await saveAsImage({ rs, id, pageUrl, pageTitle, pageNote, createdAt });
-        if (result) {
-          saving = false;
-          saved = true;
-          setTimeout(() => window.close(), 800);
-          return;
-        }
-      } catch {
-        // Fall through to bookmark save as fallback
+    saveError = '';
+    try {
+      const result = await runSavePage({
+        rs, pageUrl, pageTitle, pageNote, pageDescription,
+        embeddedContent, tweetImages, ogImage, favicon, siteName, isDirectImage,
+      });
+      if (result.ok) {
+        saved = true;
+        setTimeout(() => window.close(), 800);
+      } else {
+        saveError = result.error;
       }
+    } finally {
+      saving = false;
     }
-
-    await saveAsBookmark({
-      rs, id, pageUrl, pageTitle, pageNote, pageDescription,
-      embeddedContent, tweetImages, ogImage, favicon, siteName, createdAt
-    });
-
-    saving = false;
-    saved = true;
-    setTimeout(() => window.close(), 800);
   }
 
   async function saveNote() {
     if (!rs || saving || !noteBody.trim()) return;
     saving = true;
-
-    const id = crypto.randomUUID();
-    const createdAt = new Date().toISOString();
-
-    const item: NoteItem = {
-      id, type: 'note',
-      title: noteTitle.trim() || noteBody.trim().slice(0, 50),
-      body: noteBody.trim(),
-      createdAt
-    };
-    await rs.store(item);
-
-    saving = false;
-    saved = true;
-    setTimeout(() => window.close(), 800);
+    saveError = '';
+    try {
+      const result = await runSaveNote({ rs, noteTitle, noteBody });
+      if (result.ok) {
+        saved = true;
+        setTimeout(() => window.close(), 800);
+      } else {
+        saveError = result.error;
+      }
+    } finally {
+      saving = false;
+    }
   }
 </script>
 
@@ -180,6 +166,9 @@
         <button type="submit" class="btn-primary" disabled={saving || !pageUrl}>
           {saving ? 'Saving...' : isDirectImage ? 'Save Image' : 'Save Page'}
         </button>
+        {#if saveError}
+          <p class="error" role="alert">{saveError}</p>
+        {/if}
       </form>
     {:else}
       <form class="save-form" onsubmit={(e) => { e.preventDefault(); saveNote(); }}>
@@ -188,6 +177,9 @@
         <button type="submit" class="btn-primary" disabled={saving || !noteBody.trim()}>
           {saving ? 'Saving...' : 'Save Note'}
         </button>
+        {#if saveError}
+          <p class="error" role="alert">{saveError}</p>
+        {/if}
       </form>
     {/if}
   {/if}
@@ -352,6 +344,12 @@
     color: var(--success);
     font-size: 1.1rem;
     font-weight: 500;
+  }
+
+  .error {
+    color: var(--danger);
+    font-size: 0.8rem;
+    margin: 0.25rem 0 0;
   }
 
   .check {

--- a/packages/extension/src/popup/save-orchestrator.test.ts
+++ b/packages/extension/src/popup/save-orchestrator.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * `runSavePage` / `runSaveNote` orchestrate calls into `save-logic.ts`
+ * (which itself calls `rs.store(...)` and the SW message round-trip for
+ * image downloads). The orchestrator's contract is "never throws":
+ * everything that used to escape the popup's click handler must now be
+ * captured and returned as `{ ok: false, error }`.
+ *
+ * Browser globals are mocked at the module-loading boundary so the
+ * orchestrator and the underlying `save-logic` see consistent stubs.
+ */
+const { mockSendMessage, mockFetch } = vi.hoisted(() => ({
+  mockSendMessage: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    runtime: { sendMessage: mockSendMessage },
+    storage: { local: { get: vi.fn(), set: vi.fn() } },
+  },
+}));
+
+vi.stubGlobal('fetch', mockFetch);
+
+import { runSavePage, runSaveNote } from './save-orchestrator';
+import { DirectRS } from '../lib/rs';
+
+function makeRS(): DirectRS {
+  return new DirectRS({
+    userAddress: 'test@example.com',
+    token: 'tok',
+    href: 'https://storage.example.com',
+  });
+}
+
+const basePageParams = {
+  pageUrl: 'https://example.com/article',
+  pageTitle: 'Article',
+  pageNote: '',
+  pageDescription: '',
+  embeddedContent: '',
+  tweetImages: [] as string[],
+  ogImage: '',
+  favicon: '',
+  siteName: '',
+  isDirectImage: false,
+  generateId: () => 'page-uuid-1',
+  now: () => '2026-01-01T00:00:00.000Z',
+};
+
+const baseNoteParams = {
+  noteTitle: 'Title',
+  noteBody: 'Body',
+  generateId: () => 'note-uuid-1',
+  now: () => '2026-01-01T00:00:00.000Z',
+};
+
+describe('runSavePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns ok:true on a successful bookmark save', async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+    const rs = makeRS();
+
+    const result = await runSavePage({ rs, ...basePageParams });
+
+    expect(result).toEqual({ ok: true });
+    // No image to fetch — SW round-trip must not be invoked.
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  /**
+   * REGRESSION: the popup used to call `await saveAsBookmark(...)` with no
+   * try/catch. When the underlying PUT failed (401, 5xx, network error,
+   * MV3 SW termination) the rejection escaped the click handler, leaving
+   * `saving` stuck true and the popup hanging in "Saving…" forever.
+   */
+  it('returns ok:false when the bookmark PUT fails (e.g. 401 expired token)', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 401 });
+    const rs = makeRS();
+
+    const result = await runSavePage({ rs, ...basePageParams });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('401');
+  });
+
+  it('returns ok:false when fetch rejects (network failure / CORS block)', async () => {
+    mockFetch.mockRejectedValue(new TypeError('NetworkError'));
+    const rs = makeRS();
+
+    const result = await runSavePage({ rs, ...basePageParams });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/NetworkError/);
+  });
+
+  it('falls back to bookmark when image save returns null (SW download failed)', async () => {
+    // First call: SW image download — returns ok:false.
+    mockSendMessage.mockResolvedValue({ ok: false });
+    // Second call: bookmark PUT — succeeds.
+    mockFetch.mockResolvedValue({ ok: true });
+    const rs = makeRS();
+
+    const result = await runSavePage({
+      rs,
+      ...basePageParams,
+      isDirectImage: true,
+      pageUrl: 'https://cdn.example.com/photo.jpg',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    // bookmark PUT happened
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/inbox/items/page-uuid-1'),
+      expect.objectContaining({ method: 'PUT' }),
+    );
+  });
+
+  it('falls back to bookmark when image save throws (SW round-trip rejected)', async () => {
+    mockSendMessage.mockRejectedValue(new Error('Could not establish connection. Receiving end does not exist.'));
+    mockFetch.mockResolvedValue({ ok: true });
+    const rs = makeRS();
+
+    const result = await runSavePage({
+      rs,
+      ...basePageParams,
+      isDirectImage: true,
+      pageUrl: 'https://cdn.example.com/photo.jpg',
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('returns ok:false when both image and bookmark fail', async () => {
+    mockSendMessage.mockResolvedValue({ ok: false });
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+    const rs = makeRS();
+
+    const result = await runSavePage({
+      rs,
+      ...basePageParams,
+      isDirectImage: true,
+      pageUrl: 'https://cdn.example.com/photo.jpg',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('500');
+  });
+
+  it('returns ok:true when isDirectImage save succeeds (no fallback)', async () => {
+    mockSendMessage.mockResolvedValue({ ok: true, mimeType: 'image/jpeg' });
+    mockFetch.mockResolvedValue({ ok: true });
+    const rs = makeRS();
+
+    const result = await runSavePage({
+      rs,
+      ...basePageParams,
+      isDirectImage: true,
+      pageUrl: 'https://cdn.example.com/photo.jpg',
+    });
+
+    expect(result).toEqual({ ok: true });
+    // Exactly one fetch — the ImageItem metadata PUT. No bookmark fallback.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/inbox/items/page-uuid-1'),
+      expect.objectContaining({ method: 'PUT' }),
+    );
+  });
+
+  it('uses the supplied generateId / now hooks (deterministic in tests)', async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+    const rs = makeRS();
+
+    await runSavePage({
+      ...basePageParams,
+      rs,
+      generateId: () => 'custom-id',
+      now: () => '2099-12-31T23:59:59.999Z',
+    });
+
+    const stored = JSON.parse(mockFetch.mock.calls[0]![1].body);
+    expect(stored.id).toBe('custom-id');
+    expect(stored.createdAt).toBe('2099-12-31T23:59:59.999Z');
+  });
+
+  it('reuses the same id across image-fail -> bookmark fallback', async () => {
+    // When direct-image save fails and we fall back to bookmark, both
+    // should share the same item id. Otherwise debugging "I clicked save
+    // once but got two ids" gets impossible.
+    mockSendMessage.mockResolvedValue({ ok: false }); // SW download fails
+    mockFetch.mockResolvedValue({ ok: true });
+    const rs = makeRS();
+
+    await runSavePage({
+      ...basePageParams,
+      rs,
+      isDirectImage: true,
+      pageUrl: 'https://cdn.example.com/photo.jpg',
+      generateId: () => 'shared-id',
+    });
+
+    // The SW received the same id-derived path as the bookmark would have.
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: expect.stringContaining('shared-id') }),
+    );
+    // And the bookmark stored under the same id.
+    const bookmark = JSON.parse(mockFetch.mock.calls[0]![1].body);
+    expect(bookmark.id).toBe('shared-id');
+  });
+
+  it('persists pageNote into the saved bookmark description', async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+    const rs = makeRS();
+
+    await runSavePage({
+      ...basePageParams,
+      rs,
+      pageNote: 'My note',
+      pageDescription: 'OG description',
+    });
+
+    const stored = JSON.parse(mockFetch.mock.calls[0]![1].body);
+    expect(stored.description).toContain('My note');
+    expect(stored.description).toContain('OG description');
+  });
+});
+
+describe('runSaveNote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns ok:true on a successful save', async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+    const rs = makeRS();
+
+    const result = await runSaveNote({ rs, ...baseNoteParams });
+
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/inbox/items/note-uuid-1'),
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({ Authorization: 'Bearer tok' }),
+      }),
+    );
+  });
+
+  it('produces a NoteItem with the expected shape', async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+    const rs = makeRS();
+
+    await runSaveNote({
+      rs,
+      noteTitle: 'Reminder',
+      noteBody: 'Buy groceries',
+      generateId: () => 'note-1',
+      now: () => '2026-04-29T12:00:00.000Z',
+    });
+
+    const stored = JSON.parse(mockFetch.mock.calls[0]![1].body);
+    expect(stored).toEqual({
+      id: 'note-1',
+      type: 'note',
+      title: 'Reminder',
+      body: 'Buy groceries',
+      createdAt: '2026-04-29T12:00:00.000Z',
+    });
+  });
+
+  it('uses first 50 chars of body as title when title is empty', async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+    const rs = makeRS();
+    const longBody =
+      'This is a long note body that should get truncated for the title at fifty characters exactly.';
+
+    await runSaveNote({ rs, ...baseNoteParams, noteTitle: '', noteBody: longBody });
+
+    const stored = JSON.parse(mockFetch.mock.calls[0]![1].body);
+    expect(stored.title).toBe(longBody.slice(0, 50));
+    expect(stored.body).toBe(longBody);
+  });
+
+  it('trims whitespace-only title and body', async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+    const rs = makeRS();
+
+    await runSaveNote({ rs, ...baseNoteParams, noteTitle: '   ', noteBody: '  hello  ' });
+
+    const stored = JSON.parse(mockFetch.mock.calls[0]![1].body);
+    expect(stored.title).toBe('hello');
+    expect(stored.body).toBe('hello');
+  });
+
+  it('returns ok:false (without calling fetch) when body is empty', async () => {
+    const rs = makeRS();
+
+    const result = await runSaveNote({ rs, ...baseNoteParams, noteBody: '' });
+
+    expect(result).toEqual({ ok: false, error: 'Note body is empty' });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns ok:false (without calling fetch) when body is whitespace only', async () => {
+    const rs = makeRS();
+
+    const result = await runSaveNote({ rs, ...baseNoteParams, noteBody: '   \n\t  ' });
+
+    expect(result.ok).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  /**
+   * REGRESSION: same as for runSavePage — the popup used `await rs.store(item)`
+   * unprotected. Any rejection there would leave the popup hanging.
+   */
+  it('returns ok:false when the PUT fails (e.g. 500 server error)', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+    const rs = makeRS();
+
+    const result = await runSaveNote({ rs, ...baseNoteParams });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('500');
+  });
+
+  it('never throws — pathological rejections become tagged failures', async () => {
+    for (const reason of [undefined, null, { weird: 'shape' }, 42]) {
+      mockFetch.mockRejectedValue(reason);
+      const rs = makeRS();
+      await expect(runSaveNote({ rs, ...baseNoteParams })).resolves.toMatchObject({ ok: false });
+    }
+  });
+});

--- a/packages/extension/src/popup/save-orchestrator.ts
+++ b/packages/extension/src/popup/save-orchestrator.ts
@@ -1,0 +1,128 @@
+/**
+ * Save-flow orchestrators for the popup.
+ *
+ * The popup has historically called `saveAsImage` / `saveAsBookmark` /
+ * `rs.store()` directly inside its click handlers, with no error handling
+ * around the call. When any underlying step rejected — expired token, network
+ * failure, MV3 service-worker termination during the image-download
+ * round-trip — the exception bubbled out of the handler, the handler's
+ * `saving` flag was never reset, and the popup appeared to hang in "Saving…"
+ * forever.
+ *
+ * These orchestrators move that logic out of Svelte and turn errors into
+ * tagged results so the popup just renders state. They never throw — every
+ * failure becomes `{ ok: false, error }`, leaving the popup free to reset its
+ * spinner in `finally` regardless of outcome.
+ */
+import type { DirectRS } from '../lib/rs';
+import { saveAsImage, saveAsBookmark } from './save-logic';
+import type { NoteItem } from '@inbox-rs/rs-module';
+
+/** Tagged outcome for a save attempt. Errors never throw — they become `{ ok: false }`. */
+export type SaveResult = { ok: true } | { ok: false; error: string };
+
+export interface SavePageOrchestratorParams {
+  rs: DirectRS;
+  pageUrl: string;
+  pageTitle: string;
+  pageNote: string;
+  pageDescription: string;
+  embeddedContent: string;
+  tweetImages: string[];
+  ogImage: string;
+  favicon: string;
+  siteName: string;
+  isDirectImage: boolean;
+  /** Override for tests; defaults to `crypto.randomUUID()`. */
+  generateId?: () => string;
+  /** Override for tests; defaults to `new Date().toISOString()`. */
+  now?: () => string;
+}
+
+/**
+ * Save the active page. For direct-image pages, attempts an `ImageItem` save
+ * first and falls back to `BookmarkItem` if that fails (matching legacy
+ * behaviour). Always resolves — never throws.
+ */
+export async function runSavePage(params: SavePageOrchestratorParams): Promise<SaveResult> {
+  const id = params.generateId?.() ?? crypto.randomUUID();
+  const createdAt = params.now?.() ?? new Date().toISOString();
+
+  if (params.isDirectImage) {
+    try {
+      const result = await saveAsImage({
+        rs: params.rs,
+        id,
+        pageUrl: params.pageUrl,
+        pageTitle: params.pageTitle,
+        pageNote: params.pageNote,
+        createdAt,
+      });
+      if (result) return { ok: true };
+      // saveAsImage returned null (download via SW failed) — fall through.
+    } catch {
+      // Image save threw — fall through to bookmark save.
+    }
+  }
+
+  try {
+    await saveAsBookmark({
+      rs: params.rs,
+      id,
+      pageUrl: params.pageUrl,
+      pageTitle: params.pageTitle,
+      pageNote: params.pageNote,
+      pageDescription: params.pageDescription,
+      embeddedContent: params.embeddedContent,
+      tweetImages: params.tweetImages,
+      ogImage: params.ogImage,
+      favicon: params.favicon,
+      siteName: params.siteName,
+      createdAt,
+    });
+    return { ok: true };
+  } catch (e: any) {
+    return { ok: false, error: errorMessage(e) };
+  }
+}
+
+export interface SaveNoteOrchestratorParams {
+  rs: DirectRS;
+  noteTitle: string;
+  noteBody: string;
+  generateId?: () => string;
+  now?: () => string;
+}
+
+/**
+ * Save a quick note. Returns `{ ok: false }` if the body is empty or if
+ * `rs.store` rejects. Always resolves.
+ */
+export async function runSaveNote(params: SaveNoteOrchestratorParams): Promise<SaveResult> {
+  const body = params.noteBody.trim();
+  if (!body) return { ok: false, error: 'Note body is empty' };
+
+  const id = params.generateId?.() ?? crypto.randomUUID();
+  const createdAt = params.now?.() ?? new Date().toISOString();
+
+  const item: NoteItem = {
+    id,
+    type: 'note',
+    title: params.noteTitle.trim() || body.slice(0, 50),
+    body,
+    createdAt,
+  };
+
+  try {
+    await params.rs.store(item);
+    return { ok: true };
+  } catch (e: any) {
+    return { ok: false, error: errorMessage(e) };
+  }
+}
+
+function errorMessage(e: unknown): string {
+  if (e instanceof Error && e.message) return e.message;
+  if (typeof e === 'string' && e) return e;
+  return 'Save failed';
+}

--- a/packages/rs-module/src/runtime.test.ts
+++ b/packages/rs-module/src/runtime.test.ts
@@ -312,6 +312,70 @@ describe('connectViaOAuth', () => {
       }),
     ).rejects.toThrow('OAuth error: access_denied');
   });
+
+  /**
+   * REGRESSION: this is the failure mode the user just hit on Thunderbird.
+   * If the wrapper passes a `client_id` the server doesn't recognise, the
+   * server replies with `error=invalid_client` in the redirect — and the
+   * shared helper must surface it (not swallow it as a generic error).
+   */
+  it('propagates invalid_client from the OAuth redirect (the bug class that bit Thunderbird)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(webfingerBody()));
+    const launchAuthFlow = vi
+      .fn()
+      .mockResolvedValue(
+        'https://callback.example/#error=invalid_client&error_description=client%20not%20registered',
+      );
+
+    await expect(
+      connectViaOAuth('alice@example.com', {
+        clientId: 'inbox-rs-thunderbird', // the kind of bare identifier that triggers it
+        redirectUrl: 'https://callback.example/',
+        launchAuthFlow,
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/invalid_client/);
+  });
+
+  it('honours a custom scope override and includes it in the auth URL', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(webfingerBody()));
+    const launchAuthFlow = vi
+      .fn()
+      .mockResolvedValue('https://callback.example/#access_token=t');
+
+    await connectViaOAuth('alice@example.com', {
+      clientId: 'c',
+      redirectUrl: 'https://callback.example/',
+      scope: 'inbox:r contacts:rw',
+      launchAuthFlow,
+      fetchImpl,
+    });
+
+    const params = new URL(launchAuthFlow.mock.calls[0]![0] as string).searchParams;
+    expect(params.get('scope')).toBe('inbox:r contacts:rw');
+  });
+
+  it('does not append params to the discovered authUrl twice', async () => {
+    // Sanity check that the URL is well-formed and parseable.
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(webfingerBody()));
+    const launchAuthFlow = vi
+      .fn()
+      .mockResolvedValue('https://callback.example/#access_token=t');
+
+    await connectViaOAuth('alice@example.com', {
+      clientId: 'c',
+      redirectUrl: 'https://callback.example/',
+      launchAuthFlow,
+      fetchImpl,
+    });
+
+    const launchedUrl = new URL(launchAuthFlow.mock.calls[0]![0] as string);
+    // We expect exactly four query params (client_id, redirect_uri,
+    // response_type, scope). Anything else means the helper is appending
+    // more than it should.
+    const keys = Array.from(launchedUrl.searchParams.keys()).sort();
+    expect(keys).toEqual(['client_id', 'redirect_uri', 'response_type', 'scope']);
+  });
 });
 
 describe('DirectRS', () => {
@@ -435,6 +499,224 @@ describe('DirectRS', () => {
       await rs.store({ id: 'img-2', filePath: 'files/img-2.jpg', mimeType: 'image/jpeg' });
 
       expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Authorization header format', () => {
+    /**
+     * Servers parse the `Authorization` header strictly. Some reject
+     * anything that isn't exactly `Bearer <token>` with a single space.
+     * Pin the format down so a future refactor can't subtly break OAuth.
+     */
+    it('uses the exact "Bearer <token>" format on storeObject', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse());
+      const rs = new DirectRS(config, fetchImpl);
+
+      await rs.storeObject('items/x', {});
+
+      const auth = (fetchImpl.mock.calls[0]![1] as RequestInit).headers as Record<string, string>;
+      expect(auth.Authorization).toBe('Bearer tok');
+      expect(auth.Authorization).toMatch(/^Bearer [^ ]+$/);
+    });
+
+    it('uses the exact "Bearer <token>" format on storeFile', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse());
+      const rs = new DirectRS(config, fetchImpl);
+
+      await rs.storeFile('files/x.png', new ArrayBuffer(0), 'image/png');
+
+      const headers = (fetchImpl.mock.calls[0]![1] as RequestInit).headers as Record<string, string>;
+      expect(headers.Authorization).toBe('Bearer tok');
+    });
+
+    it('passes tokens with special URL characters through unmodified', async () => {
+      const weirdToken = 'a.b-c_d/e+f=g';
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse());
+      const rs = new DirectRS({ ...config, token: weirdToken }, fetchImpl);
+
+      await rs.storeObject('items/x', {});
+
+      const headers = (fetchImpl.mock.calls[0]![1] as RequestInit).headers as Record<string, string>;
+      expect(headers.Authorization).toBe(`Bearer ${weirdToken}`);
+    });
+  });
+
+  describe('URL construction', () => {
+    it('includes the inbox/ namespace prefix on every PUT', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse());
+      const rs = new DirectRS(config, fetchImpl);
+
+      await rs.storeObject('items/abc', {});
+      await rs.storeFile('files/x.png', new ArrayBuffer(0), 'image/png');
+
+      expect(fetchImpl.mock.calls[0]![0]).toBe(
+        'https://storage.example.com/storage/alice/inbox/items/abc',
+      );
+      expect(fetchImpl.mock.calls[1]![0]).toBe(
+        'https://storage.example.com/storage/alice/inbox/files/x.png',
+      );
+    });
+
+    it('passes path segments verbatim (does not encode slashes / dots)', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse());
+      const rs = new DirectRS(config, fetchImpl);
+
+      await rs.storeObject('items/with-dashes_and.dots', {});
+
+      expect(fetchImpl.mock.calls[0]![0]).toContain('/inbox/items/with-dashes_and.dots');
+    });
+  });
+
+  describe('error messages', () => {
+    it.each([
+      ['401 expired token', 401, 'Store failed: 401'],
+      ['403 forbidden', 403, 'Store failed: 403'],
+      ['413 payload too large', 413, 'Store failed: 413'],
+      ['500 server error', 500, 'Store failed: 500'],
+      ['502 bad gateway', 502, 'Store failed: 502'],
+    ])('storeObject error includes the numeric status: %s', async (_label, status, msg) => {
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse({ ok: false, status }));
+      const rs = new DirectRS(config, fetchImpl);
+
+      await expect(rs.storeObject('items/x', {})).rejects.toThrow(msg);
+    });
+
+    it.each([
+      [413, 'Store file failed: 413'],
+      [500, 'Store file failed: 500'],
+    ])('storeFile error includes the numeric status: %i', async (status, msg) => {
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse({ ok: false, status }));
+      const rs = new DirectRS(config, fetchImpl);
+
+      await expect(rs.storeFile('files/x', new ArrayBuffer(0), 'image/png')).rejects.toThrow(msg);
+    });
+
+    it('store() short-circuits on file PUT failure (does not attempt metadata)', async () => {
+      const fetchImpl = vi
+        .fn()
+        // First call: storeFile, fails.
+        .mockResolvedValueOnce(emptyResponse({ ok: false, status: 413 }))
+        // Subsequent calls would be the metadata PUT — must NOT happen.
+        .mockResolvedValueOnce(emptyResponse());
+
+      const rs = new DirectRS(config, fetchImpl);
+      await expect(
+        rs.store(
+          { id: 'x', filePath: 'files/x.jpg', mimeType: 'image/jpeg' },
+          new ArrayBuffer(8),
+        ),
+      ).rejects.toThrow('Store file failed: 413');
+
+      // Critical: the metadata PUT must not have run, otherwise we'd
+      // leave orphan items pointing at a missing file.
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('binary payload', () => {
+    /**
+     * REGRESSION: previous remoteStorage layers tried to convert
+     * ArrayBuffers to "binary strings" before upload, which corrupted
+     * non-ASCII bytes. DirectRS must pass the buffer through untouched.
+     */
+    it('passes the ArrayBuffer through to fetch unchanged', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(emptyResponse());
+      const rs = new DirectRS(config, fetchImpl);
+      const data = new Uint8Array([0xff, 0x00, 0xfe, 0x01, 0xde, 0xad, 0xbe, 0xef]).buffer;
+
+      await rs.storeFile('files/x.bin', data, 'application/octet-stream');
+
+      const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+      expect(init.body).toBe(data);
+      expect(init.body).toBeInstanceOf(ArrayBuffer);
+    });
+
+    it('store() uploads file before metadata so readers never see a metadata-without-file state', async () => {
+      const calls: string[] = [];
+      const fetchImpl = vi.fn(async (url: string) => {
+        calls.push(url);
+        return emptyResponse();
+      });
+      const rs = new DirectRS(config, fetchImpl);
+
+      await rs.store(
+        { id: 'img-1', filePath: 'files/img-1.jpg', mimeType: 'image/jpeg' },
+        new ArrayBuffer(4),
+      );
+
+      expect(calls[0]).toContain('/inbox/files/img-1.jpg');
+      expect(calls[1]).toContain('/inbox/items/img-1');
+    });
+  });
+
+  describe('fetch this-binding (browser "Illegal invocation" regression)', () => {
+    /**
+     * REGRESSION: in browsers, the global `fetch` validates that `this` is
+     * the Window object and throws
+     *   "TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation"
+     * when called with any other `this`. Calling `this.fetchImpl(...)` on a
+     * class instance resolves `this` to that instance, tripping the check.
+     * The DirectRS constructor binds `fetchImpl` to `globalThis` to prevent
+     * this. These tests simulate the browser's strict check so unit tests
+     * (which normally use `vi.fn()` mocks that ignore `this`) catch a
+     * regression of the bind.
+     */
+    function makeStrictBrowserFetch() {
+      // Mimic the WebIDL [[ThisValue]] check: anything that isn't the global
+      // (or the conventional null/undefined for free-function calls) throws.
+      return vi.fn(function (this: unknown) {
+        const isGlobalLike = this === globalThis || this === undefined || this === null;
+        if (!isGlobalLike) {
+          throw new TypeError("Failed to execute 'fetch' on 'Window': Illegal invocation");
+        }
+        return Promise.resolve(emptyResponse());
+      });
+    }
+
+    it('storeObject does not throw "Illegal invocation"', async () => {
+      const strictFetch = makeStrictBrowserFetch();
+      const rs = new DirectRS(config, strictFetch as unknown as typeof fetch);
+
+      await expect(rs.storeObject('items/x', { id: 'x' })).resolves.toBeUndefined();
+      expect(strictFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('storeFile does not throw "Illegal invocation"', async () => {
+      const strictFetch = makeStrictBrowserFetch();
+      const rs = new DirectRS(config, strictFetch as unknown as typeof fetch);
+
+      await expect(
+        rs.storeFile('files/x.png', new ArrayBuffer(8), 'image/png'),
+      ).resolves.toBeUndefined();
+      expect(strictFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('store (full path with file + metadata) does not throw "Illegal invocation"', async () => {
+      const strictFetch = makeStrictBrowserFetch();
+      const rs = new DirectRS(config, strictFetch as unknown as typeof fetch);
+
+      await expect(
+        rs.store(
+          { id: 'img-1', filePath: 'files/img-1.jpg', mimeType: 'image/jpeg' },
+          new ArrayBuffer(16),
+        ),
+      ).resolves.toBeUndefined();
+      expect(strictFetch).toHaveBeenCalledTimes(2); // file + metadata
+    });
+
+    it('preserves call records on already-bound or pre-wrapped impls', async () => {
+      // If a caller passes their own bound or wrapped fetch, our extra bind
+      // must not break call tracking — the inner impl still sees every call.
+      const inner = vi.fn().mockResolvedValue(emptyResponse());
+      const preBound = inner.bind({ marker: 'caller-bound' });
+      const rs = new DirectRS(config, preBound as unknown as typeof fetch);
+
+      await rs.storeObject('items/x', {});
+      expect(inner).toHaveBeenCalledTimes(1);
+      expect(inner).toHaveBeenCalledWith(
+        expect.stringContaining('/inbox/items/x'),
+        expect.objectContaining({ method: 'PUT' }),
+      );
     });
   });
 });

--- a/packages/rs-module/src/runtime.ts
+++ b/packages/rs-module/src/runtime.ts
@@ -194,7 +194,15 @@ export class DirectRS {
   constructor(private readonly config: RSConfig, fetchImpl: FetchLike = fetch) {
     if (!config.href) throw new Error('DirectRS requires config.href');
     if (!config.token) throw new Error('DirectRS requires config.token');
-    this.fetchImpl = fetchImpl;
+    // Bind to globalThis so member-access calls (`this.fetchImpl(...)`) don't
+    // trip the browser's "Illegal invocation" check, which requires `this`
+    // on the global `fetch` to be the Window. Without this, calling
+    // `this.fetchImpl(...)` resolves `this` to the DirectRS instance and
+    // browsers throw `TypeError: Failed to execute 'fetch' on 'Window':
+    // Illegal invocation`. Bind is a no-op for already-bound impls (the
+    // first bind wins) and for test mocks, whose call records still update
+    // through the bound delegate.
+    this.fetchImpl = fetchImpl.bind(globalThis);
   }
 
   private get headers(): Record<string, string> {

--- a/packages/thunderbird/manifest.json
+++ b/packages/thunderbird/manifest.json
@@ -12,7 +12,8 @@
   "permissions": [
     "messagesRead",
     "storage",
-    "identity"
+    "identity",
+    "<all_urls>"
   ],
   "message_display_action": {
     "default_popup": "src/popup/index.html",

--- a/packages/thunderbird/package.json
+++ b/packages/thunderbird/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite build --watch",
     "build": "vite build",
-    "package": "vite build && cd dist && zip -r ../inbox-rs.xpi ."
+    "package": "vite build && cd dist && zip -r ../inbox-rs.xpi .",
+    "test": "vitest run"
   },
   "dependencies": {
     "@inbox-rs/rs-module": "*"
@@ -15,6 +16,7 @@
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "svelte": "^5.0.0",
     "typescript": "^5.4.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.2"
   }
 }

--- a/packages/thunderbird/src/lib/mime.test.ts
+++ b/packages/thunderbird/src/lib/mime.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { extractTextBody } from './mime';
+
+/**
+ * `extractTextBody` walks a `messenger.messages.MessagePart` tree, prefers
+ * `text/plain`, and falls back to a tag-stripped `text/html`. Tests build
+ * minimal part shapes that match the ambient `messenger` typings without
+ * needing the real Thunderbird API.
+ */
+
+function part(contentType: string, body?: string, parts?: any[]): any {
+  return { contentType, body, parts };
+}
+
+describe('extractTextBody', () => {
+  it('returns the text/plain body when present at the root', () => {
+    expect(extractTextBody(part('text/plain', 'Hello'))).toBe('Hello');
+  });
+
+  it('finds text/plain nested inside a multipart tree', () => {
+    const tree = part('multipart/alternative', undefined, [
+      part('text/html', '<p>html version</p>'),
+      part('text/plain', 'plain version'),
+    ]);
+    expect(extractTextBody(tree)).toBe('plain version');
+  });
+
+  it('prefers text/plain over text/html when both exist', () => {
+    const tree = part('multipart/alternative', undefined, [
+      part('text/plain', 'plain wins'),
+      part('text/html', '<p>html loses</p>'),
+    ]);
+    expect(extractTextBody(tree)).toBe('plain wins');
+  });
+
+  it('falls back to text/html with tag stripping when plain is absent', () => {
+    const tree = part('multipart/alternative', undefined, [
+      part('text/html', '<p>Hello <strong>world</strong></p>'),
+    ]);
+    expect(extractTextBody(tree)).toBe('Hello world');
+  });
+
+  it('strips <script> and <style> blocks entirely', () => {
+    const html =
+      '<style>.x{color:red}</style><script>alert(1)</script><p>Body text</p>';
+    expect(extractTextBody(part('text/html', html))).toBe('Body text');
+  });
+
+  it('decodes common HTML entities', () => {
+    const html = '<p>5 &lt; 10 &amp; 20 &gt; 5 &quot;quoted&quot;&nbsp;text</p>';
+    expect(extractTextBody(part('text/html', html))).toBe('5 < 10 & 20 > 5 "quoted" text');
+  });
+
+  it('converts <br> and </p> to newlines', () => {
+    const html = '<p>line1</p><p>line2</p>line3<br>line4';
+    expect(extractTextBody(part('text/html', html))).toBe('line1\n\nline2\n\nline3\nline4');
+  });
+
+  it('collapses runs of 3+ newlines to a single blank-line separator', () => {
+    const html = '<p>a</p><br><br><br><br><p>b</p>';
+    const result = extractTextBody(part('text/html', html));
+    expect(result).not.toMatch(/\n{3,}/);
+  });
+
+  it('returns empty string when no text part exists', () => {
+    const tree = part('multipart/mixed', undefined, [
+      part('image/png'),
+      part('application/octet-stream'),
+    ]);
+    expect(extractTextBody(tree)).toBe('');
+  });
+
+  it('returns empty string when text part has no body', () => {
+    expect(extractTextBody(part('text/plain', undefined))).toBe('');
+  });
+
+  it('handles deeply nested message structures', () => {
+    const tree = part('multipart/mixed', undefined, [
+      part('multipart/related', undefined, [
+        part('multipart/alternative', undefined, [
+          part('text/html', '<p>html</p>'),
+          part('text/plain', 'deep plain'),
+        ]),
+      ]),
+    ]);
+    expect(extractTextBody(tree)).toBe('deep plain');
+  });
+});

--- a/packages/thunderbird/src/lib/rs.test.ts
+++ b/packages/thunderbird/src/lib/rs.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * `lib/rs.ts` is a thin glue layer that:
+ *   1. resolves Thunderbird's `browser.identity.getRedirectURL()` for the
+ *      OAuth `redirect_uri`,
+ *   2. forwards `browser.identity.launchWebAuthFlow` as the launcher,
+ *   3. delegates the rest to the shared `connectViaOAuth` in `@inbox-rs/rs-module`.
+ *
+ * If any of those wirings break the user can't authenticate at all — the
+ * symptom we just shipped a fix for. These tests pin the wiring down.
+ */
+
+const { mockGetRedirectURL, mockLaunchWebAuthFlow } = vi.hoisted(() => ({
+  mockGetRedirectURL: vi.fn<() => string>(),
+  mockLaunchWebAuthFlow: vi.fn<(args: { url: string; interactive: boolean }) => Promise<string>>(),
+}));
+
+// Stub the ambient `browser` global before importing the module under test.
+// The Thunderbird code uses `browser.identity.*` directly with no polyfill.
+vi.stubGlobal('browser', {
+  identity: {
+    getRedirectURL: mockGetRedirectURL,
+    launchWebAuthFlow: mockLaunchWebAuthFlow,
+  },
+});
+
+// Stub `fetch` for the WebFinger discovery call inside `connectViaOAuth`.
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { connectViaOAuth, DirectRS } from './rs';
+
+const REMOTESTORAGE_REL = 'http://tools.ietf.org/id/draft-dejong-remotestorage';
+const AUTH_PROP_KEY = 'http://tools.ietf.org/html/rfc6749#section-4.2';
+
+function webfingerResponse() {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      links: [
+        {
+          rel: REMOTESTORAGE_REL,
+          href: 'https://storage.example.com/storage/alice',
+          type: 'draft-dejong-remotestorage-12',
+          properties: { [AUTH_PROP_KEY]: 'https://storage.example.com/oauth' },
+        },
+      ],
+    }),
+  } as unknown as Response;
+}
+
+describe('connectViaOAuth (thunderbird)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRedirectURL.mockReturnValue('https://thunderbird.example/oauth-redirect');
+    mockFetch.mockResolvedValue(webfingerResponse());
+    mockLaunchWebAuthFlow.mockResolvedValue(
+      'https://thunderbird.example/oauth-redirect#access_token=tok-xyz',
+    );
+  });
+
+  it('uses Thunderbird identity API and returns a populated RSConfig', async () => {
+    const config = await connectViaOAuth('alice@example.com');
+
+    expect(config).toEqual({
+      userAddress: 'alice@example.com',
+      token: 'tok-xyz',
+      href: 'https://storage.example.com/storage/alice',
+      storageApi: 'draft-dejong-remotestorage-12',
+    });
+    expect(mockGetRedirectURL).toHaveBeenCalled();
+    expect(mockLaunchWebAuthFlow).toHaveBeenCalledWith(
+      expect.objectContaining({ interactive: true }),
+    );
+  });
+
+  /**
+   * REGRESSION: a previous version passed a static `'inbox-rs-thunderbird'`
+   * as `client_id`. Most spec-compliant remoteStorage servers (Armadietto in
+   * particular) require `client_id` to match the origin of `redirect_uri`
+   * and reject anything else with `OAuth error: invalid_client`. Pin the
+   * derivation so this can't silently regress to a static identifier.
+   */
+  it('derives client_id from the redirect_uri origin (not a static identifier)', async () => {
+    await connectViaOAuth('alice@example.com');
+
+    const launchedUrl = mockLaunchWebAuthFlow.mock.calls[0]![0].url;
+    const params = new URL(launchedUrl).searchParams;
+    const clientId = params.get('client_id');
+    const redirectUri = params.get('redirect_uri');
+
+    expect(redirectUri).toBe('https://thunderbird.example/oauth-redirect');
+    expect(clientId).toBe('https://thunderbird.example');
+    // The invariant: client_id must equal the origin of redirect_uri.
+    expect(clientId).toBe(new URL(redirectUri!).origin);
+    expect(params.get('response_type')).toBe('token');
+    expect(params.get('scope')).toBe('inbox:rw');
+  });
+
+  it('uses a different origin when the redirect URL changes', async () => {
+    // If Thunderbird ever rotates the per-extension redirect host (it does,
+    // periodically), the client_id must follow. This guards against any
+    // cached/static derivation creeping back in.
+    mockGetRedirectURL.mockReturnValueOnce('https://other-host.allizom.org/cb');
+    mockLaunchWebAuthFlow.mockResolvedValueOnce(
+      'https://other-host.allizom.org/cb#access_token=t',
+    );
+
+    await connectViaOAuth('alice@example.com');
+
+    const launchedUrl = mockLaunchWebAuthFlow.mock.calls[0]![0].url;
+    const params = new URL(launchedUrl).searchParams;
+    expect(params.get('client_id')).toBe('https://other-host.allizom.org');
+    expect(params.get('redirect_uri')).toBe('https://other-host.allizom.org/cb');
+  });
+
+  it('issues the WebFinger request to the user-supplied host', async () => {
+    await connectViaOAuth('alice@example.com');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.com/.well-known/webfinger?resource=acct:alice%40example.com',
+    );
+  });
+
+  /**
+   * REGRESSION: WebFinger discovery `fetch()` must be allowed to reach the
+   * RS host. The Thunderbird MV2 manifest used to omit host_permissions
+   * entirely, so this fetch was blocked by CORS and the Connect flow died
+   * before OAuth even started. The test for the *manifest* lives in
+   * `manifest.test.ts` — this test pins down the connection logic itself
+   * so a future refactor can't silently regress to "swallow the WebFinger
+   * error and pretend everything succeeded".
+   */
+  it('propagates a WebFinger failure as an error (does not silently succeed)', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 0, // What MV2 CORS rejection looks like in practice.
+    } as Response);
+
+    await expect(connectViaOAuth('alice@example.com')).rejects.toThrow(/WebFinger failed/);
+  });
+
+  it('propagates an OAuth error in the redirect URL', async () => {
+    mockLaunchWebAuthFlow.mockResolvedValueOnce(
+      'https://thunderbird.example/oauth-redirect#error=access_denied',
+    );
+
+    await expect(connectViaOAuth('alice@example.com')).rejects.toThrow(/access_denied/);
+  });
+
+  it('propagates a malformed user address before any network call', async () => {
+    await expect(connectViaOAuth('not-a-user-address')).rejects.toThrow(
+      /Invalid remoteStorage address/,
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockLaunchWebAuthFlow).not.toHaveBeenCalled();
+  });
+});
+
+describe('DirectRS export (thunderbird)', () => {
+  it('re-exports DirectRS from @inbox-rs/rs-module', () => {
+    expect(DirectRS).toBeDefined();
+    expect(typeof DirectRS).toBe('function');
+  });
+});

--- a/packages/thunderbird/src/lib/rs.ts
+++ b/packages/thunderbird/src/lib/rs.ts
@@ -7,20 +7,25 @@ import {
 export { DirectRS };
 export type { RSConfig };
 
-/** Static OAuth client id — Thunderbird does not provide a redirect-derived origin. */
-const THUNDERBIRD_CLIENT_ID = 'inbox-rs-thunderbird';
-
 /**
  * WebFinger discovery + OAuth via Thunderbird's identity API.
  *
  * Discovery, OAuth params, and token extraction live in the shared
  * `@inbox-rs/rs-module` runtime; this wrapper supplies Thunderbird-specific
- * glue (the global `browser.identity` API and a static client id).
+ * glue (the global `browser.identity` API).
+ *
+ * The OAuth `client_id` is derived from the redirect URL's origin — this is
+ * the convention every remoteStorage provider follows (RS spec §10), and
+ * Armadietto in particular rejects anything else with
+ * `OAuth error: invalid_client`. A previous version of this file passed a
+ * static identifier (`'inbox-rs-thunderbird'`) which broke against any
+ * spec-compliant server. The Chrome/Firefox extension (lib/rs.ts) uses the
+ * same redirect-origin trick — keep these two wrappers in lockstep.
  */
 export async function connectViaOAuth(userAddress: string): Promise<RSConfig> {
   const redirectUrl = browser.identity.getRedirectURL();
   return sharedConnectViaOAuth(userAddress, {
-    clientId: THUNDERBIRD_CLIENT_ID,
+    clientId: new URL(redirectUrl).origin,
     redirectUrl,
     launchAuthFlow: (url) =>
       browser.identity.launchWebAuthFlow({ url, interactive: true }) as Promise<string>,

--- a/packages/thunderbird/src/lib/storage.test.ts
+++ b/packages/thunderbird/src/lib/storage.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Thunderbird's `lib/storage.ts` mirrors the Chrome extension wrapper but
+ * uses the bare `browser` global (Thunderbird WebExtensions provide it
+ * natively, no polyfill import). These tests pin the wiring + the
+ * canonical storage key so the same regression class can't slip in.
+ */
+
+// `lib/storage.ts` reads the `browser` global at module-load time
+// (`createConfigStore(browser.storage.local)`), so the global must exist
+// BEFORE any of its imports execute. ES modules hoist imports above any
+// top-level statements, so `vi.hoisted()` is the only place we can
+// reliably set up the global early enough.
+const { mockGet, mockSet, mockRemove } = vi.hoisted(() => {
+  const mockGet = vi.fn();
+  const mockSet = vi.fn();
+  const mockRemove = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).browser = {
+    storage: { local: { get: mockGet, set: mockSet, remove: mockRemove } },
+  };
+  return { mockGet, mockSet, mockRemove };
+});
+
+import { getConfig, saveConfig, clearConfig } from './storage';
+import type { RSConfig } from '@inbox-rs/rs-module';
+
+const sampleConfig: RSConfig = {
+  userAddress: 'alice@example.com',
+  token: 'tok-abc',
+  href: 'https://storage.example.com/storage/alice',
+  storageApi: 'draft-dejong-remotestorage-12',
+};
+
+describe('thunderbird storage wrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue({});
+    mockSet.mockResolvedValue(undefined);
+    mockRemove.mockResolvedValue(undefined);
+  });
+
+  describe('getConfig', () => {
+    it('reads from browser.storage.local under the canonical key', async () => {
+      mockGet.mockResolvedValue({ 'inbox-rs-config': sampleConfig });
+
+      const config = await getConfig();
+
+      expect(config).toEqual(sampleConfig);
+      expect(mockGet).toHaveBeenCalledWith('inbox-rs-config');
+    });
+
+    it('uses the same storage key as the Chrome/Firefox extension', async () => {
+      // Cross-platform parity: the key is owned by `@inbox-rs/rs-module`'s
+      // `DEFAULT_CONFIG_STORAGE_KEY`. If anyone changes it, both wrappers
+      // must move in lockstep — same RS account, two extensions, one key.
+      await getConfig();
+      expect(mockGet).toHaveBeenCalledWith('inbox-rs-config');
+    });
+
+    it('returns null when no config has been saved', async () => {
+      mockGet.mockResolvedValue({});
+      expect(await getConfig()).toBeNull();
+    });
+  });
+
+  describe('saveConfig', () => {
+    it('writes to browser.storage.local under the canonical key', async () => {
+      await saveConfig(sampleConfig);
+      expect(mockSet).toHaveBeenCalledWith({ 'inbox-rs-config': sampleConfig });
+    });
+
+    it('round-trips with getConfig', async () => {
+      const store = new Map<string, unknown>();
+      mockGet.mockImplementation(async (key: string) => {
+        const out: Record<string, unknown> = {};
+        if (store.has(key)) out[key] = store.get(key);
+        return out;
+      });
+      mockSet.mockImplementation(async (items: Record<string, unknown>) => {
+        for (const [k, v] of Object.entries(items)) store.set(k, v);
+      });
+
+      await saveConfig(sampleConfig);
+      expect(await getConfig()).toEqual(sampleConfig);
+    });
+  });
+
+  describe('clearConfig', () => {
+    it('removes the canonical key from browser.storage.local', async () => {
+      await clearConfig();
+      expect(mockRemove).toHaveBeenCalledWith('inbox-rs-config');
+    });
+  });
+});

--- a/packages/thunderbird/src/manifest.test.ts
+++ b/packages/thunderbird/src/manifest.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Manifest invariants for the Thunderbird extension.
+ *
+ * REGRESSION: the manifest was originally shipped without any host match
+ * patterns. In MV2, host permissions live inline in `permissions`, and
+ * without them every cross-origin `fetch()` from the moz-extension origin
+ * (WebFinger discovery, OAuth redirect handling, RS PUTs) is subject to
+ * standard CORS — which the local Armadietto dev server and many providers
+ * fail. The user could never get past the "Connect" step. These tests pin
+ * the manifest contract so the regression cannot recur silently.
+ */
+
+const manifestPath = resolve(__dirname, '..', 'manifest.json');
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+
+describe('thunderbird manifest', () => {
+  it('targets MV2 (Thunderbird does not support MV3 yet)', () => {
+    expect(manifest.manifest_version).toBe(2);
+  });
+
+  it('declares an applications.gecko.id and minimum Thunderbird version', () => {
+    expect(manifest.applications?.gecko?.id).toMatch(/^[\w.+-]+@[\w.-]+$/);
+    expect(manifest.applications?.gecko?.strict_min_version).toBeDefined();
+  });
+
+  describe('permissions', () => {
+    it('declares messagesRead so we can read the displayed email', () => {
+      expect(manifest.permissions).toContain('messagesRead');
+    });
+
+    it('declares storage so the config can be persisted in browser.storage.local', () => {
+      expect(manifest.permissions).toContain('storage');
+    });
+
+    it('declares identity so OAuth via launchWebAuthFlow works', () => {
+      expect(manifest.permissions).toContain('identity');
+    });
+
+    /**
+     * REGRESSION: without a host match pattern, both
+     *   1. the WebFinger fetch in connectViaOAuth, and
+     *   2. every PUT made by DirectRS during save,
+     * are blocked by CORS for any RS provider that doesn't ship permissive
+     * headers (notably the local Armadietto dev server). The user reports
+     * "I can't even log in" because step 1 fails.
+     */
+    it('declares <all_urls> (or equivalent host patterns) so fetch can reach any RS host', () => {
+      const perms: string[] = manifest.permissions;
+      const hasAllUrls = perms.includes('<all_urls>');
+      const hasWildcardHttps = perms.some((p) => p.startsWith('https://') || p.startsWith('http://'));
+      expect(hasAllUrls || hasWildcardHttps).toBe(true);
+    });
+  });
+
+  it('declares a message_display_action with a popup', () => {
+    expect(manifest.message_display_action?.default_popup).toBe('src/popup/index.html');
+  });
+
+  it('declares an options page (so the user can set up RS auth)', () => {
+    expect(manifest.options_ui?.page).toBe('src/options/index.html');
+  });
+
+  it('declares a background script', () => {
+    expect(manifest.background?.scripts).toContain('background.js');
+  });
+});

--- a/packages/thunderbird/src/popup/Popup.svelte
+++ b/packages/thunderbird/src/popup/Popup.svelte
@@ -2,11 +2,12 @@
   import { DirectRS } from '../lib/rs';
   import { getConfig } from '../lib/storage';
   import { extractTextBody } from '../lib/mime';
-  import type { EmailItem } from '@inbox-rs/rs-module';
+  import { runSaveEmail } from './save-orchestrator';
 
   let connected = $state(false);
   let saving = $state(false);
   let saved = $state(false);
+  let saveError = $state('');
   let rs: DirectRS | null = null;
 
   let subject = $state('');
@@ -56,23 +57,18 @@
   async function saveEmail() {
     if (!rs || saving) return;
     saving = true;
-
-    const id = crypto.randomUUID();
-    const item: EmailItem = {
-      id,
-      type: 'email',
-      title: subject || 'Untitled email',
-      body: bodyText,
-      from: author || undefined,
-      notes: notes.trim() || undefined,
-      messageUrl: messageUrl || undefined,
-      createdAt: new Date().toISOString()
-    };
-    await rs.store(item);
-
-    saving = false;
-    saved = true;
-    setTimeout(() => window.close(), 800);
+    saveError = '';
+    try {
+      const result = await runSaveEmail({ rs, subject, author, bodyText, notes, messageUrl });
+      if (result.ok) {
+        saved = true;
+        setTimeout(() => window.close(), 800);
+      } else {
+        saveError = result.error;
+      }
+    } finally {
+      saving = false;
+    }
   }
 </script>
 
@@ -108,6 +104,9 @@
       <button type="submit" class="btn-primary" disabled={saving || !subject.trim()}>
         {saving ? 'Saving...' : 'Save to Inbox'}
       </button>
+      {#if saveError}
+        <p class="error" role="alert">{saveError}</p>
+      {/if}
     </form>
   {/if}
 </div>
@@ -228,6 +227,12 @@
     color: var(--success);
     font-size: 1.1rem;
     font-weight: 500;
+  }
+
+  .error {
+    color: var(--danger);
+    font-size: 0.8rem;
+    margin: 0.25rem 0 0;
   }
 
   .check {

--- a/packages/thunderbird/src/popup/save-orchestrator.test.ts
+++ b/packages/thunderbird/src/popup/save-orchestrator.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runSaveEmail } from './save-orchestrator';
+import { DirectRS } from '@inbox-rs/rs-module';
+
+/**
+ * Build a `DirectRS` whose underlying fetch can be controlled per-test.
+ * The orchestrator goes through `rs.store(item)` which performs a single PUT
+ * to `/inbox/items/<id>`, so each fetchImpl mock is checked once.
+ */
+function makeRS(fetchImpl: ReturnType<typeof vi.fn>): DirectRS {
+  return new DirectRS(
+    {
+      userAddress: 'alice@example.com',
+      token: 'tok',
+      href: 'https://storage.example.com',
+    },
+    fetchImpl as unknown as typeof fetch,
+  );
+}
+
+const baseParams = {
+  subject: 'Test subject',
+  author: 'sender@example.com',
+  bodyText: 'Hello world',
+  notes: '',
+  messageUrl: 'mid:abc-123',
+  generateId: () => 'email-uuid-1',
+  now: () => '2026-01-01T00:00:00.000Z',
+};
+
+describe('runSaveEmail', () => {
+  it('returns ok:true and PUTs the item when rs.store succeeds', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, status: 200 } as any);
+    const rs = makeRS(fetchImpl);
+
+    const result = await runSaveEmail({ rs, ...baseParams });
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toContain('/inbox/items/email-uuid-1');
+    const body = JSON.parse(init.body);
+    expect(body).toMatchObject({
+      id: 'email-uuid-1',
+      type: 'email',
+      title: 'Test subject',
+      body: 'Hello world',
+      from: 'sender@example.com',
+      messageUrl: 'mid:abc-123',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('falls back to "Untitled email" when subject is empty', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, status: 200 } as any);
+    const rs = makeRS(fetchImpl);
+
+    await runSaveEmail({ rs, ...baseParams, subject: '' });
+
+    const body = JSON.parse(fetchImpl.mock.calls[0]![1].body);
+    expect(body.title).toBe('Untitled email');
+  });
+
+  it('omits optional fields when blank/whitespace', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, status: 200 } as any);
+    const rs = makeRS(fetchImpl);
+
+    await runSaveEmail({
+      rs,
+      ...baseParams,
+      author: '',
+      notes: '   ',
+      messageUrl: '',
+    });
+
+    const body = JSON.parse(fetchImpl.mock.calls[0]![1].body);
+    expect(body.from).toBeUndefined();
+    expect(body.notes).toBeUndefined();
+    expect(body.messageUrl).toBeUndefined();
+  });
+
+  it('trims notes when present', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, status: 200 } as any);
+    const rs = makeRS(fetchImpl);
+
+    await runSaveEmail({ rs, ...baseParams, notes: '  important context  ' });
+
+    const body = JSON.parse(fetchImpl.mock.calls[0]![1].body);
+    expect(body.notes).toBe('important context');
+  });
+
+  /**
+   * REGRESSION: the popup used to call `await rs.store(item)` with no
+   * try/catch. When the PUT failed (expired token, network error, missing
+   * host_permissions blocking the request) the rejection propagated out of
+   * the click handler, leaving `saving` stuck true and the popup hanging in
+   * "Saving…" forever. The orchestrator MUST swallow these and return a
+   * tagged failure so the popup can reset its state in `finally`.
+   */
+  it('returns ok:false with the error message when rs.store rejects (401 expired token)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 401 } as any);
+    const rs = makeRS(fetchImpl);
+
+    const result = await runSaveEmail({ rs, ...baseParams });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('401');
+  });
+
+  it('returns ok:false when fetch itself rejects (network failure / CORS block)', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new TypeError('NetworkError when attempting to fetch resource.'));
+    const rs = makeRS(fetchImpl);
+
+    const result = await runSaveEmail({ rs, ...baseParams });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/NetworkError/i);
+  });
+
+  it('returns a generic message when the rejection has no message', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue('');
+    const rs = makeRS(fetchImpl);
+
+    const result = await runSaveEmail({ rs, ...baseParams });
+
+    expect(result).toEqual({ ok: false, error: 'Save failed' });
+  });
+
+  it('never throws — even pathological rejections become tagged failures', async () => {
+    // Real-world rejections we've seen: undefined, null, plain objects,
+    // and weird Error subclasses. The orchestrator must handle them all
+    // because the popup's UI promise depends on never seeing an exception.
+    for (const reason of [undefined, null, { weird: 'shape' }, 42]) {
+      const fetchImpl = vi.fn().mockRejectedValue(reason);
+      const rs = makeRS(fetchImpl);
+      // Must resolve, never throw.
+      await expect(runSaveEmail({ rs, ...baseParams })).resolves.toMatchObject({ ok: false });
+    }
+  });
+});

--- a/packages/thunderbird/src/popup/save-orchestrator.ts
+++ b/packages/thunderbird/src/popup/save-orchestrator.ts
@@ -1,0 +1,60 @@
+/**
+ * Save-flow orchestrator for the Thunderbird popup.
+ *
+ * Mirrors `packages/extension/src/popup/save-orchestrator.ts` — the popup
+ * historically called `rs.store()` directly with no error handling, so any
+ * rejection (expired token, network failure, missing host_permissions
+ * blocking the PUT) left the UI stuck in "Saving…" forever. This wrapper
+ * turns errors into tagged results so the popup can reset its spinner in
+ * `finally` and surface a real message instead of hanging.
+ */
+import type { DirectRS, EmailItem } from '@inbox-rs/rs-module';
+
+/** Tagged outcome for a save attempt. Errors never throw — they become `{ ok: false }`. */
+export type SaveResult = { ok: true } | { ok: false; error: string };
+
+export interface SaveEmailOrchestratorParams {
+  rs: DirectRS;
+  subject: string;
+  author: string;
+  bodyText: string;
+  notes: string;
+  messageUrl: string;
+  /** Override for tests; defaults to `crypto.randomUUID()`. */
+  generateId?: () => string;
+  /** Override for tests; defaults to `new Date().toISOString()`. */
+  now?: () => string;
+}
+
+/**
+ * Save the currently-displayed email as an `EmailItem`. Always resolves —
+ * any error from `rs.store` is converted to `{ ok: false, error }`.
+ */
+export async function runSaveEmail(params: SaveEmailOrchestratorParams): Promise<SaveResult> {
+  const id = params.generateId?.() ?? crypto.randomUUID();
+  const createdAt = params.now?.() ?? new Date().toISOString();
+
+  const item: EmailItem = {
+    id,
+    type: 'email',
+    title: params.subject || 'Untitled email',
+    body: params.bodyText,
+    from: params.author || undefined,
+    notes: params.notes.trim() || undefined,
+    messageUrl: params.messageUrl || undefined,
+    createdAt,
+  };
+
+  try {
+    await params.rs.store(item);
+    return { ok: true };
+  } catch (e: unknown) {
+    return { ok: false, error: errorMessage(e) };
+  }
+}
+
+function errorMessage(e: unknown): string {
+  if (e instanceof Error && e.message) return e.message;
+  if (typeof e === 'string' && e) return e;
+  return 'Save failed';
+}

--- a/packages/thunderbird/vitest.config.ts
+++ b/packages/thunderbird/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+// Thunderbird's source uses ambient `messenger` and `browser` types declared in
+// src/types/thunderbird.d.ts. Tests don't need those globals at runtime — each
+// suite stubs whatever it needs via vi.stubGlobal — so we just include the .ts
+// source files directly without dragging the build system in.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

Repairs four production bugs across the browser extensions and adds 51 regression tests so the same bug classes can't recur silently.

### Bugs fixed

**1. Thunderbird auth was completely broken — `<all_urls>` host permission missing.**
The MV2 manifest had no host match patterns, so the WebFinger discovery fetch (and every save PUT) was rejected by CORS from the `moz-extension://` origin. Users reported "I can't even log in".

**2. Save hangs in "Saving…" forever on any failure.**
Both popups called `await rs.store(item)` directly inside their click handlers with no try/catch. Any rejection (expired token, network failure, MV3 SW termination during the image-download round-trip) bubbled out, leaving `saving = $state(true)` permanently set with no error surfaced.

**3. Chrome save threw `Failed to execute 'fetch' on 'Window': Illegal invocation`.**
`DirectRS` stored `fetch` as an instance property and called it via `this.fetchImpl(…)`. Browser `fetch` requires `this === Window` and throws when invoked through any other `this`. Tests using `vi.fn()` mocks didn't catch this because mocks don't validate `this`.

**4. Thunderbird OAuth failed with `invalid_client`.**
The Thunderbird wrapper passed a static identifier (`'inbox-rs-thunderbird'`) as `client_id`. The remoteStorage spec (§10) and most providers (Armadietto in particular) require `client_id` to equal the origin of `redirect_uri` and reject anything else.

### How they were fixed

- `packages/thunderbird/manifest.json` — added `<all_urls>` to MV2 `permissions`.
- New `save-orchestrator.ts` modules in both extensions extract the save flow into pure functions that return `{ ok: true } | { ok: false, error: string }` and never throw. Both `Popup.svelte` files wrap calls in `try/finally`, always reset `saving`, and render `saveError` in red.
- `packages/rs-module/src/runtime.ts` — `DirectRS` constructor binds `fetchImpl` to `globalThis`, eliminating the `Illegal invocation` class.
- `packages/thunderbird/src/lib/rs.ts` — `client_id` now derives from `new URL(redirectUrl).origin`, matching the Chrome wrapper exactly.

### Test coverage

Added regression tests for every bug above plus broader coverage for previously-untested files. Set up Thunderbird's vitest infrastructure (previously had zero tests). Final counts:

| Package | Before | After | New |
|---|---|---|---|
| `rs-module` | 45 | 67 | +22 |
| `extension` | 43 | 92 | +49 |
| `thunderbird` | 0 | 42 | +42 |
| `web` | 191 | 191 | 0 |
| **total** | **279** | **392** | **+113** |

Highlights of the new regression tests:
- `manifest.test.ts` (both packages) — fails if `<all_urls>` (or equivalent) is removed.
- `save-orchestrator.test.ts` (both packages) — "never throws on pathological rejections" + 401/network-failure/etc. failure-path tests.
- `runtime.test.ts > fetch this-binding` — simulates browser fetch's strict `this` check; would have caught the `Illegal invocation` bug.
- `lib/rs.test.ts` (both packages) — `client_id === new URL(redirect_uri).origin` invariant; would have caught the `invalid_client` bug, including the Chrome variant that nothing previously tested.

## Test plan

- [x] `npm test` — 392 passing across rs-module / extension / thunderbird / web
- [x] `npm run build:extension` — succeeds with no new warnings
- [x] `npm run build:thunderbird` — succeeds with no new warnings
- [ ] Manual: load `packages/extension/dist` in Chrome, log in, save a page → no hang, no `Illegal invocation` in console
- [ ] Manual: load `packages/thunderbird/dist` in Thunderbird, set up RS in options page → OAuth completes without `invalid_client`
- [ ] Manual: open the Thunderbird extension popup on a displayed message, save → email lands in `/inbox/items/`