### PR TITLE
refactor(web): split AddEntryModal and ViewCardModal into per-type units

### DIFF
--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -1,25 +1,31 @@
 <script lang="ts">
-  import type { Component } from 'svelte';
-  import { onDestroy } from 'svelte';
-  import type { BookmarkItem, InboxItem, InboxItemType } from '@inbox-rs/rs-module';
+  import type { InboxItem, InboxItemType } from '@inbox-rs/rs-module';
   import {
-    storeItem, moveItemToCollection,
-    sortedGroups, groupCollections,
+    storeItem,
+    moveItemToCollection,
+    sortedGroups,
+    groupCollections,
   } from '../lib/stores';
-  import { renderMarkdown } from '../lib/markdown';
-  import { transcribeAudio } from '../lib/transcribe';
   import {
-    canCaptureTodo,
-    loadMarkdownEditorComponent,
-    type MarkdownEditorProps,
-    shouldLoadMarkdownEditor,
+    type BuildItemFn,
     shouldShowCollectionPicker,
     shouldSubmitAddEntryForm,
   } from '../lib/add-entry-modal';
-  import { isInsideCodeBlock, insertIndent, indentSelection, dedentSelection, insertNewlineWithIndent, isOnClosingFence } from '../lib/code-indent';
-  import { autofocus } from '../lib/actions';
+  import BookmarkForm from './add-entry/BookmarkForm.svelte';
+  import NoteForm from './add-entry/NoteForm.svelte';
+  import ImageForm from './add-entry/ImageForm.svelte';
+  import AudioForm from './add-entry/AudioForm.svelte';
+  import DocumentForm from './add-entry/DocumentForm.svelte';
+  import EmailForm from './add-entry/EmailForm.svelte';
+  import TodoForm from './add-entry/TodoForm.svelte';
 
-  let { type, editItem = undefined, collectionId = undefined, onclose, ondelete }: {
+  let {
+    type,
+    editItem = undefined,
+    collectionId = undefined,
+    onclose,
+    ondelete,
+  }: {
     type: InboxItemType;
     editItem?: InboxItem;
     collectionId?: string;
@@ -29,6 +35,13 @@
 
   const isEdit = !!editItem;
   let saving = $state(false);
+  let error = $state('');
+
+  // Each per-type form sets these via $bindable. The shell stays unaware
+  // of how the item is constructed — it just calls `buildItem` on Save and
+  // reads `formCanSubmit` to gate the action button.
+  let formCanSubmit = $state(false);
+  let formBuildItem = $state<BuildItemFn | undefined>(undefined);
 
   // Initial destination for new items: honour the caller's explicit
   // `collectionId` prop (e.g. a collection quick-add button), otherwise leave
@@ -58,7 +71,7 @@
     }
     for (const group of $sortedGroups) {
       const cols = $groupCollections[group.id] ?? [];
-      const found = cols.find(c => c.id === selectedCollectionId);
+      const found = cols.find((c) => c.id === selectedCollectionId);
       if (found) return found.name;
     }
     return isTodoType ? 'Unfiled' : noCollectionLabel;
@@ -74,12 +87,37 @@
     return false;
   });
 
-  const showCollectionPicker = $derived(shouldShowCollectionPicker(isEdit, type, hasAnyCollection));
+  const showCollectionPicker = $derived(
+    shouldShowCollectionPicker(isEdit, type, hasAnyCollection),
+  );
+
+  const addLabels: Record<InboxItemType, string> = {
+    bookmark: 'Add Bookmark',
+    note: 'Add Note',
+    image: 'Add Image',
+    audio: 'Add Audio',
+    video: 'Add Video',
+    document: 'Add File',
+    todo: 'Add Todo',
+    email: 'Add Email',
+  };
+
+  const editLabels: Record<InboxItemType, string> = {
+    bookmark: 'Edit Bookmark',
+    note: 'Edit Note',
+    image: 'Edit Image',
+    audio: 'Edit Audio',
+    video: 'Edit Video',
+    document: 'Edit File',
+    todo: 'Edit Todo',
+    email: 'Edit Email',
+  };
 
   $effect(() => {
     if (!collectionPickerOpen) return;
     const onDoc = (e: MouseEvent) => {
-      if (collectionPickerEl && !collectionPickerEl.contains(e.target as Node)) collectionPickerOpen = false;
+      if (collectionPickerEl && !collectionPickerEl.contains(e.target as Node))
+        collectionPickerOpen = false;
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') collectionPickerOpen = false;
@@ -121,8 +159,12 @@
     const gap = 4;
     const spaceBelow = viewportHeight - rect.bottom - gap;
     const spaceAbove = rect.top - gap;
-    const preferUp = spaceBelow < Math.min(menuMaxHeight, 200) && spaceAbove > spaceBelow;
-    const maxHeight = Math.max(120, Math.min(menuMaxHeight, preferUp ? spaceAbove : spaceBelow));
+    const preferUp =
+      spaceBelow < Math.min(menuMaxHeight, 200) && spaceAbove > spaceBelow;
+    const maxHeight = Math.max(
+      120,
+      Math.min(menuMaxHeight, preferUp ? spaceAbove : spaceBelow),
+    );
     const left = rect.left;
     const width = rect.width;
     if (preferUp) {
@@ -139,235 +181,22 @@
     collectionPickerOpen = !collectionPickerOpen;
   }
 
-  // Form fields — pre-populate from editItem if editing
-  let title = $state(editItem?.title ?? '');
-  let url = $state(editItem && 'url' in editItem ? editItem.url : '');
-  let body = $state(editItem && 'body' in editItem ? editItem.body ?? '' : '');
-  let description = $state(editItem?.description ?? '');
-  let completed = $state(editItem && 'completed' in editItem ? editItem.completed : false);
-  let from = $state(editItem && 'from' in editItem ? editItem.from ?? '' : '');
-  let notes = $state(editItem && 'notes' in editItem ? editItem.notes ?? '' : '');
-  let file = $state<File | null>(null);
-
-  // Markdown editor mode for notes
-  let editorMode = $state<'visual' | 'write' | 'preview'>('visual');
-  let MarkdownEditorComponent = $state<Component<MarkdownEditorProps> | null>(null);
-  let markdownEditorLoadError = $state('');
-  let previewHtml = $state('');
-
-  // Voice recording state
-  let recording = $state(false);
-  let recordingDuration = $state(0);
-  let recordedBlob = $state<Blob | null>(null);
-  let recordedUrl = $state<string | null>(null);
-  let transcript = $state('');
-  let transcribing = $state(false);
-  let transcriptionId = 0;
-  let mediaRecorder: MediaRecorder | null = null;
-  let recordingInterval: ReturnType<typeof setInterval> | null = null;
-
-  async function runTranscription(blob: Blob) {
-    const myId = ++transcriptionId;
-    transcribing = true;
-    try {
-      const result = await transcribeAudio(blob);
-      if (myId !== transcriptionId) return; // discarded
-      transcript = result;
-      if (transcript && !body) body = transcript;
-      if (transcript && !title) title = transcript.slice(0, 50);
-    } catch (e) {
-      if (myId !== transcriptionId) return;
-      console.warn('Transcription failed:', e);
-    } finally {
-      if (myId === transcriptionId) transcribing = false;
-    }
-  }
-
-  async function startRecording() {
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      const chunks: Blob[] = [];
-      mediaRecorder = new MediaRecorder(stream);
-      mediaRecorder.ondataavailable = (e) => {
-        if (e.data.size > 0) chunks.push(e.data);
-      };
-      mediaRecorder.onstop = () => {
-        stream.getTracks().forEach((t) => {
-          t.stop();
-        });
-        if (recordedUrl) URL.revokeObjectURL(recordedUrl);
-        const mimeType = mediaRecorder?.mimeType || 'audio/webm';
-        const blob = new Blob(chunks, { type: mimeType });
-        recordedBlob = blob;
-        recordedUrl = URL.createObjectURL(blob);
-        file = null;
-        runTranscription(blob);
-      };
-      mediaRecorder.start();
-      recording = true;
-      recordingDuration = 0;
-      recordingInterval = setInterval(() => { recordingDuration++; }, 1000);
-    } catch {
-      // Mic permission denied or unavailable
-    }
-  }
-
-  function stopRecording() {
-    if (mediaRecorder && mediaRecorder.state !== 'inactive') {
-      mediaRecorder.stop();
-    }
-    recording = false;
-    if (recordingInterval) {
-      clearInterval(recordingInterval);
-      recordingInterval = null;
-    }
-  }
-
-  function discardRecording() {
-    transcriptionId++; // cancel in-flight transcription
-    if (recordedUrl) URL.revokeObjectURL(recordedUrl);
-    recordedBlob = null;
-    recordedUrl = null;
-    recordingDuration = 0;
-    transcript = '';
-    transcribing = false;
-  }
-
-  function formatTimer(seconds: number): string {
-    const m = Math.floor(seconds / 60);
-    const s = seconds % 60;
-    return `${m}:${s.toString().padStart(2, '0')}`;
-  }
-
-  const addLabels: Record<InboxItemType, string> = {
-    'bookmark': 'Add Bookmark',
-    'note': 'Add Note',
-    'image': 'Add Image',
-    'audio': 'Add Audio',
-    'document': 'Add File',
-    'todo': 'Add Todo',
-    'email': 'Add Email',
-  };
-
-  const editLabels: Record<InboxItemType, string> = {
-    'bookmark': 'Edit Bookmark',
-    'note': 'Edit Note',
-    'image': 'Edit Image',
-    'audio': 'Edit Audio',
-    'document': 'Edit File',
-    'todo': 'Edit Todo',
-    'email': 'Edit Email',
-  };
-
-  function handleFileChange(e: Event) {
-    const input = e.currentTarget as HTMLInputElement;
-    file = input.files?.[0] ?? null;
-  }
-
-  function getExtension(filename: string): string {
-    const dot = filename.lastIndexOf('.');
-    return dot >= 0 ? filename.slice(dot) : '';
-  }
-
-  let error = $state('');
-
-  // For edit mode, check if the item already has a file
-  const hasExistingFile = !!editItem && 'filePath' in editItem && !!editItem.filePath;
-
   async function handleSubmit() {
+    if (!formBuildItem || !formCanSubmit) return;
     saving = true;
     error = '';
     try {
-      const id = isEdit ? editItem?.id : crypto.randomUUID();
-      const createdAt = isEdit ? editItem?.createdAt : new Date().toISOString();
-      let item: InboxItem;
-      let fileData: ArrayBuffer | undefined;
-
-      if (type === 'bookmark') {
-        const bookmark: BookmarkItem = {
-          id,
-          type: 'bookmark',
-          title: title || url,
-          url,
-          description: description || undefined,
-          createdAt,
-        };
-        // Preserve existing bookmark metadata when editing
-        if (editItem && editItem.type === 'bookmark') {
-          if (editItem.favicon) bookmark.favicon = editItem.favicon;
-          if (editItem.ogImage) bookmark.ogImage = editItem.ogImage;
-          if (editItem.siteName) bookmark.siteName = editItem.siteName;
-          if (editItem.body) bookmark.body = editItem.body;
-          if (editItem.filePath) bookmark.filePath = editItem.filePath;
-          if (editItem.mimeType) bookmark.mimeType = editItem.mimeType;
-        }
-        item = bookmark;
-      } else if (type === 'note') {
-        item = { id, type: 'note', title: title || body.slice(0, 50), body, description: description || undefined, createdAt };
-      } else if (type === 'image') {
-        if (file) {
-          const existingPath = isEdit && editItem?.type === 'image' ? editItem?.filePath : undefined;
-          const ext = getExtension(file.name);
-          const filePath = existingPath || `files/${id}${ext}`;
-          fileData = await file.arrayBuffer();
-          item = { id, type: 'image', title: title || file.name, filePath, mimeType: file.type, description: description || undefined, createdAt };
-        } else if (editItem && editItem.type === 'image') {
-          item = { ...editItem, title: title || editItem.title, description: description || undefined };
-        } else {
-          return;
-        }
-      } else if (type === 'audio') {
-        if (recordedBlob || file) {
-          const existingPath = isEdit && editItem?.type === 'audio' ? editItem?.filePath : undefined;
-          let filePath: string;
-          let mimeType: string;
-          let duration: number | undefined;
-          if (recordedBlob) {
-            const ext = recordedBlob.type.includes('webm') ? '.webm' : recordedBlob.type.includes('mp4') ? '.mp4' : '.ogg';
-            filePath = existingPath || `files/${id}${ext}`;
-            mimeType = recordedBlob.type || 'audio/webm';
-            fileData = await recordedBlob.arrayBuffer();
-            duration = recordingDuration || undefined;
-          } else if (file) {
-            const ext = getExtension(file.name);
-            filePath = existingPath || `files/${id}${ext}`;
-            mimeType = file.type;
-            fileData = await file.arrayBuffer();
-          } else {
-            return;
-          }
-          const memoBody = body || transcript || undefined;
-          const autoTitle = title || transcript || 'Audio';
-          const transcribed = !!(recordedBlob || transcript || body) || undefined;
-          item = { id, type: 'audio', title: autoTitle, filePath, mimeType, duration, body: memoBody, transcribed, description: description || undefined, createdAt };
-        } else if (editItem && editItem.type === 'audio') {
-          item = { ...editItem, title: title || editItem.title, body: body || undefined, description: description || undefined };
-        } else {
-          return;
-        }
-      } else if (type === 'document') {
-        if (file) {
-          const existingPath = isEdit && editItem?.type === 'document' ? editItem?.filePath : undefined;
-          const ext = getExtension(file.name);
-          const filePath = existingPath || `files/${id}${ext}`;
-          fileData = await file.arrayBuffer();
-          item = { id, type: 'document', title: title || file.name, filePath, mimeType: file.type, fileSize: file.size, fileName: file.name, description: description || undefined, createdAt };
-        } else if (editItem && editItem.type === 'document') {
-          item = { ...editItem, title: title || editItem.title, description: description || undefined };
-        } else {
-          return;
-        }
-      } else if (type === 'email') {
-        const emailMessageUrl = isEdit && editItem?.type === 'email' ? editItem?.messageUrl : undefined;
-        item = { id, type: 'email', title: title || 'Untitled email', body, from: from || undefined, notes: notes || undefined, messageUrl: emailMessageUrl, createdAt };
-      } else if (type === 'todo') {
-        item = { id, type: 'todo', title, body: body || undefined, completed, completedAt: completed && !(editItem && 'completed' in editItem && editItem.completed) ? new Date().toISOString() : (editItem && 'completedAt' in editItem ? editItem.completedAt : undefined), description: description || undefined, createdAt, isTodo: true };
-      } else {
-        return;
-      }
+      const id = isEdit ? (editItem?.id ?? crypto.randomUUID()) : crypto.randomUUID();
+      const createdAt = isEdit
+        ? (editItem?.createdAt ?? new Date().toISOString())
+        : new Date().toISOString();
+      const result = await formBuildItem({ id, createdAt, isEdit, editItem });
+      if (!result) return;
+      const { item, fileData } = result;
 
       // Preserve todo fields when editing non-todo types (converted items).
-      // For actual todo types, the form's completed checkbox is the source of truth.
+      // For actual todo types, the form's completed checkbox is the source
+      // of truth and already wrote whatever it needs.
       if (isEdit && type !== 'todo') {
         if (editItem?.isTodo) item.isTodo = true;
         if (editItem?.completed) item.completed = editItem?.completed;
@@ -381,159 +210,21 @@
       //   real id                 → assign via moveItemToCollection after storage
       await storeItem(item, fileData);
       if (selectedCollectionId && !isEdit) {
-        await moveItemToCollection(item?.id, selectedCollectionId);
+        await moveItemToCollection(item.id, selectedCollectionId);
       }
       onclose();
     } catch (e) {
       console.error('Save failed:', e);
-      error = e instanceof Error ? e.message : typeof e === 'string' ? e : String(e) || 'Failed to save';
+      error =
+        e instanceof Error
+          ? e.message
+          : typeof e === 'string'
+            ? e
+            : String(e) || 'Failed to save';
     } finally {
       saving = false;
     }
   }
-
-  async function _convertToTodo() {
-    saving = true;
-    error = '';
-    try {
-      if (!editItem) return;
-      const { completedAt: _, ...rest } = editItem;
-      const updated = { ...rest, isTodo: true, completed: false };
-      await storeItem(updated as InboxItem);
-      onclose();
-    } catch (e) {
-      console.error('Convert failed:', e);
-      error = e instanceof Error ? e.message : typeof e === 'string' ? e : String(e) || 'Failed to convert';
-    } finally {
-      saving = false;
-    }
-  }
-
-  /**
-   * Apply a computed TextState to a textarea using setRangeText, which
-   * preserves native undo/redo and auto-fires the input event.
-   */
-  function applyTextState(
-    ta: HTMLTextAreaElement,
-    next: import('../lib/code-indent').TextState,
-  ) {
-    ta.setRangeText(next.value, 0, ta.value.length, 'end');
-    ta.selectionStart = next.selectionStart;
-    ta.selectionEnd = next.selectionEnd;
-    ta.dispatchEvent(new Event('input', { bubbles: true }));
-  }
-
-  // Track whether Escape was pressed to release the Tab trap.
-  // Reset when the textarea regains focus or the user types a normal key.
-  let tabTrapped = $state(true);
-
-  /** Handle Tab, Enter, and Escape for auto-indenting inside code areas */
-  function handleCodeKeydown(e: KeyboardEvent, alwaysActive: boolean = false) {
-    const ta = e.currentTarget as HTMLTextAreaElement;
-
-    if (e.key === 'Escape') {
-      tabTrapped = false;
-      return;
-    }
-
-    // Any non-modifier key re-enables the Tab trap (user is typing again).
-    if (!e.key.startsWith('Shift') && !e.key.startsWith('Alt') && !e.key.startsWith('Control') && !e.key.startsWith('Meta') && e.key !== 'Tab' && e.key !== 'Enter') {
-      tabTrapped = true;
-    }
-
-    const active = alwaysActive || isInsideCodeBlock(ta.value, ta.selectionStart);
-    if (!active) return;
-
-    if (e.key === 'Tab' && tabTrapped) {
-      e.preventDefault();
-      const state = { value: ta.value, selectionStart: ta.selectionStart, selectionEnd: ta.selectionEnd };
-      if (state.selectionStart === state.selectionEnd) {
-        applyTextState(ta, insertIndent(state));
-      } else if (e.shiftKey) {
-        applyTextState(ta, dedentSelection(state));
-      } else {
-        applyTextState(ta, indentSelection(state));
-      }
-    } else if (e.key === 'Enter') {
-      if (!alwaysActive && isOnClosingFence(ta.value, ta.selectionStart)) return;
-
-      e.preventDefault();
-      const state = { value: ta.value, selectionStart: ta.selectionStart, selectionEnd: ta.selectionEnd };
-      applyTextState(ta, insertNewlineWithIndent(state));
-    }
-  }
-
-  onDestroy(() => {
-    if (mediaRecorder && mediaRecorder.state !== 'inactive') {
-      mediaRecorder.stop();
-    }
-    if (recordingInterval) clearInterval(recordingInterval);
-    if (recordedUrl) URL.revokeObjectURL(recordedUrl);
-  });
-
-  $effect(() => {
-    if (!shouldLoadMarkdownEditor(type, editorMode, !!MarkdownEditorComponent, !!markdownEditorLoadError)) {
-      return;
-    }
-
-    let cancelled = false;
-
-    loadMarkdownEditorComponent()
-      .then((component) => {
-        if (!cancelled) {
-          MarkdownEditorComponent = component;
-        }
-      })
-      .catch((loadError) => {
-        console.error('Failed to load markdown editor:', loadError);
-        if (!cancelled) {
-          markdownEditorLoadError = 'Visual editor unavailable. Markdown mode is still available.';
-          editorMode = 'write';
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  });
-
-  $effect(() => {
-    if (type !== 'note' || editorMode !== 'preview') {
-      previewHtml = '';
-      return;
-    }
-
-    const currentBody = body;
-    let cancelled = false;
-
-    renderMarkdown(currentBody)
-      .then((html) => {
-        if (!cancelled && body === currentBody && editorMode === 'preview') {
-          previewHtml = html;
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          previewHtml = '';
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  });
-
-  const needsFile = $derived(type === 'image' || type === 'document');
-  const canSubmit = $derived(
-    saving || recording ? false
-    : type === 'audio' ? !!(file || recordedBlob || hasExistingFile)
-    : needsFile ? !!(file || hasExistingFile)
-    : type === 'bookmark' ? !!url
-    : type === 'note' ? !!(title || body)
-    : type === 'email' ? !!body
-    : type === 'todo' ? canCaptureTodo(title)
-    : true
-  );
 </script>
 
 <!--
@@ -557,195 +248,70 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="overlay" onclick={onclose}>
-  <div class="modal" class:modal-note={type === 'note'} role="dialog" aria-modal="true" aria-labelledby="modal-title" onclick={(e) => e.stopPropagation()}>
-    <h2 class="modal-title" id="modal-title">{isEdit ? editLabels[type] : addLabels[type]}</h2>
+  <div
+    class="modal"
+    class:modal-note={type === 'note'}
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="modal-title"
+    onclick={(e) => e.stopPropagation()}
+  >
+    <h2 class="modal-title" id="modal-title">
+      {isEdit ? editLabels[type] : addLabels[type]}
+    </h2>
 
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="form" onkeydown={(e) => { if (shouldSubmitAddEntryForm(e.key, e.target, canSubmit)) { e.preventDefault(); handleSubmit(); } }}>
+    <div
+      class="form"
+      onkeydown={(e) => {
+        if (shouldSubmitAddEntryForm(e.key, e.target, formCanSubmit && !saving)) {
+          e.preventDefault();
+          handleSubmit();
+        }
+      }}
+    >
       {#if type === 'bookmark'}
-        <p class="info-note">Metadata fetching is not yet available in the web app. Use the browser extension to auto-fill bookmark details. Sockethub integration is planned for a future release.</p>
-        <label class="field">
-          <span>URL *</span>
-          <input use:autofocus type="url" bind:value={url} placeholder="https://..." />
-        </label>
-        <label class="field">
-          <span>Title</span>
-          <input type="text" bind:value={title} placeholder="Page title" />
-        </label>
-        <label class="field">
-          <span>Note</span>
-          <textarea bind:value={description} rows="2" placeholder="Optional note..."></textarea>
-        </label>
-
+        <BookmarkForm
+          {editItem}
+          bind:canSubmit={formCanSubmit}
+          bind:buildItem={formBuildItem}
+        />
       {:else if type === 'note'}
-        <label class="field">
-          <span>Title</span>
-          <!--
-            Title is autofocused for the note modal too. The visual editor
-            below is async-loaded and doesn't autofocus on mount, so without
-            this the user opens the modal and lands on no field at all. When
-            in `write` (Markdown) mode the body textarea also has
-            `use:autofocus` and runs later in the DOM, so it wins the focus
-            race and the user lands in the editor — which is what they want
-            once they've explicitly switched to Markdown mode.
-          -->
-          <input use:autofocus type="text" bind:value={title} placeholder="Note title" />
-        </label>
-        <div class="field note-editor-field">
-          <div class="field-header">
-            <span>Content</span>
-            <div class="editor-tabs">
-              <button type="button" class="tab" class:active={editorMode === 'visual'} onclick={() => editorMode = 'visual'} disabled={!!markdownEditorLoadError}>Visual</button>
-              <button type="button" class="tab" class:active={editorMode === 'write'} onclick={() => editorMode = 'write'}>Markdown</button>
-              <button type="button" class="tab" class:active={editorMode === 'preview'} onclick={() => editorMode = 'preview'}>Preview</button>
-            </div>
-          </div>
-          {#if editorMode === 'visual'}
-            {#if MarkdownEditorComponent}
-              <MarkdownEditorComponent bind:value={body} placeholder="Write your note..." />
-            {:else if markdownEditorLoadError}
-              <textarea
-                use:autofocus
-                class="code-input"
-                bind:value={body}
-                rows="10"
-                placeholder="Write your note in Markdown..."
-                onkeydown={handleCodeKeydown}
-              ></textarea>
-            {:else}
-              <div class="editor-loading" aria-live="polite">Loading visual editor…</div>
-            {/if}
-          {:else if editorMode === 'write'}
-            <textarea
-              use:autofocus
-              class="code-input"
-              bind:value={body}
-              rows="10"
-              placeholder="Write your note in Markdown..."
-              onkeydown={handleCodeKeydown}
-            ></textarea>
-          {:else}
-            <div class="preview-wrap markdown-body">
-              {#if previewHtml}
-                {@html previewHtml}
-              {:else if body.trim()}
-                <span class="preview-empty">Preview unavailable</span>
-              {:else}
-                <span class="preview-empty">Nothing to preview</span>
-              {/if}
-            </div>
-          {/if}
-        </div>
-        {#if markdownEditorLoadError}
-          <p class="info-note">{markdownEditorLoadError}</p>
-        {/if}
-
+        <NoteForm
+          {editItem}
+          bind:canSubmit={formCanSubmit}
+          bind:buildItem={formBuildItem}
+        />
       {:else if type === 'image'}
-        <label class="field">
-          <span>{hasExistingFile ? 'Replace image' : 'Image *'}</span>
-          <input type="file" accept="image/*" onchange={handleFileChange} />
-        </label>
-        <label class="field">
-          <span>Title</span>
-          <input use:autofocus type="text" bind:value={title} placeholder="Image title" />
-        </label>
-        <label class="field">
-          <span>Description</span>
-          <textarea bind:value={description} rows="2" placeholder="Optional description..."></textarea>
-        </label>
-
+        <ImageForm
+          {editItem}
+          bind:canSubmit={formCanSubmit}
+          bind:buildItem={formBuildItem}
+        />
       {:else if type === 'audio'}
-        {#if !isEdit}
-          <div class="field">
-            <span>Record</span>
-            <div class="recorder">
-              {#if recording}
-                <span class="rec-indicator"></span>
-                <span class="rec-timer">{formatTimer(recordingDuration)}</span>
-                <button type="button" class="rec-btn rec-stop" onclick={stopRecording}>Stop</button>
-              {:else if recordedBlob}
-                <!-- See AudioCard.svelte for why an empty captions track is OK here. -->
-                <audio controls src={recordedUrl} preload="metadata">
-                  <track kind="captions" />
-                </audio>
-                <button type="button" class="rec-btn rec-discard" onclick={discardRecording}>Discard</button>
-              {:else}
-                <button type="button" class="rec-btn rec-start" onclick={startRecording}>Start Recording</button>
-              {/if}
-            </div>
-          </div>
-          {#if transcribing}
-            <p class="transcript-status">Transcribing...</p>
-          {/if}
-          {#if transcript}
-            <div class="field">
-              <span>Transcript</span>
-              <p class="transcript">{transcript}</p>
-            </div>
-          {/if}
-          {#if !recordedBlob && !recording}
-            <label class="field">
-              <span>Or upload audio file</span>
-              <input type="file" accept="audio/*" onchange={handleFileChange} />
-            </label>
-          {/if}
-        {/if}
-        <label class="field">
-          <span>Title</span>
-          <input use:autofocus type="text" bind:value={title} placeholder="Memo title" />
-        </label>
-        <label class="field">
-          <span>Body</span>
-          <textarea class="auto-expand" bind:value={body} rows="3" placeholder="Transcription or notes..."></textarea>
-        </label>
-
+        <AudioForm
+          {editItem}
+          bind:canSubmit={formCanSubmit}
+          bind:buildItem={formBuildItem}
+        />
       {:else if type === 'document'}
-        <label class="field">
-          <span>{hasExistingFile ? 'Replace file' : 'File *'}</span>
-          <input type="file" onchange={handleFileChange} />
-        </label>
-        <label class="field">
-          <span>Title</span>
-          <input use:autofocus type="text" bind:value={title} placeholder="Document title" />
-        </label>
-        <label class="field">
-          <span>Description</span>
-          <textarea bind:value={description} rows="2" placeholder="Optional description..."></textarea>
-        </label>
-
+        <DocumentForm
+          {editItem}
+          bind:canSubmit={formCanSubmit}
+          bind:buildItem={formBuildItem}
+        />
       {:else if type === 'email'}
-        <label class="field">
-          <span>Subject</span>
-          <input use:autofocus type="text" bind:value={title} placeholder="Email subject" />
-        </label>
-        <label class="field">
-          <span>From</span>
-          <input type="text" bind:value={from} placeholder="Sender" />
-        </label>
-        <label class="field">
-          <span>Body *</span>
-          <textarea bind:value={body} rows="6" placeholder="Email body..."></textarea>
-        </label>
-        <label class="field">
-          <span>Notes</span>
-          <textarea bind:value={notes} rows="2" placeholder="Optional notes..."></textarea>
-        </label>
-
+        <EmailForm
+          {editItem}
+          bind:canSubmit={formCanSubmit}
+          bind:buildItem={formBuildItem}
+        />
       {:else if type === 'todo'}
-        <label class="field">
-          <span>Title *</span>
-          <input use:autofocus type="text" bind:value={title} placeholder="What needs to be done?" />
-        </label>
-        <label class="field">
-          <span>Details</span>
-          <textarea bind:value={body} rows="3" placeholder="Optional details..." onkeydown={handleCodeKeydown}></textarea>
-        </label>
-        {#if isEdit}
-          <label class="field checkbox-field">
-            <input type="checkbox" bind:checked={completed} />
-            <span>Completed</span>
-          </label>
-        {/if}
+        <TodoForm
+          {editItem}
+          bind:canSubmit={formCanSubmit}
+          bind:buildItem={formBuildItem}
+        />
       {/if}
 
       {#if showCollectionPicker}
@@ -761,12 +327,29 @@
               aria-expanded={collectionPickerOpen}
             >
               <span class="dest-label">{collectionLabel}</span>
-              <svg aria-hidden="true" class="dest-chevron" class:open={collectionPickerOpen} width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <svg
+                aria-hidden="true"
+                class="dest-chevron"
+                class:open={collectionPickerOpen}
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
                 <polyline points="6 9 12 15 18 9"></polyline>
               </svg>
             </button>
             {#if collectionPickerOpen}
-              <div class="dest-menu" role="listbox" aria-label="Destination" style={pickerMenuStyle}>
+              <div
+                class="dest-menu"
+                role="listbox"
+                aria-label="Destination"
+                style={pickerMenuStyle}
+              >
                 <!--
                   Default non-collection destination. For refs this is Inbox;
                   for todos this is unfiled so they can be organized later.
@@ -778,7 +361,11 @@
                     class:selected={selectedCollectionId === undefined}
                     onclick={() => selectCollection(undefined)}
                   >
-                    <span class="dest-dot" style="background: #9ca3af" aria-hidden="true"></span>
+                    <span
+                      class="dest-dot"
+                      style="background: #9ca3af"
+                      aria-hidden="true"
+                    ></span>
                     Unfiled
                   </button>
                 {:else if !isTodoType}
@@ -795,8 +382,15 @@
                 {#each $sortedGroups as group (group.id)}
                   {@const cols = $groupCollections[group.id] ?? []}
                   {#if cols.length > 0}
-                    <div class="dest-group-label" style="--group-color: {group.color || 'var(--accent)'}">
-                      <span class="dest-dot" style="background: var(--group-color)" aria-hidden="true"></span>
+                    <div
+                      class="dest-group-label"
+                      style="--group-color: {group.color || 'var(--accent)'}"
+                    >
+                      <span
+                        class="dest-dot"
+                        style="background: var(--group-color)"
+                        aria-hidden="true"
+                      ></span>
                       {group.name}
                     </div>
                     {#each cols as col (col.id)}
@@ -806,7 +400,11 @@
                         class:selected={selectedCollectionId === col.id}
                         onclick={() => selectCollection(col.id)}
                       >
-                        <span class="dest-dot" style="background: {col.color || 'var(--accent)'}" aria-hidden="true"></span>
+                        <span
+                          class="dest-dot"
+                          style="background: {col.color || 'var(--accent)'}"
+                          aria-hidden="true"
+                        ></span>
                         {col.name}
                       </button>
                     {/each}
@@ -824,16 +422,38 @@
 
       <div class="actions">
         {#if isEdit && ondelete && editItem}
-          <button type="button" class="btn-delete-item" disabled={saving} onclick={() => editItem && ondelete?.(editItem)}>
-            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <button
+            type="button"
+            class="btn-delete-item"
+            disabled={saving}
+            onclick={() => editItem && ondelete?.(editItem)}
+          >
+            <svg
+              aria-hidden="true"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
               <polyline points="3 6 5 6 21 6"></polyline>
-              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+              <path
+                d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
+              ></path>
             </svg>
             Delete
           </button>
         {/if}
         <button type="button" class="btn-cancel" onclick={onclose}>Cancel</button>
-        <button type="button" class="btn-save" disabled={!canSubmit} onclick={handleSubmit}>
+        <button
+          type="button"
+          class="btn-save"
+          disabled={!formCanSubmit || saving}
+          onclick={handleSubmit}
+        >
           {saving ? 'Saving...' : 'Save'}
         </button>
       </div>
@@ -865,7 +485,8 @@
 
   @media (max-width: 600px), (display-mode: standalone) {
     .overlay {
-      padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+      padding: env(safe-area-inset-top) env(safe-area-inset-right)
+        env(safe-area-inset-bottom) env(safe-area-inset-left);
       background: var(--bg);
     }
 
@@ -899,32 +520,39 @@
     margin-bottom: 1rem;
   }
 
-  .field {
+  /*
+   * Form-field styles. Per-type form components render `.field` / `.info-note`
+   * / `.error` / etc. into the modal's DOM. Because Svelte CSS is scoped per
+   * component, a child component's plain `.field` selector wouldn't match
+   * styles defined here unless we mark them `:global`. They're scoped under
+   * `.form` so the leak stays bounded to this modal's children.
+   */
+  .form :global(.field) {
     display: flex;
     flex-direction: column;
     gap: 0.3rem;
     margin-bottom: 0.75rem;
   }
 
-  .field span {
+  .form :global(.field span) {
     font-size: 0.8rem;
     color: var(--text-muted);
     font-weight: 500;
   }
 
-  .checkbox-field {
+  .form :global(.checkbox-field) {
     flex-direction: row;
     align-items: center;
     gap: 0.5rem;
   }
 
-  .checkbox-field input[type="checkbox"] {
+  .form :global(.checkbox-field input[type='checkbox']) {
     accent-color: var(--accent);
   }
 
-  input[type="text"],
-  input[type="url"],
-  textarea {
+  .form :global(input[type='text']),
+  .form :global(input[type='url']),
+  .form :global(textarea) {
     background: var(--bg);
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
@@ -935,19 +563,19 @@
     resize: vertical;
   }
 
-  input[type="text"]:focus,
-  input[type="url"]:focus,
-  textarea:focus {
+  .form :global(input[type='text']:focus),
+  .form :global(input[type='url']:focus),
+  .form :global(textarea:focus) {
     outline: none;
     border-color: var(--accent);
   }
 
-  input[type="file"] {
+  .form :global(input[type='file']) {
     font-size: 0.85rem;
     color: var(--text-muted);
   }
 
-  .auto-expand {
+  .form :global(.auto-expand) {
     resize: vertical;
     min-height: 4.5em;
     max-height: 50vh;
@@ -955,14 +583,14 @@
     field-sizing: content;
   }
 
-  .code-input {
+  .form :global(.code-input) {
     font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
     font-size: 0.8rem;
     line-height: 1.5;
     tab-size: 2;
   }
 
-  .editor-loading {
+  .form :global(.editor-loading) {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -974,7 +602,7 @@
     font-size: 0.85rem;
   }
 
-  .preview-wrap {
+  .form :global(.preview-wrap) {
     flex: 1;
     background: var(--bg);
     border: 1px solid var(--border);
@@ -984,10 +612,244 @@
     min-height: 0;
   }
 
-  .preview-empty {
+  .form :global(.preview-empty) {
     color: var(--text-muted);
     font-style: italic;
     font-size: 0.85rem;
+  }
+
+  .form :global(.info-note) {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.5rem 0.75rem;
+    margin: 0 0 0.75rem;
+    line-height: 1.5;
+  }
+
+  .form :global(.error) {
+    color: #ef4444;
+    font-size: 0.8rem;
+    margin: 0;
+  }
+
+  .form :global(.recorder) {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+  }
+
+  .form :global(.recorder audio) {
+    flex: 1;
+    height: 36px;
+  }
+
+  .form :global(.rec-indicator) {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #ef4444;
+    animation: pulse 1s ease-in-out infinite;
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.3;
+    }
+  }
+
+  .form :global(.rec-timer) {
+    font-size: 1rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: var(--text);
+  }
+
+  .form :global(.rec-btn) {
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 0.35rem 0.75rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: border-color 0.15s;
+  }
+
+  .form :global(.rec-btn:hover) {
+    border-color: var(--accent);
+  }
+
+  .form :global(.rec-start) {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  .form :global(.rec-stop) {
+    border-color: #ef4444;
+    color: #ef4444;
+  }
+
+  .form :global(.rec-discard) {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .form :global(.transcript-status) {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin: 0;
+    font-style: italic;
+  }
+
+  .form :global(.transcript) {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.5rem 0.75rem;
+    white-space: pre-wrap;
+    margin: 0;
+  }
+
+  .form :global(.field-header) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .form :global(.editor-tabs) {
+    display: flex;
+    gap: 0.25rem;
+  }
+
+  .form :global(.tab) {
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    padding: 0.15rem 0.5rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.7rem;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+  }
+
+  .form :global(.tab:hover) {
+    color: var(--text);
+    border-color: var(--text-muted);
+  }
+
+  .form :global(.tab.active) {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+
+  .form :global(.note-editor-field) {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .form :global(.markdown-body) {
+    font-size: 0.9rem;
+    color: var(--text);
+    line-height: 1.6;
+    word-break: break-word;
+  }
+
+  .form :global(.markdown-body h1) {
+    font-size: 1.3rem;
+    font-weight: 600;
+    margin: 0.75rem 0 0.4rem;
+  }
+  .form :global(.markdown-body h2) {
+    font-size: 1.15rem;
+    font-weight: 600;
+    margin: 0.6rem 0 0.35rem;
+  }
+  .form :global(.markdown-body h3) {
+    font-size: 1.05rem;
+    font-weight: 600;
+    margin: 0.5rem 0 0.3rem;
+  }
+  .form :global(.markdown-body p) {
+    margin: 0 0 0.5rem;
+  }
+  .form :global(.markdown-body p:last-child) {
+    margin-bottom: 0;
+  }
+  .form :global(.markdown-body ul),
+  .form :global(.markdown-body ol) {
+    padding-left: 1.5rem;
+    margin: 0 0 0.5rem;
+  }
+  .form :global(.markdown-body ul) {
+    list-style: disc;
+  }
+  .form :global(.markdown-body ol) {
+    list-style: decimal;
+  }
+  .form :global(.markdown-body li) {
+    margin-bottom: 0.15rem;
+  }
+  .form :global(.markdown-body blockquote) {
+    border-left: 3px solid var(--accent);
+    padding-left: 0.75rem;
+    margin: 0 0 0.5rem;
+    color: var(--text-muted);
+  }
+  .form :global(.markdown-body a) {
+    color: var(--accent);
+    text-decoration: none;
+  }
+  .form :global(.markdown-body a:hover) {
+    text-decoration: underline;
+  }
+  .form :global(.markdown-body code) {
+    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+    background: rgba(255, 255, 255, 0.06);
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+    font-size: 0.82rem;
+  }
+  .form :global(.markdown-body pre) {
+    background: #0d1117;
+    border-radius: var(--radius-sm);
+    padding: 0.75rem;
+    margin: 0 0 0.5rem;
+    overflow-x: auto;
+  }
+  .form :global(.markdown-body pre code) {
+    background: none;
+    padding: 0;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: #e6edf3;
+  }
+  .form :global(.markdown-body hr) {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 0.75rem 0;
+  }
+  .form :global(.markdown-body strong) {
+    font-weight: 600;
+  }
+  .form :global(.markdown-body em) {
+    font-style: italic;
   }
 
   .actions {
@@ -1018,31 +880,6 @@
   }
 
   .btn-delete-item:disabled {
-    opacity: 0.4;
-    cursor: default;
-  }
-
-  .btn-todo {
-    margin-right: auto;
-    background: none;
-    border: 1px solid var(--border);
-    color: var(--text-muted);
-    padding: 0.45rem 0.75rem;
-    border-radius: var(--radius-sm);
-    font-size: 0.8rem;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
-    transition: color 0.15s, border-color 0.15s;
-  }
-
-  .btn-todo:hover {
-    color: var(--accent);
-    border-color: var(--accent);
-  }
-
-  .btn-todo:disabled {
     opacity: 0.4;
     cursor: default;
   }
@@ -1080,17 +917,6 @@
   .btn-save:disabled {
     opacity: 0.4;
     cursor: default;
-  }
-
-  .info-note {
-    font-size: 0.8rem;
-    color: var(--text-muted);
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    padding: 0.5rem 0.75rem;
-    margin: 0 0 0.75rem;
-    line-height: 1.5;
   }
 
   .dest-wrapper {
@@ -1210,188 +1036,4 @@
   .dest-dot.inbox {
     background: var(--accent);
   }
-
-  .error {
-    color: #ef4444;
-    font-size: 0.8rem;
-    margin: 0;
-  }
-
-  .recorder {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.75rem;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-  }
-
-  .recorder audio {
-    flex: 1;
-    height: 36px;
-  }
-
-  .rec-indicator {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background: #ef4444;
-    animation: pulse 1s ease-in-out infinite;
-  }
-
-  @keyframes pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.3; }
-  }
-
-  .rec-timer {
-    font-size: 1rem;
-    font-weight: 600;
-    font-variant-numeric: tabular-nums;
-    color: var(--text);
-  }
-
-  .rec-btn {
-    background: none;
-    border: 1px solid var(--border);
-    color: var(--text);
-    padding: 0.35rem 0.75rem;
-    border-radius: var(--radius-sm);
-    font-size: 0.8rem;
-    cursor: pointer;
-    transition: border-color 0.15s;
-  }
-
-  .rec-btn:hover {
-    border-color: var(--accent);
-  }
-
-  .rec-start {
-    border-color: var(--accent);
-    color: var(--accent);
-  }
-
-  .rec-stop {
-    border-color: #ef4444;
-    color: #ef4444;
-  }
-
-  .rec-discard {
-    font-size: 0.75rem;
-    color: var(--text-muted);
-    flex-shrink: 0;
-  }
-
-  .transcript-status {
-    font-size: 0.8rem;
-    color: var(--text-muted);
-    margin: 0;
-    font-style: italic;
-  }
-
-  .transcript {
-    font-size: 0.85rem;
-    color: var(--text-muted);
-    line-height: 1.5;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    padding: 0.5rem 0.75rem;
-    white-space: pre-wrap;
-    margin: 0;
-  }
-
-  .field-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .editor-tabs {
-    display: flex;
-    gap: 0.25rem;
-  }
-
-  .tab {
-    background: none;
-    border: 1px solid var(--border);
-    color: var(--text-muted);
-    padding: 0.15rem 0.5rem;
-    border-radius: var(--radius-sm);
-    font-size: 0.7rem;
-    cursor: pointer;
-    transition: color 0.15s, border-color 0.15s;
-  }
-
-  .tab:hover {
-    color: var(--text);
-    border-color: var(--text-muted);
-  }
-
-  .tab.active {
-    color: var(--accent);
-    border-color: var(--accent);
-  }
-
-  .note-editor-field {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-  }
-
-  .markdown-body {
-    font-size: 0.9rem;
-    color: var(--text);
-    line-height: 1.6;
-    word-break: break-word;
-  }
-
-  .markdown-body :global(h1) { font-size: 1.3rem; font-weight: 600; margin: 0.75rem 0 0.4rem; }
-  .markdown-body :global(h2) { font-size: 1.15rem; font-weight: 600; margin: 0.6rem 0 0.35rem; }
-  .markdown-body :global(h3) { font-size: 1.05rem; font-weight: 600; margin: 0.5rem 0 0.3rem; }
-  .markdown-body :global(p) { margin: 0 0 0.5rem; }
-  .markdown-body :global(p:last-child) { margin-bottom: 0; }
-  .markdown-body :global(ul),
-  .markdown-body :global(ol) { padding-left: 1.5rem; margin: 0 0 0.5rem; }
-  .markdown-body :global(ul) { list-style: disc; }
-  .markdown-body :global(ol) { list-style: decimal; }
-  .markdown-body :global(li) { margin-bottom: 0.15rem; }
-  .markdown-body :global(blockquote) {
-    border-left: 3px solid var(--accent);
-    padding-left: 0.75rem;
-    margin: 0 0 0.5rem;
-    color: var(--text-muted);
-  }
-  .markdown-body :global(a) { color: var(--accent); text-decoration: none; }
-  .markdown-body :global(a:hover) { text-decoration: underline; }
-  .markdown-body :global(code) {
-    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
-    background: rgba(255, 255, 255, 0.06);
-    padding: 0.1rem 0.3rem;
-    border-radius: 3px;
-    font-size: 0.82rem;
-  }
-  .markdown-body :global(pre) {
-    background: #0d1117;
-    border-radius: var(--radius-sm);
-    padding: 0.75rem;
-    margin: 0 0 0.5rem;
-    overflow-x: auto;
-  }
-  .markdown-body :global(pre code) {
-    background: none;
-    padding: 0;
-    font-size: 0.8rem;
-    line-height: 1.5;
-    color: #e6edf3;
-  }
-  .markdown-body :global(hr) {
-    border: none;
-    border-top: 1px solid var(--border);
-    margin: 0.75rem 0;
-  }
-  .markdown-body :global(strong) { font-weight: 600; }
-  .markdown-body :global(em) { font-style: italic; }
 </style>

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -1,24 +1,37 @@
 <script lang="ts">
-  import { untrack, onDestroy } from 'svelte';
+  import { onDestroy } from 'svelte';
   import type { InboxItem } from '@inbox-rs/rs-module';
-  import { deleteItem, storeItem, blobUrls, connected, sortedGroups, groupCollections, moveItemToCollection, loadFileBlobUrl } from '../lib/stores';
-  import rs from '../lib/rs';
-  import { transcribeAudio } from '../lib/transcribe';
+  import {
+    deleteItem,
+    storeItem,
+    sortedGroups,
+    groupCollections,
+    moveItemToCollection,
+  } from '../lib/stores';
   import ShareButton from './ShareButton.svelte';
-  import Lightbox from './Lightbox.svelte';
   import DeleteConfirm from './DeleteConfirm.svelte';
-  import 'highlight.js/styles/github-dark.min.css';
-  import { renderMarkdown } from '../lib/markdown';
+  import BookmarkView from './view-card/BookmarkView.svelte';
+  import NoteView from './view-card/NoteView.svelte';
+  import ImageView from './view-card/ImageView.svelte';
+  import AudioView from './view-card/AudioView.svelte';
+  import DocumentView from './view-card/DocumentView.svelte';
+  import EmailView from './view-card/EmailView.svelte';
+  import TodoView from './view-card/TodoView.svelte';
 
-  let { item, onclose, onedit }: {
+  let {
+    item,
+    onclose,
+    onedit,
+  }: {
     item: InboxItem;
     onclose: () => void;
     onedit: (item: InboxItem) => void;
   } = $props();
 
+  const TITLE_ID = 'view-modal-title';
+
   let showDelete = $state(false);
   let deleting = $state(false);
-  let showLightbox = $state(false);
   let showMoveMenu = $state(false);
   let moveButtonEl = $state<HTMLButtonElement | null>(null);
   let dropdownStyle = $state('');
@@ -30,99 +43,16 @@
   let makeTodoButtonEl = $state<HTMLButtonElement | null>(null);
   let makeTodoDropdownStyle = $state('');
 
-  // Audio playback
-  const audioSrc = $derived(
-    item.type === 'audio'
-      ? ($blobUrls[item.filePath] || null)
-      : null
-  );
-
-  // Audio state
-  let audioError = $state(false);
-  let transcribing = $state(false);
-  let transcriptionError = $state(false);
-
-  // Markdown rendering for notes
-  let renderedBody = $state('');
-
-  // Document download
-  let docBlobUrl = $state<string | null>(null);
-  let docLoading = $state(false);
-
-  $effect(() => {
-    // Track only item to trigger reloads when it changes
-    const currentItem = item;
-
-    // Reset per-item state
-    audioError = false;
-    transcribing = false;
-    transcriptionError = false;
-    renderedBody = '';
-    showLightbox = false;
-    untrack(() => { if (docBlobUrl) URL.revokeObjectURL(docBlobUrl); });
-    docBlobUrl = null;
-    docLoading = false;
-
-    if (currentItem.type === 'note' && currentItem.body) {
-      renderMarkdown(currentItem.body).then((html) => {
-        if (item.id === currentItem.id) renderedBody = html;
-      });
-    }
-  });
+  let convertingTodo = $state(false);
+  // Surface conversion failures inline. Both Make-Todo paths share this so
+  // either flow can announce its error in the same dropdown.
+  let convertError = $state('');
+  let convertingRef = $state(false);
 
   onDestroy(() => {
-    if (docBlobUrl) URL.revokeObjectURL(docBlobUrl);
     removeMoveMenuListeners();
     removeMakeTodoMenuListeners();
   });
-
-  async function handleTranscribe() {
-    if (item.type !== 'audio') return;
-    const target = item; // snapshot to guard against item changing mid-transcription
-    transcribing = true;
-    transcriptionError = false;
-    try {
-      const file = await rs.inbox.getFile(target.filePath);
-      if (!file?.data) throw new Error('Could not load audio file');
-      const blob = new Blob([file.data], { type: target.mimeType });
-      const text = await transcribeAudio(blob);
-      const updated = {
-        ...target,
-        body: text || undefined,
-        title: text && target.title === 'Audio' ? text.slice(0, 50) : target.title,
-        transcribed: true,
-      };
-      await storeItem(updated);
-    } catch (e) {
-      console.warn('Transcription failed:', e);
-      if (item.id === target.id) transcriptionError = true;
-    } finally {
-      if (item.id === target.id) transcribing = false;
-    }
-  }
-
-  async function downloadDoc() {
-    if (item.type !== 'document') return;
-    if (docBlobUrl) { openDownload(docBlobUrl); return; }
-    docLoading = true;
-    try {
-      const file = await rs.inbox.getFile(item.filePath);
-      if (file?.data) {
-        docBlobUrl = URL.createObjectURL(new Blob([file.data], { type: item.mimeType }));
-        openDownload(docBlobUrl);
-      }
-    } finally {
-      docLoading = false;
-    }
-  }
-
-  function openDownload(url: string) {
-    if (item.type !== 'document') return;
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = item.fileName || item.title;
-    a.click();
-  }
 
   async function handleDelete() {
     deleting = true;
@@ -131,11 +61,6 @@
     deleting = false;
     onclose();
   }
-
-  let convertingTodo = $state(false);
-  // Surface conversion failures inline. Both Make-Todo paths share this so
-  // either flow can announce its error in the same dropdown.
-  let convertError = $state('');
 
   /** Promote the current item to an unfiled todo. */
   async function convertToUnfiledTodo() {
@@ -158,7 +83,8 @@
       onclose();
     } catch (error) {
       console.error('Failed to convert to unfiled todo', error);
-      convertError = error instanceof Error ? error.message : 'Failed to convert to todo';
+      convertError =
+        error instanceof Error ? error.message : 'Failed to convert to todo';
     } finally {
       convertingTodo = false;
     }
@@ -184,15 +110,43 @@
       await moveItemToCollection(item.id, collectionId);
       // Now flip the todo flags. storeItem only touches the item doc — the
       // itemIds arrays are already reconciled by the move above.
-      const updated = { ...rest, isTodo: true, completed: false, collectionId };
+      const updated = {
+        ...rest,
+        isTodo: true,
+        completed: false,
+        collectionId,
+      };
       await storeItem(updated as InboxItem);
       closeMakeTodoMenu();
       onclose();
     } catch (error) {
       console.error('Failed to convert to todo', error);
-      convertError = error instanceof Error ? error.message : 'Failed to convert to todo';
+      convertError =
+        error instanceof Error ? error.message : 'Failed to convert to todo';
     } finally {
       convertingTodo = false;
+    }
+  }
+
+  async function convertToReference() {
+    convertingRef = true;
+    try {
+      // Cast to Record<string,unknown> for the structural rewrite below —
+      // we're deleting and re-typing fields, which the discriminated InboxItem
+      // union actively prevents at the type level.
+      const updated: Record<string, unknown> = { ...item };
+      delete updated.isTodo;
+      delete updated.completed;
+      delete updated.completedAt;
+      // type: 'todo' items require `completed` in the schema — convert to note
+      if (updated.type === 'todo') {
+        updated.type = 'note';
+        if (!updated.body) updated.body = '';
+      }
+      await storeItem(updated as unknown as InboxItem);
+      onclose();
+    } finally {
+      convertingRef = false;
     }
   }
 
@@ -255,7 +209,8 @@
 
   function handleMakeTodoMenuScroll(event: Event) {
     const target = event.target;
-    if (target instanceof Element && target.closest('.make-todo-dropdown')) return;
+    if (target instanceof Element && target.closest('.make-todo-dropdown'))
+      return;
     closeMakeTodoMenu();
   }
 
@@ -285,14 +240,20 @@
 
     const openUpward = spaceAbove > spaceBelow;
     const available = openUpward ? spaceAbove : spaceBelow;
-    const maxHeight = Math.max(0, Math.min(available - viewportPadding, dropdownMaxHeight));
+    const maxHeight = Math.max(
+      0,
+      Math.min(available - viewportPadding, dropdownMaxHeight),
+    );
 
     const dropdownWidth = Math.min(280, window.innerWidth - viewportPadding * 2);
     // Anchor to the right edge of the button so the picker doesn't drift off
     // the right side of the modal on tight layouts — Make Todo lives on the
     // right side of the header.
     const right = window.innerWidth - rect.right;
-    const clampedRight = Math.max(viewportPadding, Math.min(right, window.innerWidth - dropdownWidth - viewportPadding));
+    const clampedRight = Math.max(
+      viewportPadding,
+      Math.min(right, window.innerWidth - dropdownWidth - viewportPadding),
+    );
 
     if (openUpward) {
       makeTodoDropdownStyle = `bottom: ${window.innerHeight - rect.top + gap}px; right: ${clampedRight}px; max-height: ${maxHeight}px;`;
@@ -312,11 +273,17 @@
 
     const openUpward = spaceAbove > spaceBelow;
     const available = openUpward ? spaceAbove : spaceBelow;
-    const maxHeight = Math.max(0, Math.min(available - viewportPadding, dropdownMaxHeight));
+    const maxHeight = Math.max(
+      0,
+      Math.min(available - viewportPadding, dropdownMaxHeight),
+    );
 
     // Clamp horizontal position using max possible rendered width
     const dropdownWidth = Math.min(280, window.innerWidth - viewportPadding * 2);
-    const left = Math.max(viewportPadding, Math.min(rect.left, window.innerWidth - dropdownWidth - viewportPadding));
+    const left = Math.max(
+      viewportPadding,
+      Math.min(rect.left, window.innerWidth - dropdownWidth - viewportPadding),
+    );
 
     if (openUpward) {
       dropdownStyle = `bottom: ${window.innerHeight - rect.top + gap}px; left: ${left}px; max-height: ${maxHeight}px;`;
@@ -325,89 +292,25 @@
     }
   }
 
-  let convertingRef = $state(false);
-
-  async function convertToReference() {
-    convertingRef = true;
-    try {
-      // Cast to Record<string,unknown> for the structural rewrite below —
-      // we're deleting and re-typing fields, which the discriminated InboxItem
-      // union actively prevents at the type level.
-      const updated: Record<string, unknown> = { ...item };
-      delete updated.isTodo;
-      delete updated.completed;
-      delete updated.completedAt;
-      // type: 'todo' items require `completed` in the schema — convert to note
-      if (updated.type === 'todo') {
-        updated.type = 'note';
-        if (!updated.body) updated.body = '';
-      }
-      await storeItem(updated as unknown as InboxItem);
-      onclose();
-    } finally {
-      convertingRef = false;
-    }
-  }
-
   function formatDate(iso: string): string {
     const d = new Date(iso);
-    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' });
+    return d.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
   }
 
-  function formatSize(bytes?: number): string {
-    if (!bytes) return '';
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  }
-
-  function formatDuration(seconds?: number): string {
-    if (!seconds) return '';
-    const m = Math.floor(seconds / 60);
-    const s = Math.floor(seconds % 60);
-    return `${m}:${s.toString().padStart(2, '0')}`;
-  }
-
-  function getDomain(url: string): string {
-    try { return new URL(url).hostname.replace(/^www\./, ''); }
-    catch { return url; }
-  }
-
-  // Notes and body helpers. We've already type-narrowed via `'notes' in item`
-  // / `'body' in item` / `'filePath' in item`, but biome's narrowing for
-  // discriminated unions doesn't always carry through across `in` checks —
-  // pull the field through a Record cast so callers stay strict.
-  const notes = $derived(
-    'notes' in item ? (item as Record<string, unknown>).notes : undefined,
-  );
-  const body = $derived(
-    'body' in item ? (item as Record<string, unknown>).body : undefined,
-  );
+  // The discriminated union narrows nicely on `item.type === 'X'`, but a few
+  // shared trailing sections (notes/description/share) want to peek at
+  // optional fields without forcing the per-type branches. Use a Record cast
+  // for those structural reads.
   const description = $derived(item.description);
-
   const hasFile = $derived(
     'filePath' in item && !!(item as Record<string, unknown>).filePath,
   );
-
-  const imageSrc = $derived(
-    item.type === 'bookmark'
-      ? ((item.filePath ? ($blobUrls[item.filePath] || null) : null) || item.ogImage || null)
-      : item.type === 'image'
-        ? ($blobUrls[item.filePath] || null)
-        : null
-  );
-
-  // Fetch file-backed items via Authorization header (works on all RS servers).
-  // Forward mimeType so the blob is tagged with the clean type from item
-  // metadata rather than the server's Content-Type (5apps preserves the
-  // `; charset=binary` suffix that wireclient adds on upload, and Chrome won't
-  // render an <img>/<audio> whose Blob type carries that suffix).
-  $effect(() => {
-    if (!$connected) return;
-    if (item.type === 'image' && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
-    if (item.type === 'audio' && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
-    if (item.type === 'bookmark' && 'filePath' in item && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
-  });
 
   /**
    * Window-level Escape handler. Defers to nested overlays when any are open
@@ -427,7 +330,7 @@
    */
   function handleWindowEscape(e: KeyboardEvent) {
     if (e.key !== 'Escape') return;
-    if (showDelete || showLightbox || showMoveMenu || showMakeTodoMenu) return;
+    if (showDelete || showMoveMenu || showMakeTodoMenu) return;
     onclose();
   }
 </script>
@@ -437,12 +340,19 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="overlay" onclick={onclose}>
-  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="view-modal-title" onclick={(e) => e.stopPropagation()}>
+  <div
+    class="modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby={TITLE_ID}
+    onclick={(e) => e.stopPropagation()}
+  >
     <div class="modal-header">
       <span class="type-badge">{item.type}</span>
       <time class="date">{formatDate(item.createdAt)}</time>
       {#if canMakeTodo}
-        <button type="button"
+        <button
+          type="button"
           class="btn-todo btn-todo-top"
           class:open={showMakeTodoMenu}
           bind:this={makeTodoButtonEl}
@@ -451,127 +361,100 @@
           aria-haspopup="listbox"
           aria-expanded={showMakeTodoMenu}
         >
-          <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg
+            aria-hidden="true"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
             <polyline points="9 11 12 14 22 4"></polyline>
-            <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path>
+            <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"
+            ></path>
           </svg>
           Make Todo
-          <svg aria-hidden="true" class="caret" class:open={showMakeTodoMenu} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <svg
+            aria-hidden="true"
+            class="caret"
+            class:open={showMakeTodoMenu}
+            width="10"
+            height="10"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
             <polyline points="6 9 12 15 18 9"></polyline>
           </svg>
         </button>
       {/if}
       {#if canMakeRef}
-        <button type="button" class="btn-todo btn-todo-top" disabled={convertingRef} onclick={convertToReference}>
-          <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <button
+          type="button"
+          class="btn-todo btn-todo-top"
+          disabled={convertingRef}
+          onclick={convertToReference}
+        >
+          <svg
+            aria-hidden="true"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
             <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path>
-            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path>
+            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"
+            ></path>
           </svg>
           Make Reference
         </button>
       {/if}
     </div>
 
-    <h2 class="title" id="view-modal-title">
+    <!--
+      Per-type body. Each child renders the title (with type-specific link
+      icon for bookmark/email) plus its own meta and main content. Wrapping
+      in `{#key item.id}` resets per-type local state (audio transcribe
+      flags, document blob URL caches, image lightbox state, etc.) when the
+      user navigates between cards without forcing every child to write its
+      own reset effect.
+    -->
+    {#key item.id}
       {#if item.type === 'bookmark'}
-        <a href={item.url} target="_blank" rel="noopener noreferrer">{item.title}<svg aria-hidden="true" class="link-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg></a>
-      {:else if item.type === 'email' && 'messageUrl' in item && item.messageUrl}
-        <a href={item.messageUrl}>{item.title}<svg aria-hidden="true" class="link-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg></a>
+        <BookmarkView {item} titleId={TITLE_ID} />
+      {:else if item.type === 'note'}
+        <NoteView {item} titleId={TITLE_ID} />
+      {:else if item.type === 'image'}
+        <ImageView {item} titleId={TITLE_ID} />
+      {:else if item.type === 'audio'}
+        <AudioView {item} titleId={TITLE_ID} />
+      {:else if item.type === 'document'}
+        <DocumentView {item} titleId={TITLE_ID} />
+      {:else if item.type === 'email'}
+        <EmailView {item} titleId={TITLE_ID} />
+      {:else if item.type === 'todo'}
+        <TodoView {item} titleId={TITLE_ID} />
       {:else}
-        {item.title}
+        <!--
+          Generic fallback for item types without a dedicated view (e.g.
+          `video`, which the rs-module schema reserves but the web UI
+          doesn't yet render). Renders the title only so the modal still
+          presents something legible — and so `aria-labelledby` always
+          resolves to a real heading.
+        -->
+        <h2 class="title" id={TITLE_ID}>{item.title}</h2>
       {/if}
-    </h2>
-
-    {#if item.type === 'bookmark'}
-      <div class="meta-row">
-        {#if item.favicon}
-          <img class="favicon" src={item.favicon} alt="" width="16" height="16"
-            onerror={(e) => (e.currentTarget as HTMLImageElement).style.display = 'none'} />
-        {/if}
-        <span class="domain">{item.siteName || getDomain(item.url)}</span>
-      </div>
-    {/if}
-
-    {#if item.type === 'email' && 'from' in item && item.from}
-      <p class="meta-text">From: {item.from}</p>
-    {/if}
-
-    {#if imageSrc}
-      <!-- svelte-ignore a11y_click_events_have_key_events -->
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div class="view-image-link" onclick={() => showLightbox = true}>
-        <img class="view-image" src={imageSrc} alt=""
-          onerror={(e) => (e.currentTarget as HTMLImageElement).style.display = 'none'} />
-      </div>
-    {/if}
-    {#if showLightbox && imageSrc}
-      <Lightbox
-        src={imageSrc}
-        alt={item.title}
-        onclose={() => showLightbox = false}
-        filePath={'filePath' in item ? (item as Record<string, unknown>).filePath as string | undefined : undefined}
-        mimeType={'mimeType' in item ? (item as Record<string, unknown>).mimeType as string | undefined : undefined}
-        filename={item.title || undefined}
-      />
-    {/if}
-
-    {#if item.type === 'audio'}
-      <div class="player">
-        {#if audioError}
-          <p class="status-text">Failed to load audio</p>
-        {:else if audioSrc}
-          <audio controls src={audioSrc} preload="metadata"
-            onerror={() => audioError = true}>
-            <!-- See AudioCard.svelte for why an empty captions track is OK here. -->
-            <track kind="captions" />
-          </audio>
-        {:else}
-          <p class="status-text">Connect to load audio</p>
-        {/if}
-        {#if item.duration}
-          <span class="duration">{formatDuration(item.duration)}</span>
-        {/if}
-        {#if transcribing}
-          <p class="status-text">Transcribing...</p>
-        {:else if transcriptionError}
-          <p class="status-text">Transcription failed</p>
-          <button type="button" class="btn-action" onclick={handleTranscribe}>Retry</button>
-        {:else if audioSrc && !item.transcribed && !item.body}
-          <button type="button" class="btn-action" onclick={handleTranscribe}>Transcribe</button>
-        {/if}
-      </div>
-    {/if}
-
-    {#if item.type === 'document'}
-      {#if item.fileName}
-        <p class="meta-text">{item.fileName}</p>
-      {/if}
-      {#if item.fileSize}
-        <span class="meta-text">{formatSize(item.fileSize)}</span>
-      {/if}
-      <button type="button" class="btn-action" onclick={(e) => { e.stopPropagation(); downloadDoc(); }} disabled={docLoading}>
-        {docLoading ? 'Loading...' : 'Download'}
-      </button>
-    {/if}
-
-    <!-- Notes prioritized over body -->
-    {#if notes}
-      <div class="content-block notes-block">
-        <span class="content-label">Notes</span>
-        <p class="content-text">{notes}</p>
-      </div>
-    {/if}
-
-    {#if body}
-      <div class="content-block">
-        <span class="content-label">{item.type === 'audio' ? 'Transcription' : 'Body'}</span>
-        {#if item.type === 'note' && renderedBody}
-          <div class="markdown-body">{@html renderedBody}</div>
-        {:else}
-          <p class="content-text">{body}</p>
-        {/if}
-      </div>
-    {/if}
+    {/key}
 
     {#if description}
       <div class="content-block">
@@ -582,21 +465,54 @@
 
     {#if hasFile}
       <div class="share-row">
-        <ShareButton filePath={(item as Record<string, unknown>).filePath as string} mimeType={(item as Record<string, unknown>).mimeType as string | undefined} filename={item.title || undefined} />
+        <ShareButton
+          filePath={(item as Record<string, unknown>).filePath as string}
+          mimeType={(item as Record<string, unknown>).mimeType as
+            | string
+            | undefined}
+          filename={item.title || undefined}
+        />
       </div>
     {/if}
 
     <div class="actions">
-      <button type="button" class="btn-delete" onclick={() => showDelete = true}>
-        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <button type="button" class="btn-delete" onclick={() => (showDelete = true)}>
+        <svg
+          aria-hidden="true"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
           <polyline points="3 6 5 6 21 6"></polyline>
-          <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+          <path
+            d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
+          ></path>
         </svg>
         Delete
       </button>
       <div class="move-container">
-        <button type="button" class="btn-move" bind:this={moveButtonEl} onclick={toggleMoveMenu}>
-          <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <button
+          type="button"
+          class="btn-move"
+          bind:this={moveButtonEl}
+          onclick={toggleMoveMenu}
+        >
+          <svg
+            aria-hidden="true"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
             <rect x="3" y="3" width="7" height="7"></rect>
             <rect x="14" y="3" width="7" height="7"></rect>
             <rect x="3" y="14" width="7" height="7"></rect>
@@ -612,7 +528,7 @@
     {#if showDelete}
       <DeleteConfirm
         onConfirm={handleDelete}
-        onCancel={() => showDelete = false}
+        onCancel={() => (showDelete = false)}
         {deleting}
       />
     {/if}
@@ -625,12 +541,24 @@
         aria-label="Close make todo menu"
         onclick={() => closeMakeTodoMenu()}
       ></button>
-      <div class="move-dropdown make-todo-dropdown" style={makeTodoDropdownStyle} role="listbox" aria-label="Choose a collection for this todo">
+      <div
+        class="move-dropdown make-todo-dropdown"
+        style={makeTodoDropdownStyle}
+        role="listbox"
+        aria-label="Choose a collection for this todo"
+      >
         <div class="picker-title">File todo</div>
         {#if convertError}
-          <p class="move-error" role="status" aria-live="polite">{convertError}</p>
+          <p class="move-error" role="status" aria-live="polite">
+            {convertError}
+          </p>
         {/if}
-        <button type="button" class="move-option" onclick={convertToUnfiledTodo} disabled={convertingTodo}>
+        <button
+          type="button"
+          class="move-option"
+          onclick={convertToUnfiledTodo}
+          disabled={convertingTodo}
+        >
           <span class="move-dot" style="background: #9ca3af"></span>
           Unfiled
         </button>
@@ -638,10 +566,21 @@
           <div class="move-divider"></div>
         {/if}
         {#each $sortedGroups as group (group.id)}
-          {#each ($groupCollections[group.id] ?? []) as col (col.id)}
-            <button type="button" class="move-option" onclick={() => convertToTodoInCollection(col.id)} disabled={convertingTodo}>
-              <span class="move-dot" style="background: {col.color || '#6366f1'}"></span>
-              <span class="move-group-prefix" style="color: {group.color || 'var(--accent)'}">{group.name}</span> : {col.name}
+          {#each $groupCollections[group.id] ?? [] as col (col.id)}
+            <button
+              type="button"
+              class="move-option"
+              onclick={() => convertToTodoInCollection(col.id)}
+              disabled={convertingTodo}
+            >
+              <span
+                class="move-dot"
+                style="background: {col.color || '#6366f1'}"
+              ></span>
+              <span
+                class="move-group-prefix"
+                style="color: {group.color || 'var(--accent)'}">{group.name}</span
+              > : {col.name}
             </button>
           {/each}
         {/each}
@@ -658,18 +597,45 @@
       ></button>
       <div class="move-dropdown" style={dropdownStyle}>
         {#if item.collectionId}
-          <button type="button" class="move-option" onclick={() => { moveItemToCollection(item.id, undefined).catch(e => console.error('Move failed:', e)); closeMoveMenu(); onclose(); }}>
+          <button
+            type="button"
+            class="move-option"
+            onclick={() => {
+              moveItemToCollection(item.id, undefined).catch((e) =>
+                console.error('Move failed:', e),
+              );
+              closeMoveMenu();
+              onclose();
+            }}
+          >
             <span class="move-dot" style="background: #9ca3af"></span>
             {item.isTodo || item.type === 'todo' ? 'Unfile' : 'Inbox'}
           </button>
           <div class="move-divider"></div>
         {/if}
         {#each $sortedGroups as group (group.id)}
-          {#each ($groupCollections[group.id] ?? []) as col (col.id)}
+          {#each $groupCollections[group.id] ?? [] as col (col.id)}
             {#if col.id !== item.collectionId}
-              <button type="button" class="move-option" onclick={() => { moveItemToCollection(item.id, col.id).catch(e => console.error('Move failed:', e)); closeMoveMenu(); onclose(); }}>
-                <span class="move-dot" style="background: {col.color || '#6366f1'}"></span>
-                <span class="move-group-prefix" style="color: {group.color || 'var(--accent)'}">{group.name}</span> : {col.name}
+              <button
+                type="button"
+                class="move-option"
+                onclick={() => {
+                  moveItemToCollection(item.id, col.id).catch((e) =>
+                    console.error('Move failed:', e),
+                  );
+                  closeMoveMenu();
+                  onclose();
+                }}
+              >
+                <span
+                  class="move-dot"
+                  style="background: {col.color || '#6366f1'}"
+                ></span>
+                <span
+                  class="move-group-prefix"
+                  style="color: {group.color || 'var(--accent)'}"
+                  >{group.name}</span
+                > : {col.name}
               </button>
             {/if}
           {/each}
@@ -706,7 +672,8 @@
 
   @media (max-width: 600px), (display-mode: standalone) {
     .overlay {
-      padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+      padding: env(safe-area-inset-top) env(safe-area-inset-right)
+        env(safe-area-inset-bottom) env(safe-area-inset-left);
       background: var(--bg);
     }
 
@@ -741,62 +708,68 @@
     color: var(--text-muted);
   }
 
-  .title {
+  /*
+   * Per-type view styles. Children render `.title` / `.meta-row` / etc. into
+   * the modal's DOM, but Svelte CSS scoping would otherwise prevent these
+   * rules from matching them. Scoping under `.modal` keeps the leak bounded
+   * to this modal's children.
+   */
+  .modal :global(.title) {
     font-size: 1.15rem;
     font-weight: 600;
     margin-bottom: 0.5rem;
     line-height: 1.3;
   }
 
-  .title a {
+  .modal :global(.title a) {
     color: var(--text);
     transition: color 0.15s;
   }
 
-  .title a:hover {
+  .modal :global(.title a:hover) {
     color: var(--accent);
   }
 
-  .title :global(.link-icon) {
+  .modal :global(.title .link-icon) {
     display: inline;
     vertical-align: middle;
     margin-left: 0.35rem;
     opacity: 0.5;
   }
 
-  .title a:hover :global(.link-icon) {
+  .modal :global(.title a:hover .link-icon) {
     opacity: 1;
   }
 
-  .meta-row {
+  .modal :global(.meta-row) {
     display: flex;
     align-items: center;
     gap: 0.4rem;
     margin-bottom: 0.5rem;
   }
 
-  .favicon {
+  .modal :global(.favicon) {
     border-radius: 2px;
     flex-shrink: 0;
   }
 
-  .domain {
+  .modal :global(.domain) {
     font-size: 0.8rem;
     color: var(--text-muted);
   }
 
-  .meta-text {
+  .modal :global(.meta-text) {
     font-size: 0.85rem;
     color: var(--text-muted);
     margin-bottom: 0.5rem;
   }
 
-  .view-image-link {
+  .modal :global(.view-image-link) {
     cursor: zoom-in;
     margin-bottom: 0.75rem;
   }
 
-  .view-image {
+  .modal :global(.view-image) {
     width: 100%;
     max-height: 300px;
     object-fit: cover;
@@ -804,157 +777,26 @@
     border: 1px solid var(--border);
   }
 
-  .player {
+  .modal :global(.player) {
     margin-bottom: 0.75rem;
   }
 
-  .player audio {
+  .modal :global(.player audio) {
     width: 100%;
     height: 36px;
   }
 
-  .duration {
+  .modal :global(.duration) {
     font-size: 0.8rem;
     color: var(--text-muted);
   }
 
-  .status-text {
+  .modal :global(.status-text) {
     font-size: 0.8rem;
     color: var(--text-muted);
   }
 
-  .content-block {
-    margin-bottom: 0.75rem;
-  }
-
-  .content-label {
-    display: block;
-    font-size: 0.75rem;
-    color: var(--text-muted);
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    margin-bottom: 0.25rem;
-  }
-
-  .content-text {
-    font-size: 0.9rem;
-    color: var(--text);
-    line-height: 1.6;
-    white-space: pre-wrap;
-    word-break: break-word;
-  }
-
-  .markdown-body {
-    font-size: 0.9rem;
-    color: var(--text);
-    line-height: 1.6;
-    word-break: break-word;
-  }
-
-  .markdown-body :global(h1) { font-size: 1.1rem; font-weight: 600; margin: 0.75rem 0 0.4rem; }
-  .markdown-body :global(h2) { font-size: 1rem; font-weight: 600; margin: 0.6rem 0 0.35rem; }
-  .markdown-body :global(h3) { font-size: 0.95rem; font-weight: 600; margin: 0.5rem 0 0.3rem; }
-  .markdown-body :global(h4),
-  .markdown-body :global(h5),
-  .markdown-body :global(h6) { font-size: 0.9rem; font-weight: 600; margin: 0.4rem 0 0.25rem; }
-
-  .markdown-body :global(p) { margin: 0 0 0.5rem; }
-  .markdown-body :global(p:last-child) { margin-bottom: 0; }
-
-  .markdown-body :global(ul),
-  .markdown-body :global(ol) {
-    padding-left: 1.5rem;
-    margin: 0 0 0.5rem;
-  }
-  .markdown-body :global(ul) { list-style: disc; }
-  .markdown-body :global(ol) { list-style: decimal; }
-  .markdown-body :global(li) { margin-bottom: 0.15rem; }
-  .markdown-body :global(li > ul),
-  .markdown-body :global(li > ol) { margin-top: 0.15rem; margin-bottom: 0; }
-
-  .markdown-body :global(blockquote) {
-    border-left: 3px solid var(--accent);
-    padding-left: 0.75rem;
-    margin: 0 0 0.5rem;
-    color: var(--text-muted);
-  }
-
-  .markdown-body :global(a) {
-    color: var(--accent);
-    text-decoration: none;
-  }
-  .markdown-body :global(a:hover) { text-decoration: underline; }
-
-  .markdown-body :global(code) {
-    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
-    background: rgba(255, 255, 255, 0.06);
-    padding: 0.1rem 0.3rem;
-    border-radius: 3px;
-    font-size: 0.82rem;
-  }
-
-  .markdown-body :global(pre) {
-    background: #0d1117;
-    border-radius: var(--radius-sm);
-    padding: 0.75rem;
-    margin: 0 0 0.5rem;
-    overflow-x: auto;
-    max-height: 400px;
-    overflow-y: auto;
-  }
-
-  .markdown-body :global(pre code) {
-    background: none;
-    padding: 0;
-    font-size: 0.8rem;
-    line-height: 1.5;
-    color: #e6edf3;
-  }
-
-  .markdown-body :global(pre .hljs) {
-    background: transparent;
-    padding: 0;
-  }
-
-  .markdown-body :global(hr) {
-    border: none;
-    border-top: 1px solid var(--border);
-    margin: 0.75rem 0;
-  }
-
-  .markdown-body :global(strong) { font-weight: 600; }
-  .markdown-body :global(em) { font-style: italic; }
-
-  .markdown-body :global(table) {
-    border-collapse: collapse;
-    width: 100%;
-    margin: 0 0 0.5rem;
-    font-size: 0.85rem;
-  }
-  .markdown-body :global(th),
-  .markdown-body :global(td) {
-    border: 1px solid var(--border);
-    padding: 0.35rem 0.6rem;
-    text-align: left;
-  }
-  .markdown-body :global(th) {
-    font-weight: 600;
-    background: rgba(255, 255, 255, 0.03);
-  }
-
-  .notes-block .content-text {
-    color: var(--accent);
-    font-style: italic;
-  }
-
-  .share-row {
-    margin-bottom: 0.75rem;
-    padding-top: 0.5rem;
-    border-top: 1px solid var(--border);
-  }
-
-  .btn-action {
+  .modal :global(.btn-action) {
     background: var(--accent-subtle);
     color: var(--accent);
     border: none;
@@ -966,13 +808,180 @@
     margin-bottom: 0.75rem;
   }
 
-  .btn-action:hover {
+  .modal :global(.btn-action:hover) {
     background: var(--accent-subtle-strong);
   }
 
-  .btn-action:disabled {
+  .modal :global(.btn-action:disabled) {
     opacity: 0.5;
     cursor: default;
+  }
+
+  .modal :global(.content-block) {
+    margin-bottom: 0.75rem;
+  }
+
+  .modal :global(.content-label) {
+    display: block;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.25rem;
+  }
+
+  .modal :global(.content-text) {
+    font-size: 0.9rem;
+    color: var(--text);
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .modal :global(.notes-block .content-text) {
+    color: var(--accent);
+    font-style: italic;
+  }
+
+  /* Markdown rendering inside note view. */
+  .modal :global(.markdown-body) {
+    font-size: 0.9rem;
+    color: var(--text);
+    line-height: 1.6;
+    word-break: break-word;
+  }
+
+  .modal :global(.markdown-body h1) {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin: 0.75rem 0 0.4rem;
+  }
+  .modal :global(.markdown-body h2) {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0.6rem 0 0.35rem;
+  }
+  .modal :global(.markdown-body h3) {
+    font-size: 0.95rem;
+    font-weight: 600;
+    margin: 0.5rem 0 0.3rem;
+  }
+  .modal :global(.markdown-body h4),
+  .modal :global(.markdown-body h5),
+  .modal :global(.markdown-body h6) {
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin: 0.4rem 0 0.25rem;
+  }
+
+  .modal :global(.markdown-body p) {
+    margin: 0 0 0.5rem;
+  }
+  .modal :global(.markdown-body p:last-child) {
+    margin-bottom: 0;
+  }
+
+  .modal :global(.markdown-body ul),
+  .modal :global(.markdown-body ol) {
+    padding-left: 1.5rem;
+    margin: 0 0 0.5rem;
+  }
+  .modal :global(.markdown-body ul) {
+    list-style: disc;
+  }
+  .modal :global(.markdown-body ol) {
+    list-style: decimal;
+  }
+  .modal :global(.markdown-body li) {
+    margin-bottom: 0.15rem;
+  }
+  .modal :global(.markdown-body li > ul),
+  .modal :global(.markdown-body li > ol) {
+    margin-top: 0.15rem;
+    margin-bottom: 0;
+  }
+
+  .modal :global(.markdown-body blockquote) {
+    border-left: 3px solid var(--accent);
+    padding-left: 0.75rem;
+    margin: 0 0 0.5rem;
+    color: var(--text-muted);
+  }
+
+  .modal :global(.markdown-body a) {
+    color: var(--accent);
+    text-decoration: none;
+  }
+  .modal :global(.markdown-body a:hover) {
+    text-decoration: underline;
+  }
+
+  .modal :global(.markdown-body code) {
+    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+    background: rgba(255, 255, 255, 0.06);
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+    font-size: 0.82rem;
+  }
+
+  .modal :global(.markdown-body pre) {
+    background: #0d1117;
+    border-radius: var(--radius-sm);
+    padding: 0.75rem;
+    margin: 0 0 0.5rem;
+    overflow-x: auto;
+    max-height: 400px;
+    overflow-y: auto;
+  }
+
+  .modal :global(.markdown-body pre code) {
+    background: none;
+    padding: 0;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: #e6edf3;
+  }
+
+  .modal :global(.markdown-body pre .hljs) {
+    background: transparent;
+    padding: 0;
+  }
+
+  .modal :global(.markdown-body hr) {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 0.75rem 0;
+  }
+
+  .modal :global(.markdown-body strong) {
+    font-weight: 600;
+  }
+  .modal :global(.markdown-body em) {
+    font-style: italic;
+  }
+
+  .modal :global(.markdown-body table) {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0 0 0.5rem;
+    font-size: 0.85rem;
+  }
+  .modal :global(.markdown-body th),
+  .modal :global(.markdown-body td) {
+    border: 1px solid var(--border);
+    padding: 0.35rem 0.6rem;
+    text-align: left;
+  }
+  .modal :global(.markdown-body th) {
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  .share-row {
+    margin-bottom: 0.75rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid var(--border);
   }
 
   .actions {

--- a/packages/web/src/components/add-entry/AudioForm.svelte
+++ b/packages/web/src/components/add-entry/AudioForm.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
-  import type { AudioItem, InboxItem } from '@inbox-rs/rs-module';
+  import type { InboxItem } from '@inbox-rs/rs-module';
   import { autofocus } from '../../lib/actions';
   import {
-    type BuildItemContext,
     type BuildItemFn,
-    type BuildItemResult,
     formatRecordingTimer,
-    getFileExtension,
   } from '../../lib/add-entry-modal';
+  import { buildAudioItem } from '../../lib/build-item';
   import { transcribeAudio } from '../../lib/transcribe';
 
   let {
@@ -130,64 +128,19 @@
     transcribing = false;
   }
 
-  buildItem = async ({
-    id,
-    createdAt,
-  }: BuildItemContext): Promise<BuildItemResult | null> => {
-    if (recordedBlob || file) {
-      const existingPath =
-        isEdit && editItem?.type === 'audio' ? editItem?.filePath : undefined;
-      let filePath: string;
-      let mimeType: string;
-      let duration: number | undefined;
-      let fileData: ArrayBuffer;
-      if (recordedBlob) {
-        const ext = recordedBlob.type.includes('webm')
-          ? '.webm'
-          : recordedBlob.type.includes('mp4')
-            ? '.mp4'
-            : '.ogg';
-        filePath = existingPath || `files/${id}${ext}`;
-        mimeType = recordedBlob.type || 'audio/webm';
-        fileData = await recordedBlob.arrayBuffer();
-        duration = recordingDuration || undefined;
-      } else if (file) {
-        const ext = getFileExtension(file.name);
-        filePath = existingPath || `files/${id}${ext}`;
-        mimeType = file.type;
-        fileData = await file.arrayBuffer();
-      } else {
-        return null;
-      }
-      const memoBody = body || transcript || undefined;
-      const autoTitle = title || transcript || 'Audio';
-      const transcribed =
-        !!(recordedBlob || transcript || body) || undefined;
-      const item: AudioItem = {
-        id,
-        type: 'audio',
-        title: autoTitle,
-        filePath,
-        mimeType,
-        duration,
-        body: memoBody,
-        transcribed,
-        description: description || undefined,
-        createdAt,
-      };
-      return { item, fileData };
-    }
-    if (editItem && editItem.type === 'audio') {
-      const item: AudioItem = {
-        ...editItem,
-        title: title || editItem.title,
-        body: body || undefined,
-        description: description || undefined,
-      };
-      return { item };
-    }
-    return null;
-  };
+  buildItem = ({ id, createdAt, editItem: ctxEditItem }) =>
+    buildAudioItem(
+      { id, createdAt, editItem: ctxEditItem },
+      {
+        title,
+        body,
+        description,
+        file,
+        recordedBlob,
+        recordingDuration,
+        transcript,
+      },
+    );
 
   onDestroy(() => {
     if (mediaRecorder && mediaRecorder.state !== 'inactive') {

--- a/packages/web/src/components/add-entry/AudioForm.svelte
+++ b/packages/web/src/components/add-entry/AudioForm.svelte
@@ -1,0 +1,256 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import type { AudioItem, InboxItem } from '@inbox-rs/rs-module';
+  import { autofocus } from '../../lib/actions';
+  import {
+    type BuildItemContext,
+    type BuildItemFn,
+    type BuildItemResult,
+    formatRecordingTimer,
+    getFileExtension,
+  } from '../../lib/add-entry-modal';
+  import { transcribeAudio } from '../../lib/transcribe';
+
+  let {
+    editItem,
+    canSubmit = $bindable(false),
+    buildItem = $bindable(),
+  }: {
+    editItem?: InboxItem;
+    canSubmit?: boolean;
+    buildItem?: BuildItemFn;
+  } = $props();
+
+  const isEdit = !!editItem;
+  const hasExistingFile = !!(
+    editItem &&
+    'filePath' in editItem &&
+    editItem.filePath
+  );
+
+  let title = $state(editItem?.title ?? '');
+  let body = $state(editItem && 'body' in editItem ? (editItem.body ?? '') : '');
+  let description = $state(editItem?.description ?? '');
+  let file = $state<File | null>(null);
+
+  // Voice recording state — owned entirely by this form so the modal shell
+  // doesn't need to know recording exists.
+  let recording = $state(false);
+  let recordingDuration = $state(0);
+  let recordedBlob = $state<Blob | null>(null);
+  let recordedUrl = $state<string | null>(null);
+  let transcript = $state('');
+  let transcribing = $state(false);
+  // `transcriptionId` increments each time we kick off a transcription so a
+  // late-arriving result from a previous recording can't clobber a fresher
+  // capture's transcript.
+  let transcriptionId = 0;
+  let mediaRecorder: MediaRecorder | null = null;
+  let recordingInterval: ReturnType<typeof setInterval> | null = null;
+
+  $effect(() => {
+    if (recording) {
+      canSubmit = false;
+      return;
+    }
+    canSubmit = !!(file || recordedBlob || hasExistingFile);
+  });
+
+  function handleFileChange(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    file = input.files?.[0] ?? null;
+  }
+
+  async function runTranscription(blob: Blob) {
+    const myId = ++transcriptionId;
+    transcribing = true;
+    try {
+      const result = await transcribeAudio(blob);
+      if (myId !== transcriptionId) return; // discarded
+      transcript = result;
+      if (transcript && !body) body = transcript;
+      if (transcript && !title) title = transcript.slice(0, 50);
+    } catch (e) {
+      if (myId !== transcriptionId) return;
+      console.warn('Transcription failed:', e);
+    } finally {
+      if (myId === transcriptionId) transcribing = false;
+    }
+  }
+
+  async function startRecording() {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const chunks: Blob[] = [];
+      mediaRecorder = new MediaRecorder(stream);
+      mediaRecorder.ondataavailable = (e) => {
+        if (e.data.size > 0) chunks.push(e.data);
+      };
+      mediaRecorder.onstop = () => {
+        stream.getTracks().forEach((t) => {
+          t.stop();
+        });
+        if (recordedUrl) URL.revokeObjectURL(recordedUrl);
+        const mimeType = mediaRecorder?.mimeType || 'audio/webm';
+        const blob = new Blob(chunks, { type: mimeType });
+        recordedBlob = blob;
+        recordedUrl = URL.createObjectURL(blob);
+        file = null;
+        runTranscription(blob);
+      };
+      mediaRecorder.start();
+      recording = true;
+      recordingDuration = 0;
+      recordingInterval = setInterval(() => {
+        recordingDuration++;
+      }, 1000);
+    } catch {
+      // Mic permission denied or unavailable
+    }
+  }
+
+  function stopRecording() {
+    if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+      mediaRecorder.stop();
+    }
+    recording = false;
+    if (recordingInterval) {
+      clearInterval(recordingInterval);
+      recordingInterval = null;
+    }
+  }
+
+  function discardRecording() {
+    transcriptionId++; // cancel in-flight transcription
+    if (recordedUrl) URL.revokeObjectURL(recordedUrl);
+    recordedBlob = null;
+    recordedUrl = null;
+    recordingDuration = 0;
+    transcript = '';
+    transcribing = false;
+  }
+
+  buildItem = async ({
+    id,
+    createdAt,
+  }: BuildItemContext): Promise<BuildItemResult | null> => {
+    if (recordedBlob || file) {
+      const existingPath =
+        isEdit && editItem?.type === 'audio' ? editItem?.filePath : undefined;
+      let filePath: string;
+      let mimeType: string;
+      let duration: number | undefined;
+      let fileData: ArrayBuffer;
+      if (recordedBlob) {
+        const ext = recordedBlob.type.includes('webm')
+          ? '.webm'
+          : recordedBlob.type.includes('mp4')
+            ? '.mp4'
+            : '.ogg';
+        filePath = existingPath || `files/${id}${ext}`;
+        mimeType = recordedBlob.type || 'audio/webm';
+        fileData = await recordedBlob.arrayBuffer();
+        duration = recordingDuration || undefined;
+      } else if (file) {
+        const ext = getFileExtension(file.name);
+        filePath = existingPath || `files/${id}${ext}`;
+        mimeType = file.type;
+        fileData = await file.arrayBuffer();
+      } else {
+        return null;
+      }
+      const memoBody = body || transcript || undefined;
+      const autoTitle = title || transcript || 'Audio';
+      const transcribed =
+        !!(recordedBlob || transcript || body) || undefined;
+      const item: AudioItem = {
+        id,
+        type: 'audio',
+        title: autoTitle,
+        filePath,
+        mimeType,
+        duration,
+        body: memoBody,
+        transcribed,
+        description: description || undefined,
+        createdAt,
+      };
+      return { item, fileData };
+    }
+    if (editItem && editItem.type === 'audio') {
+      const item: AudioItem = {
+        ...editItem,
+        title: title || editItem.title,
+        body: body || undefined,
+        description: description || undefined,
+      };
+      return { item };
+    }
+    return null;
+  };
+
+  onDestroy(() => {
+    if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+      mediaRecorder.stop();
+    }
+    if (recordingInterval) clearInterval(recordingInterval);
+    if (recordedUrl) URL.revokeObjectURL(recordedUrl);
+  });
+</script>
+
+{#if !isEdit}
+  <div class="field">
+    <span>Record</span>
+    <div class="recorder">
+      {#if recording}
+        <span class="rec-indicator"></span>
+        <span class="rec-timer">{formatRecordingTimer(recordingDuration)}</span>
+        <button type="button" class="rec-btn rec-stop" onclick={stopRecording}
+          >Stop</button
+        >
+      {:else if recordedBlob}
+        <!-- See AudioCard.svelte for why an empty captions track is OK here. -->
+        <audio controls src={recordedUrl} preload="metadata">
+          <track kind="captions" />
+        </audio>
+        <button
+          type="button"
+          class="rec-btn rec-discard"
+          onclick={discardRecording}>Discard</button
+        >
+      {:else}
+        <button type="button" class="rec-btn rec-start" onclick={startRecording}
+          >Start Recording</button
+        >
+      {/if}
+    </div>
+  </div>
+  {#if transcribing}
+    <p class="transcript-status">Transcribing...</p>
+  {/if}
+  {#if transcript}
+    <div class="field">
+      <span>Transcript</span>
+      <p class="transcript">{transcript}</p>
+    </div>
+  {/if}
+  {#if !recordedBlob && !recording}
+    <label class="field">
+      <span>Or upload audio file</span>
+      <input type="file" accept="audio/*" onchange={handleFileChange} />
+    </label>
+  {/if}
+{/if}
+<label class="field">
+  <span>Title</span>
+  <input use:autofocus type="text" bind:value={title} placeholder="Memo title" />
+</label>
+<label class="field">
+  <span>Body</span>
+  <textarea
+    class="auto-expand"
+    bind:value={body}
+    rows="3"
+    placeholder="Transcription or notes..."
+  ></textarea>
+</label>

--- a/packages/web/src/components/add-entry/BookmarkForm.svelte
+++ b/packages/web/src/components/add-entry/BookmarkForm.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import type { BookmarkItem, InboxItem } from '@inbox-rs/rs-module';
+  import { autofocus } from '../../lib/actions';
+  import type {
+    BuildItemContext,
+    BuildItemFn,
+    BuildItemResult,
+  } from '../../lib/add-entry-modal';
+
+  let {
+    editItem,
+    canSubmit = $bindable(false),
+    buildItem = $bindable(),
+  }: {
+    editItem?: InboxItem;
+    canSubmit?: boolean;
+    buildItem?: BuildItemFn;
+  } = $props();
+
+  let url = $state(editItem && 'url' in editItem ? editItem.url : '');
+  let title = $state(editItem?.title ?? '');
+  let description = $state(editItem?.description ?? '');
+
+  // The URL field is the only required input — title falls back to the URL
+  // and description is optional. Surface readiness to the shell so the Save
+  // button can stay disabled until something useful exists.
+  $effect(() => {
+    canSubmit = !!url;
+  });
+
+  // Set the build function once. The closure reads the latest reactive
+  // state on every call, so the shell can invoke this whenever the user
+  // clicks Save.
+  buildItem = ({ id, createdAt }: BuildItemContext): BuildItemResult => {
+    const bookmark: BookmarkItem = {
+      id,
+      type: 'bookmark',
+      title: title || url,
+      url,
+      description: description || undefined,
+      createdAt,
+    };
+    // Preserve enrichment metadata fetched by the extension (favicon,
+    // ogImage, siteName, embedded body, downloaded image) — the web form
+    // doesn't surface these fields, so we'd lose them if we didn't copy
+    // them through on edit.
+    if (editItem && editItem.type === 'bookmark') {
+      if (editItem.favicon) bookmark.favicon = editItem.favicon;
+      if (editItem.ogImage) bookmark.ogImage = editItem.ogImage;
+      if (editItem.siteName) bookmark.siteName = editItem.siteName;
+      if (editItem.body) bookmark.body = editItem.body;
+      if (editItem.filePath) bookmark.filePath = editItem.filePath;
+      if (editItem.mimeType) bookmark.mimeType = editItem.mimeType;
+    }
+    return { item: bookmark };
+  };
+</script>
+
+<p class="info-note">
+  Metadata fetching is not yet available in the web app. Use the browser
+  extension to auto-fill bookmark details. Sockethub integration is planned
+  for a future release.
+</p>
+<label class="field">
+  <span>URL *</span>
+  <input use:autofocus type="url" bind:value={url} placeholder="https://..." />
+</label>
+<label class="field">
+  <span>Title</span>
+  <input type="text" bind:value={title} placeholder="Page title" />
+</label>
+<label class="field">
+  <span>Note</span>
+  <textarea bind:value={description} rows="2" placeholder="Optional note..."
+  ></textarea>
+</label>

--- a/packages/web/src/components/add-entry/BookmarkForm.svelte
+++ b/packages/web/src/components/add-entry/BookmarkForm.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
-  import type { BookmarkItem, InboxItem } from '@inbox-rs/rs-module';
+  import type { InboxItem } from '@inbox-rs/rs-module';
   import { autofocus } from '../../lib/actions';
-  import type {
-    BuildItemContext,
-    BuildItemFn,
-    BuildItemResult,
-  } from '../../lib/add-entry-modal';
+  import type { BuildItemFn } from '../../lib/add-entry-modal';
+  import { buildBookmarkItem } from '../../lib/build-item';
 
   let {
     editItem,
@@ -30,30 +27,13 @@
 
   // Set the build function once. The closure reads the latest reactive
   // state on every call, so the shell can invoke this whenever the user
-  // clicks Save.
-  buildItem = ({ id, createdAt }: BuildItemContext): BuildItemResult => {
-    const bookmark: BookmarkItem = {
-      id,
-      type: 'bookmark',
-      title: title || url,
-      url,
-      description: description || undefined,
-      createdAt,
-    };
-    // Preserve enrichment metadata fetched by the extension (favicon,
-    // ogImage, siteName, embedded body, downloaded image) — the web form
-    // doesn't surface these fields, so we'd lose them if we didn't copy
-    // them through on edit.
-    if (editItem && editItem.type === 'bookmark') {
-      if (editItem.favicon) bookmark.favicon = editItem.favicon;
-      if (editItem.ogImage) bookmark.ogImage = editItem.ogImage;
-      if (editItem.siteName) bookmark.siteName = editItem.siteName;
-      if (editItem.body) bookmark.body = editItem.body;
-      if (editItem.filePath) bookmark.filePath = editItem.filePath;
-      if (editItem.mimeType) bookmark.mimeType = editItem.mimeType;
-    }
-    return { item: bookmark };
-  };
+  // clicks Save. Item-shaping rules live in the pure builder so they can
+  // be unit-tested without mounting this component.
+  buildItem = ({ id, createdAt, editItem: ctxEditItem }) =>
+    buildBookmarkItem(
+      { id, createdAt, editItem: ctxEditItem },
+      { url, title, description },
+    );
 </script>
 
 <p class="info-note">

--- a/packages/web/src/components/add-entry/DocumentForm.svelte
+++ b/packages/web/src/components/add-entry/DocumentForm.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import type { DocumentItem, InboxItem } from '@inbox-rs/rs-module';
+  import { autofocus } from '../../lib/actions';
+  import {
+    type BuildItemContext,
+    type BuildItemFn,
+    type BuildItemResult,
+    getFileExtension,
+  } from '../../lib/add-entry-modal';
+
+  let {
+    editItem,
+    canSubmit = $bindable(false),
+    buildItem = $bindable(),
+  }: {
+    editItem?: InboxItem;
+    canSubmit?: boolean;
+    buildItem?: BuildItemFn;
+  } = $props();
+
+  const isEdit = !!editItem;
+  const hasExistingFile = !!(
+    editItem &&
+    'filePath' in editItem &&
+    editItem.filePath
+  );
+
+  let title = $state(editItem?.title ?? '');
+  let description = $state(editItem?.description ?? '');
+  let file = $state<File | null>(null);
+
+  $effect(() => {
+    canSubmit = !!file || hasExistingFile;
+  });
+
+  function handleFileChange(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    file = input.files?.[0] ?? null;
+  }
+
+  buildItem = async ({
+    id,
+    createdAt,
+  }: BuildItemContext): Promise<BuildItemResult | null> => {
+    if (file) {
+      const existingPath =
+        isEdit && editItem?.type === 'document' ? editItem?.filePath : undefined;
+      const ext = getFileExtension(file.name);
+      const filePath = existingPath || `files/${id}${ext}`;
+      const fileData = await file.arrayBuffer();
+      const item: DocumentItem = {
+        id,
+        type: 'document',
+        title: title || file.name,
+        filePath,
+        mimeType: file.type,
+        fileSize: file.size,
+        fileName: file.name,
+        description: description || undefined,
+        createdAt,
+      };
+      return { item, fileData };
+    }
+    if (editItem && editItem.type === 'document') {
+      const item: DocumentItem = {
+        ...editItem,
+        title: title || editItem.title,
+        description: description || undefined,
+      };
+      return { item };
+    }
+    return null;
+  };
+</script>
+
+<label class="field">
+  <span>{hasExistingFile ? 'Replace file' : 'File *'}</span>
+  <input type="file" onchange={handleFileChange} />
+</label>
+<label class="field">
+  <span>Title</span>
+  <input
+    use:autofocus
+    type="text"
+    bind:value={title}
+    placeholder="Document title"
+  />
+</label>
+<label class="field">
+  <span>Description</span>
+  <textarea
+    bind:value={description}
+    rows="2"
+    placeholder="Optional description..."
+  ></textarea>
+</label>

--- a/packages/web/src/components/add-entry/DocumentForm.svelte
+++ b/packages/web/src/components/add-entry/DocumentForm.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
-  import type { DocumentItem, InboxItem } from '@inbox-rs/rs-module';
+  import type { InboxItem } from '@inbox-rs/rs-module';
   import { autofocus } from '../../lib/actions';
-  import {
-    type BuildItemContext,
-    type BuildItemFn,
-    type BuildItemResult,
-    getFileExtension,
-  } from '../../lib/add-entry-modal';
+  import type { BuildItemFn } from '../../lib/add-entry-modal';
+  import { buildDocumentItem } from '../../lib/build-item';
 
   let {
     editItem,
@@ -18,7 +14,6 @@
     buildItem?: BuildItemFn;
   } = $props();
 
-  const isEdit = !!editItem;
   const hasExistingFile = !!(
     editItem &&
     'filePath' in editItem &&
@@ -38,39 +33,11 @@
     file = input.files?.[0] ?? null;
   }
 
-  buildItem = async ({
-    id,
-    createdAt,
-  }: BuildItemContext): Promise<BuildItemResult | null> => {
-    if (file) {
-      const existingPath =
-        isEdit && editItem?.type === 'document' ? editItem?.filePath : undefined;
-      const ext = getFileExtension(file.name);
-      const filePath = existingPath || `files/${id}${ext}`;
-      const fileData = await file.arrayBuffer();
-      const item: DocumentItem = {
-        id,
-        type: 'document',
-        title: title || file.name,
-        filePath,
-        mimeType: file.type,
-        fileSize: file.size,
-        fileName: file.name,
-        description: description || undefined,
-        createdAt,
-      };
-      return { item, fileData };
-    }
-    if (editItem && editItem.type === 'document') {
-      const item: DocumentItem = {
-        ...editItem,
-        title: title || editItem.title,
-        description: description || undefined,
-      };
-      return { item };
-    }
-    return null;
-  };
+  buildItem = ({ id, createdAt, editItem: ctxEditItem }) =>
+    buildDocumentItem(
+      { id, createdAt, editItem: ctxEditItem },
+      { title, description, file },
+    );
 </script>
 
 <label class="field">

--- a/packages/web/src/components/add-entry/EmailForm.svelte
+++ b/packages/web/src/components/add-entry/EmailForm.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import type { EmailItem, InboxItem } from '@inbox-rs/rs-module';
+  import { autofocus } from '../../lib/actions';
+  import type {
+    BuildItemContext,
+    BuildItemFn,
+    BuildItemResult,
+  } from '../../lib/add-entry-modal';
+
+  let {
+    editItem,
+    canSubmit = $bindable(false),
+    buildItem = $bindable(),
+  }: {
+    editItem?: InboxItem;
+    canSubmit?: boolean;
+    buildItem?: BuildItemFn;
+  } = $props();
+
+  const isEdit = !!editItem;
+
+  let title = $state(editItem?.title ?? '');
+  let body = $state(editItem && 'body' in editItem ? (editItem.body ?? '') : '');
+  let from = $state(editItem && 'from' in editItem ? (editItem.from ?? '') : '');
+  let notes = $state(editItem && 'notes' in editItem ? (editItem.notes ?? '') : '');
+
+  $effect(() => {
+    canSubmit = !!body;
+  });
+
+  buildItem = ({ id, createdAt }: BuildItemContext): BuildItemResult => {
+    // Preserve the mid: URI when editing — this links the captured email
+    // back to the user's mail client and isn't surfaced in the form.
+    const emailMessageUrl =
+      isEdit && editItem?.type === 'email' ? editItem?.messageUrl : undefined;
+    const item: EmailItem = {
+      id,
+      type: 'email',
+      title: title || 'Untitled email',
+      body,
+      from: from || undefined,
+      notes: notes || undefined,
+      messageUrl: emailMessageUrl,
+      createdAt,
+    };
+    return { item };
+  };
+</script>
+
+<label class="field">
+  <span>Subject</span>
+  <input
+    use:autofocus
+    type="text"
+    bind:value={title}
+    placeholder="Email subject"
+  />
+</label>
+<label class="field">
+  <span>From</span>
+  <input type="text" bind:value={from} placeholder="Sender" />
+</label>
+<label class="field">
+  <span>Body *</span>
+  <textarea bind:value={body} rows="6" placeholder="Email body..."></textarea>
+</label>
+<label class="field">
+  <span>Notes</span>
+  <textarea bind:value={notes} rows="2" placeholder="Optional notes..."
+  ></textarea>
+</label>

--- a/packages/web/src/components/add-entry/EmailForm.svelte
+++ b/packages/web/src/components/add-entry/EmailForm.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
-  import type { EmailItem, InboxItem } from '@inbox-rs/rs-module';
+  import type { InboxItem } from '@inbox-rs/rs-module';
   import { autofocus } from '../../lib/actions';
-  import type {
-    BuildItemContext,
-    BuildItemFn,
-    BuildItemResult,
-  } from '../../lib/add-entry-modal';
+  import type { BuildItemFn } from '../../lib/add-entry-modal';
+  import { buildEmailItem } from '../../lib/build-item';
 
   let {
     editItem,
@@ -17,8 +14,6 @@
     buildItem?: BuildItemFn;
   } = $props();
 
-  const isEdit = !!editItem;
-
   let title = $state(editItem?.title ?? '');
   let body = $state(editItem && 'body' in editItem ? (editItem.body ?? '') : '');
   let from = $state(editItem && 'from' in editItem ? (editItem.from ?? '') : '');
@@ -28,23 +23,11 @@
     canSubmit = !!body;
   });
 
-  buildItem = ({ id, createdAt }: BuildItemContext): BuildItemResult => {
-    // Preserve the mid: URI when editing — this links the captured email
-    // back to the user's mail client and isn't surfaced in the form.
-    const emailMessageUrl =
-      isEdit && editItem?.type === 'email' ? editItem?.messageUrl : undefined;
-    const item: EmailItem = {
-      id,
-      type: 'email',
-      title: title || 'Untitled email',
-      body,
-      from: from || undefined,
-      notes: notes || undefined,
-      messageUrl: emailMessageUrl,
-      createdAt,
-    };
-    return { item };
-  };
+  buildItem = ({ id, createdAt, editItem: ctxEditItem }) =>
+    buildEmailItem(
+      { id, createdAt, editItem: ctxEditItem },
+      { title, body, from, notes },
+    );
 </script>
 
 <label class="field">

--- a/packages/web/src/components/add-entry/ImageForm.svelte
+++ b/packages/web/src/components/add-entry/ImageForm.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
-  import type { ImageItem, InboxItem } from '@inbox-rs/rs-module';
+  import type { InboxItem } from '@inbox-rs/rs-module';
   import { autofocus } from '../../lib/actions';
-  import {
-    type BuildItemContext,
-    type BuildItemFn,
-    type BuildItemResult,
-    getFileExtension,
-  } from '../../lib/add-entry-modal';
+  import type { BuildItemFn } from '../../lib/add-entry-modal';
+  import { buildImageItem } from '../../lib/build-item';
 
   let {
     editItem,
@@ -18,7 +14,6 @@
     buildItem?: BuildItemFn;
   } = $props();
 
-  const isEdit = !!editItem;
   const hasExistingFile = !!(
     editItem &&
     'filePath' in editItem &&
@@ -40,39 +35,11 @@
     file = input.files?.[0] ?? null;
   }
 
-  buildItem = async ({
-    id,
-    createdAt,
-  }: BuildItemContext): Promise<BuildItemResult | null> => {
-    if (file) {
-      // On edit, reuse the original file path so the new bytes overwrite
-      // the existing storage location instead of leaving the old blob behind.
-      const existingPath =
-        isEdit && editItem?.type === 'image' ? editItem?.filePath : undefined;
-      const ext = getFileExtension(file.name);
-      const filePath = existingPath || `files/${id}${ext}`;
-      const fileData = await file.arrayBuffer();
-      const item: ImageItem = {
-        id,
-        type: 'image',
-        title: title || file.name,
-        filePath,
-        mimeType: file.type,
-        description: description || undefined,
-        createdAt,
-      };
-      return { item, fileData };
-    }
-    if (editItem && editItem.type === 'image') {
-      const item: ImageItem = {
-        ...editItem,
-        title: title || editItem.title,
-        description: description || undefined,
-      };
-      return { item };
-    }
-    return null;
-  };
+  buildItem = ({ id, createdAt, editItem: ctxEditItem }) =>
+    buildImageItem(
+      { id, createdAt, editItem: ctxEditItem },
+      { title, description, file },
+    );
 </script>
 
 <label class="field">

--- a/packages/web/src/components/add-entry/ImageForm.svelte
+++ b/packages/web/src/components/add-entry/ImageForm.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  import type { ImageItem, InboxItem } from '@inbox-rs/rs-module';
+  import { autofocus } from '../../lib/actions';
+  import {
+    type BuildItemContext,
+    type BuildItemFn,
+    type BuildItemResult,
+    getFileExtension,
+  } from '../../lib/add-entry-modal';
+
+  let {
+    editItem,
+    canSubmit = $bindable(false),
+    buildItem = $bindable(),
+  }: {
+    editItem?: InboxItem;
+    canSubmit?: boolean;
+    buildItem?: BuildItemFn;
+  } = $props();
+
+  const isEdit = !!editItem;
+  const hasExistingFile = !!(
+    editItem &&
+    'filePath' in editItem &&
+    editItem.filePath
+  );
+
+  let title = $state(editItem?.title ?? '');
+  let description = $state(editItem?.description ?? '');
+  let file = $state<File | null>(null);
+
+  // Save needs either a freshly picked file or, in edit mode, an already-
+  // stored image whose metadata we're updating without replacing the bytes.
+  $effect(() => {
+    canSubmit = !!file || hasExistingFile;
+  });
+
+  function handleFileChange(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    file = input.files?.[0] ?? null;
+  }
+
+  buildItem = async ({
+    id,
+    createdAt,
+  }: BuildItemContext): Promise<BuildItemResult | null> => {
+    if (file) {
+      // On edit, reuse the original file path so the new bytes overwrite
+      // the existing storage location instead of leaving the old blob behind.
+      const existingPath =
+        isEdit && editItem?.type === 'image' ? editItem?.filePath : undefined;
+      const ext = getFileExtension(file.name);
+      const filePath = existingPath || `files/${id}${ext}`;
+      const fileData = await file.arrayBuffer();
+      const item: ImageItem = {
+        id,
+        type: 'image',
+        title: title || file.name,
+        filePath,
+        mimeType: file.type,
+        description: description || undefined,
+        createdAt,
+      };
+      return { item, fileData };
+    }
+    if (editItem && editItem.type === 'image') {
+      const item: ImageItem = {
+        ...editItem,
+        title: title || editItem.title,
+        description: description || undefined,
+      };
+      return { item };
+    }
+    return null;
+  };
+</script>
+
+<label class="field">
+  <span>{hasExistingFile ? 'Replace image' : 'Image *'}</span>
+  <input type="file" accept="image/*" onchange={handleFileChange} />
+</label>
+<label class="field">
+  <span>Title</span>
+  <input use:autofocus type="text" bind:value={title} placeholder="Image title" />
+</label>
+<label class="field">
+  <span>Description</span>
+  <textarea bind:value={description} rows="2" placeholder="Optional description..."
+  ></textarea>
+</label>

--- a/packages/web/src/components/add-entry/NoteForm.svelte
+++ b/packages/web/src/components/add-entry/NoteForm.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
   import type { Component } from 'svelte';
-  import type { InboxItem, NoteItem } from '@inbox-rs/rs-module';
+  import type { InboxItem } from '@inbox-rs/rs-module';
   import { autofocus } from '../../lib/actions';
   import {
-    type BuildItemContext,
     type BuildItemFn,
-    type BuildItemResult,
     loadMarkdownEditorComponent,
     type MarkdownEditorProps,
     shouldLoadMarkdownEditor,
   } from '../../lib/add-entry-modal';
+  import { buildNoteItem } from '../../lib/build-item';
   import { createCodeKeydownHandler } from '../../lib/code-indent';
   import { renderMarkdown } from '../../lib/markdown';
 
@@ -41,17 +40,11 @@
     canSubmit = !!(title || body);
   });
 
-  buildItem = ({ id, createdAt }: BuildItemContext): BuildItemResult => {
-    const item: NoteItem = {
-      id,
-      type: 'note',
-      title: title || body.slice(0, 50),
-      body,
-      description: description || undefined,
-      createdAt,
-    };
-    return { item };
-  };
+  buildItem = ({ id, createdAt, editItem: ctxEditItem }) =>
+    buildNoteItem(
+      { id, createdAt, editItem: ctxEditItem },
+      { title, body, description },
+    );
 
   // Lazy-load the visual editor on demand: it pulls in TipTap and friends
   // (~hundreds of KB) and only ~60% of users open the note modal in any

--- a/packages/web/src/components/add-entry/NoteForm.svelte
+++ b/packages/web/src/components/add-entry/NoteForm.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+  import type { Component } from 'svelte';
+  import type { InboxItem, NoteItem } from '@inbox-rs/rs-module';
+  import { autofocus } from '../../lib/actions';
+  import {
+    type BuildItemContext,
+    type BuildItemFn,
+    type BuildItemResult,
+    loadMarkdownEditorComponent,
+    type MarkdownEditorProps,
+    shouldLoadMarkdownEditor,
+  } from '../../lib/add-entry-modal';
+  import { createCodeKeydownHandler } from '../../lib/code-indent';
+  import { renderMarkdown } from '../../lib/markdown';
+
+  let {
+    editItem,
+    canSubmit = $bindable(false),
+    buildItem = $bindable(),
+  }: {
+    editItem?: InboxItem;
+    canSubmit?: boolean;
+    buildItem?: BuildItemFn;
+  } = $props();
+
+  let title = $state(editItem?.title ?? '');
+  let body = $state(editItem && 'body' in editItem ? (editItem.body ?? '') : '');
+  let description = $state(editItem?.description ?? '');
+
+  let editorMode = $state<'visual' | 'write' | 'preview'>('visual');
+  let MarkdownEditorComponent = $state<Component<MarkdownEditorProps> | null>(
+    null,
+  );
+  let markdownEditorLoadError = $state('');
+  let previewHtml = $state('');
+
+  const handleCodeKeydown = createCodeKeydownHandler();
+
+  // A note is captureable as soon as the user has typed a title or any body.
+  $effect(() => {
+    canSubmit = !!(title || body);
+  });
+
+  buildItem = ({ id, createdAt }: BuildItemContext): BuildItemResult => {
+    const item: NoteItem = {
+      id,
+      type: 'note',
+      title: title || body.slice(0, 50),
+      body,
+      description: description || undefined,
+      createdAt,
+    };
+    return { item };
+  };
+
+  // Lazy-load the visual editor on demand: it pulls in TipTap and friends
+  // (~hundreds of KB) and only ~60% of users open the note modal in any
+  // given session. Falls back to the markdown textarea if loading fails so
+  // the user can still capture content.
+  $effect(() => {
+    if (
+      !shouldLoadMarkdownEditor(
+        'note',
+        editorMode,
+        !!MarkdownEditorComponent,
+        !!markdownEditorLoadError,
+      )
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+
+    loadMarkdownEditorComponent()
+      .then((component) => {
+        if (!cancelled) {
+          MarkdownEditorComponent = component;
+        }
+      })
+      .catch((loadError) => {
+        console.error('Failed to load markdown editor:', loadError);
+        if (!cancelled) {
+          markdownEditorLoadError =
+            'Visual editor unavailable. Markdown mode is still available.';
+          editorMode = 'write';
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  // Render markdown preview asynchronously. Re-checks `body === currentBody`
+  // before applying the rendered HTML so a stale render from a previous body
+  // value doesn't overwrite a fresher one.
+  $effect(() => {
+    if (editorMode !== 'preview') {
+      previewHtml = '';
+      return;
+    }
+
+    const currentBody = body;
+    let cancelled = false;
+
+    renderMarkdown(currentBody)
+      .then((html) => {
+        if (!cancelled && body === currentBody && editorMode === 'preview') {
+          previewHtml = html;
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          previewHtml = '';
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  });
+</script>
+
+<label class="field">
+  <span>Title</span>
+  <!--
+    Title is autofocused for the note modal too. The visual editor below is
+    async-loaded and doesn't autofocus on mount, so without this the user
+    opens the modal and lands on no field at all. When in `write` (Markdown)
+    mode the body textarea also has `use:autofocus` and runs later in the
+    DOM, so it wins the focus race and the user lands in the editor —
+    which is what they want once they've explicitly switched to Markdown
+    mode.
+  -->
+  <input use:autofocus type="text" bind:value={title} placeholder="Note title" />
+</label>
+<div class="field note-editor-field">
+  <div class="field-header">
+    <span>Content</span>
+    <div class="editor-tabs">
+      <button
+        type="button"
+        class="tab"
+        class:active={editorMode === 'visual'}
+        onclick={() => (editorMode = 'visual')}
+        disabled={!!markdownEditorLoadError}>Visual</button
+      >
+      <button
+        type="button"
+        class="tab"
+        class:active={editorMode === 'write'}
+        onclick={() => (editorMode = 'write')}>Markdown</button
+      >
+      <button
+        type="button"
+        class="tab"
+        class:active={editorMode === 'preview'}
+        onclick={() => (editorMode = 'preview')}>Preview</button
+      >
+    </div>
+  </div>
+  {#if editorMode === 'visual'}
+    {#if MarkdownEditorComponent}
+      <MarkdownEditorComponent bind:value={body} placeholder="Write your note..." />
+    {:else if markdownEditorLoadError}
+      <textarea
+        use:autofocus
+        class="code-input"
+        bind:value={body}
+        rows="10"
+        placeholder="Write your note in Markdown..."
+        onkeydown={handleCodeKeydown}
+      ></textarea>
+    {:else}
+      <div class="editor-loading" aria-live="polite">Loading visual editor…</div>
+    {/if}
+  {:else if editorMode === 'write'}
+    <textarea
+      use:autofocus
+      class="code-input"
+      bind:value={body}
+      rows="10"
+      placeholder="Write your note in Markdown..."
+      onkeydown={handleCodeKeydown}
+    ></textarea>
+  {:else}
+    <div class="preview-wrap markdown-body">
+      {#if previewHtml}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+        {@html previewHtml}
+      {:else if body.trim()}
+        <span class="preview-empty">Preview unavailable</span>
+      {:else}
+        <span class="preview-empty">Nothing to preview</span>
+      {/if}
+    </div>
+  {/if}
+</div>
+{#if markdownEditorLoadError}
+  <p class="info-note">{markdownEditorLoadError}</p>
+{/if}

--- a/packages/web/src/components/add-entry/TodoForm.svelte
+++ b/packages/web/src/components/add-entry/TodoForm.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-  import type { InboxItem, TodoItem } from '@inbox-rs/rs-module';
+  import type { InboxItem } from '@inbox-rs/rs-module';
   import { autofocus } from '../../lib/actions';
   import {
-    type BuildItemContext,
     type BuildItemFn,
-    type BuildItemResult,
     canCaptureTodo,
   } from '../../lib/add-entry-modal';
+  import { buildTodoItem } from '../../lib/build-item';
   import { createCodeKeydownHandler } from '../../lib/code-indent';
 
   let {
@@ -34,34 +33,11 @@
     canSubmit = canCaptureTodo(title);
   });
 
-  buildItem = ({ id, createdAt }: BuildItemContext): BuildItemResult => {
-    // Stamp `completedAt` only on the false→true transition. Otherwise we
-    // pass the editItem's existing value through untouched — including the
-    // case where the user *unchecks* a previously-completed todo, where we
-    // intentionally retain the historical timestamp instead of clearing it.
-    // This matches the pre-refactor behaviour and means the schema can
-    // surface "last completed at <time>" hints even on re-opened todos.
-    const wasCompleted =
-      editItem && 'completed' in editItem && !!editItem.completed;
-    const previousCompletedAt =
-      editItem && 'completedAt' in editItem ? editItem.completedAt : undefined;
-    const completedAt =
-      completed && !wasCompleted
-        ? new Date().toISOString()
-        : previousCompletedAt;
-    const item: TodoItem = {
-      id,
-      type: 'todo',
-      title,
-      body: body || undefined,
-      completed,
-      completedAt,
-      description: description || undefined,
-      createdAt,
-      isTodo: true,
-    };
-    return { item };
-  };
+  buildItem = ({ id, createdAt, editItem: ctxEditItem }) =>
+    buildTodoItem(
+      { id, createdAt, editItem: ctxEditItem },
+      { title, body, description, completed },
+    );
 </script>
 
 <label class="field">

--- a/packages/web/src/components/add-entry/TodoForm.svelte
+++ b/packages/web/src/components/add-entry/TodoForm.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  import type { InboxItem, TodoItem } from '@inbox-rs/rs-module';
+  import { autofocus } from '../../lib/actions';
+  import {
+    type BuildItemContext,
+    type BuildItemFn,
+    type BuildItemResult,
+    canCaptureTodo,
+  } from '../../lib/add-entry-modal';
+  import { createCodeKeydownHandler } from '../../lib/code-indent';
+
+  let {
+    editItem,
+    canSubmit = $bindable(false),
+    buildItem = $bindable(),
+  }: {
+    editItem?: InboxItem;
+    canSubmit?: boolean;
+    buildItem?: BuildItemFn;
+  } = $props();
+
+  const isEdit = !!editItem;
+
+  let title = $state(editItem?.title ?? '');
+  let body = $state(editItem && 'body' in editItem ? (editItem.body ?? '') : '');
+  let description = $state(editItem?.description ?? '');
+  let completed = $state(
+    editItem && 'completed' in editItem ? !!editItem.completed : false,
+  );
+
+  const handleCodeKeydown = createCodeKeydownHandler();
+
+  $effect(() => {
+    canSubmit = canCaptureTodo(title);
+  });
+
+  buildItem = ({ id, createdAt }: BuildItemContext): BuildItemResult => {
+    // Stamp `completedAt` only on the false→true transition. Otherwise we
+    // pass the editItem's existing value through untouched — including the
+    // case where the user *unchecks* a previously-completed todo, where we
+    // intentionally retain the historical timestamp instead of clearing it.
+    // This matches the pre-refactor behaviour and means the schema can
+    // surface "last completed at <time>" hints even on re-opened todos.
+    const wasCompleted =
+      editItem && 'completed' in editItem && !!editItem.completed;
+    const previousCompletedAt =
+      editItem && 'completedAt' in editItem ? editItem.completedAt : undefined;
+    const completedAt =
+      completed && !wasCompleted
+        ? new Date().toISOString()
+        : previousCompletedAt;
+    const item: TodoItem = {
+      id,
+      type: 'todo',
+      title,
+      body: body || undefined,
+      completed,
+      completedAt,
+      description: description || undefined,
+      createdAt,
+      isTodo: true,
+    };
+    return { item };
+  };
+</script>
+
+<label class="field">
+  <span>Title *</span>
+  <input
+    use:autofocus
+    type="text"
+    bind:value={title}
+    placeholder="What needs to be done?"
+  />
+</label>
+<label class="field">
+  <span>Details</span>
+  <textarea
+    bind:value={body}
+    rows="3"
+    placeholder="Optional details..."
+    onkeydown={handleCodeKeydown}
+  ></textarea>
+</label>
+{#if isEdit}
+  <label class="field checkbox-field">
+    <input type="checkbox" bind:checked={completed} />
+    <span>Completed</span>
+  </label>
+{/if}

--- a/packages/web/src/components/view-card/AudioView.svelte
+++ b/packages/web/src/components/view-card/AudioView.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  import type { AudioItem } from '@inbox-rs/rs-module';
+  import { blobUrls, connected, loadFileBlobUrl, storeItem } from '../../lib/stores';
+  import rs from '../../lib/rs';
+  import { transcribeAudio } from '../../lib/transcribe';
+
+  let { item, titleId }: { item: AudioItem; titleId: string } = $props();
+
+  let audioError = $state(false);
+  let transcribing = $state(false);
+  let transcriptionError = $state(false);
+
+  const audioSrc = $derived($blobUrls[item.filePath] || null);
+
+  // The parent shell wraps the per-type view in `{#key item.id}`, so
+  // navigating between audios remounts this component — `audioError` and
+  // friends initialise fresh without explicit reset effects.
+
+  // Pass mimeType so the blob is tagged with the clean type from item
+  // metadata; see BookmarkView for the longer note.
+  $effect(() => {
+    if (!$connected) return;
+    if (item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
+  });
+
+  function formatDuration(seconds?: number): string {
+    if (!seconds) return '';
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60);
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  }
+
+  async function handleTranscribe() {
+    // The parent's `{#key item.id}` block destroys this component if the
+    // user navigates to a different audio mid-transcription, which cancels
+    // any UI updates from the in-flight promise — Svelte simply stops
+    // applying state writes from a destroyed component. So we don't need
+    // an explicit id-guard around the finally block.
+    transcribing = true;
+    transcriptionError = false;
+    try {
+      const file = await rs.inbox.getFile(item.filePath);
+      if (!file?.data) throw new Error('Could not load audio file');
+      const blob = new Blob([file.data], { type: item.mimeType });
+      const text = await transcribeAudio(blob);
+      const updated: AudioItem = {
+        ...item,
+        body: text || undefined,
+        title: text && item.title === 'Audio' ? text.slice(0, 50) : item.title,
+        transcribed: true,
+      };
+      await storeItem(updated);
+    } catch (e) {
+      console.warn('Transcription failed:', e);
+      transcriptionError = true;
+    } finally {
+      transcribing = false;
+    }
+  }
+</script>
+
+<h2 class="title" id={titleId}>{item.title}</h2>
+
+<div class="player">
+  {#if audioError}
+    <p class="status-text">Failed to load audio</p>
+  {:else if audioSrc}
+    <audio
+      controls
+      src={audioSrc}
+      preload="metadata"
+      onerror={() => (audioError = true)}
+    >
+      <!-- See AudioCard.svelte for why an empty captions track is OK here. -->
+      <track kind="captions" />
+    </audio>
+  {:else}
+    <p class="status-text">Connect to load audio</p>
+  {/if}
+  {#if item.duration}
+    <span class="duration">{formatDuration(item.duration)}</span>
+  {/if}
+  {#if transcribing}
+    <p class="status-text">Transcribing...</p>
+  {:else if transcriptionError}
+    <p class="status-text">Transcription failed</p>
+    <button type="button" class="btn-action" onclick={handleTranscribe}
+      >Retry</button
+    >
+  {:else if audioSrc && !item.transcribed && !item.body}
+    <button type="button" class="btn-action" onclick={handleTranscribe}
+      >Transcribe</button
+    >
+  {/if}
+</div>
+
+{#if item.body}
+  <div class="content-block">
+    <span class="content-label">Transcription</span>
+    <p class="content-text">{item.body}</p>
+  </div>
+{/if}

--- a/packages/web/src/components/view-card/BookmarkView.svelte
+++ b/packages/web/src/components/view-card/BookmarkView.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import type { BookmarkItem } from '@inbox-rs/rs-module';
+  import { blobUrls, connected, loadFileBlobUrl } from '../../lib/stores';
+  import Lightbox from '../Lightbox.svelte';
+
+  let { item, titleId }: { item: BookmarkItem; titleId: string } = $props();
+
+  let showLightbox = $state(false);
+
+  function getDomain(url: string): string {
+    try {
+      return new URL(url).hostname.replace(/^www\./, '');
+    } catch {
+      return url;
+    }
+  }
+
+  // Prefer the locally-stored copy of the OG image when we have it (fetched
+  // via Authorization header so it works on all RS servers); otherwise fall
+  // back to the live ogImage URL the bookmark was originally tagged with.
+  const imageSrc = $derived(
+    (item.filePath ? ($blobUrls[item.filePath] || null) : null) ||
+      item.ogImage ||
+      null,
+  );
+
+  // Pass mimeType so the blob is tagged with the clean type from item
+  // metadata rather than the server's Content-Type — 5apps preserves the
+  // `; charset=binary` suffix that wireclient adds on upload, and Chrome
+  // won't render an <img> whose Blob type carries that suffix.
+  $effect(() => {
+    if (!$connected) return;
+    if (item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
+  });
+</script>
+
+<h2 class="title" id={titleId}>
+  <a href={item.url} target="_blank" rel="noopener noreferrer"
+    >{item.title}<svg
+      aria-hidden="true"
+      class="link-icon"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      ><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+      ></path><polyline points="15 3 21 3 21 9"></polyline><line
+        x1="10"
+        y1="14"
+        x2="21"
+        y2="3"
+      ></line></svg
+    ></a
+  >
+</h2>
+
+<div class="meta-row">
+  {#if item.favicon}
+    <img
+      class="favicon"
+      src={item.favicon}
+      alt=""
+      width="16"
+      height="16"
+      onerror={(e) => ((e.currentTarget as HTMLImageElement).style.display = 'none')}
+    />
+  {/if}
+  <span class="domain">{item.siteName || getDomain(item.url)}</span>
+</div>
+
+{#if imageSrc}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="view-image-link" onclick={() => (showLightbox = true)}>
+    <img
+      class="view-image"
+      src={imageSrc}
+      alt=""
+      onerror={(e) => ((e.currentTarget as HTMLImageElement).style.display = 'none')}
+    />
+  </div>
+{/if}
+{#if showLightbox && imageSrc}
+  <Lightbox
+    src={imageSrc}
+    alt={item.title}
+    onclose={() => (showLightbox = false)}
+    filePath={item.filePath}
+    mimeType={item.mimeType}
+    filename={item.title || undefined}
+  />
+{/if}
+
+<!--
+  Embedded body content captured by the extension (tweet text, article
+  excerpt, etc.). We render it after the image so the bookmark's primary
+  visual cue stays at the top, but before description so the user-supplied
+  caption (if any) reads as a follow-up to the captured content.
+-->
+{#if item.body}
+  <div class="content-block">
+    <span class="content-label">Body</span>
+    <p class="content-text">{item.body}</p>
+  </div>
+{/if}

--- a/packages/web/src/components/view-card/DocumentView.svelte
+++ b/packages/web/src/components/view-card/DocumentView.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import type { DocumentItem } from '@inbox-rs/rs-module';
+  import rs from '../../lib/rs';
+
+  let { item, titleId }: { item: DocumentItem; titleId: string } = $props();
+
+  let docBlobUrl = $state<string | null>(null);
+  let docLoading = $state(false);
+
+  // The parent shell wraps the per-type view in `{#key item.id}`, so
+  // navigating between documents fully remounts this component and
+  // `onDestroy` runs on the way out — that's where the cached blob URL
+  // gets revoked. No per-id reset effect needed.
+  onDestroy(() => {
+    if (docBlobUrl) URL.revokeObjectURL(docBlobUrl);
+  });
+
+  function formatSize(bytes?: number): string {
+    if (!bytes) return '';
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  async function downloadDoc() {
+    // Reuse the cached blob URL when we already pulled the file once —
+    // re-fetching on every Download click would waste bandwidth on
+    // metered connections.
+    if (docBlobUrl) {
+      openDownload(docBlobUrl);
+      return;
+    }
+    docLoading = true;
+    try {
+      const file = await rs.inbox.getFile(item.filePath);
+      if (file?.data) {
+        docBlobUrl = URL.createObjectURL(
+          new Blob([file.data], { type: item.mimeType }),
+        );
+        openDownload(docBlobUrl);
+      }
+    } finally {
+      docLoading = false;
+    }
+  }
+
+  function openDownload(url: string) {
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = item.fileName || item.title;
+    a.click();
+  }
+</script>
+
+<h2 class="title" id={titleId}>{item.title}</h2>
+
+{#if item.fileName}
+  <p class="meta-text">{item.fileName}</p>
+{/if}
+{#if item.fileSize}
+  <span class="meta-text">{formatSize(item.fileSize)}</span>
+{/if}
+<button
+  type="button"
+  class="btn-action"
+  onclick={(e) => {
+    e.stopPropagation();
+    downloadDoc();
+  }}
+  disabled={docLoading}
+>
+  {docLoading ? 'Loading...' : 'Download'}
+</button>

--- a/packages/web/src/components/view-card/EmailView.svelte
+++ b/packages/web/src/components/view-card/EmailView.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import type { EmailItem } from '@inbox-rs/rs-module';
+
+  let { item, titleId }: { item: EmailItem; titleId: string } = $props();
+</script>
+
+<h2 class="title" id={titleId}>
+  {#if item.messageUrl}
+    <a href={item.messageUrl}
+      >{item.title}<svg
+        aria-hidden="true"
+        class="link-icon"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        ><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+        ></path><polyline points="15 3 21 3 21 9"></polyline><line
+          x1="10"
+          y1="14"
+          x2="21"
+          y2="3"
+        ></line></svg
+      ></a
+    >
+  {:else}
+    {item.title}
+  {/if}
+</h2>
+
+{#if item.from}
+  <p class="meta-text">From: {item.from}</p>
+{/if}
+
+<!-- Notes appear before the body — they're the user's own annotation and
+     we want them surfaced first when reviewing what's worth reading. -->
+{#if item.notes}
+  <div class="content-block notes-block">
+    <span class="content-label">Notes</span>
+    <p class="content-text">{item.notes}</p>
+  </div>
+{/if}
+
+{#if item.body}
+  <div class="content-block">
+    <span class="content-label">Body</span>
+    <p class="content-text">{item.body}</p>
+  </div>
+{/if}

--- a/packages/web/src/components/view-card/ImageView.svelte
+++ b/packages/web/src/components/view-card/ImageView.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import type { ImageItem } from '@inbox-rs/rs-module';
+  import { blobUrls, connected, loadFileBlobUrl } from '../../lib/stores';
+  import Lightbox from '../Lightbox.svelte';
+
+  let { item, titleId }: { item: ImageItem; titleId: string } = $props();
+
+  let showLightbox = $state(false);
+
+  const imageSrc = $derived($blobUrls[item.filePath] || null);
+
+  // The parent shell wraps the per-type view in `{#key item.id}`, so
+  // navigating between images remounts this component — `showLightbox`
+  // initialises fresh without an explicit reset effect.
+
+  // Pass mimeType so the blob is tagged with the clean type from item
+  // metadata; see BookmarkView for the longer note.
+  $effect(() => {
+    if (!$connected) return;
+    if (item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
+  });
+</script>
+
+<h2 class="title" id={titleId}>{item.title}</h2>
+
+{#if imageSrc}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="view-image-link" onclick={() => (showLightbox = true)}>
+    <img
+      class="view-image"
+      src={imageSrc}
+      alt=""
+      onerror={(e) => ((e.currentTarget as HTMLImageElement).style.display = 'none')}
+    />
+  </div>
+{/if}
+{#if showLightbox && imageSrc}
+  <Lightbox
+    src={imageSrc}
+    alt={item.title}
+    onclose={() => (showLightbox = false)}
+    filePath={item.filePath}
+    mimeType={item.mimeType}
+    filename={item.title || undefined}
+  />
+{/if}

--- a/packages/web/src/components/view-card/NoteView.svelte
+++ b/packages/web/src/components/view-card/NoteView.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import type { NoteItem } from '@inbox-rs/rs-module';
+  import 'highlight.js/styles/github-dark.min.css';
+  import { renderMarkdown } from '../../lib/markdown';
+
+  let { item, titleId }: { item: NoteItem; titleId: string } = $props();
+
+  let renderedBody = $state('');
+
+  // Re-render markdown whenever the note body changes. The id check guards
+  // against a late async render from a previous note overwriting the
+  // current one (the parent may swap the item under us as the user
+  // navigates between cards).
+  $effect(() => {
+    const currentItem = item;
+    renderedBody = '';
+    if (!currentItem.body) return;
+    renderMarkdown(currentItem.body).then((html) => {
+      if (item.id === currentItem.id) renderedBody = html;
+    });
+  });
+</script>
+
+<h2 class="title" id={titleId}>{item.title}</h2>
+
+{#if item.body}
+  <div class="content-block">
+    <span class="content-label">Body</span>
+    {#if renderedBody}
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      <div class="markdown-body">{@html renderedBody}</div>
+    {:else}
+      <p class="content-text">{item.body}</p>
+    {/if}
+  </div>
+{/if}

--- a/packages/web/src/components/view-card/TodoView.svelte
+++ b/packages/web/src/components/view-card/TodoView.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import type { TodoItem } from '@inbox-rs/rs-module';
+
+  let { item, titleId }: { item: TodoItem; titleId: string } = $props();
+</script>
+
+<h2 class="title" id={titleId}>{item.title}</h2>
+
+{#if item.body}
+  <div class="content-block">
+    <span class="content-label">Body</span>
+    <p class="content-text">{item.body}</p>
+  </div>
+{/if}

--- a/packages/web/src/lib/add-entry-modal.test.ts
+++ b/packages/web/src/lib/add-entry-modal.test.ts
@@ -2,6 +2,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   canCaptureTodo,
+  formatRecordingTimer,
+  getFileExtension,
   loadMarkdownEditorComponent,
   makeUnfiledTodo,
   shouldLoadMarkdownEditor,
@@ -104,5 +106,48 @@ describe('collection picker todo capture rules', () => {
 
   it('keeps the collection picker visible for non-todo refs', () => {
     expect(shouldShowCollectionPicker(false, 'note', false)).toBe(true);
+  });
+});
+
+describe('getFileExtension', () => {
+  it('returns the dotted suffix for typical filenames', () => {
+    expect(getFileExtension('photo.png')).toBe('.png');
+    expect(getFileExtension('archive.tar.gz')).toBe('.gz');
+  });
+
+  it('returns an empty string when no extension is present', () => {
+    expect(getFileExtension('Makefile')).toBe('');
+    expect(getFileExtension('')).toBe('');
+  });
+
+  it('treats a trailing dot as a zero-length extension', () => {
+    // Edge case: "foo." technically has an extension that is the empty
+    // string. Document the current behaviour so callers don't rely on a
+    // different reading.
+    expect(getFileExtension('foo.')).toBe('.');
+  });
+
+  it('treats a leading dot as the extension on dotfiles', () => {
+    // ".bashrc" has no actual extension, but lastIndexOf returns 0, so
+    // the function reports the entire name as the extension. This
+    // matches the old in-modal helper exactly; keeping the test here
+    // freezes the contract.
+    expect(getFileExtension('.bashrc')).toBe('.bashrc');
+  });
+});
+
+describe('formatRecordingTimer', () => {
+  it('renders zero seconds as 0:00', () => {
+    expect(formatRecordingTimer(0)).toBe('0:00');
+  });
+
+  it('zero-pads the seconds component', () => {
+    expect(formatRecordingTimer(5)).toBe('0:05');
+    expect(formatRecordingTimer(65)).toBe('1:05');
+  });
+
+  it('does not zero-pad the minutes component', () => {
+    expect(formatRecordingTimer(599)).toBe('9:59');
+    expect(formatRecordingTimer(600)).toBe('10:00');
   });
 });

--- a/packages/web/src/lib/add-entry-modal.ts
+++ b/packages/web/src/lib/add-entry-modal.ts
@@ -1,5 +1,54 @@
-import type { InboxItemType, TodoItem } from '@inbox-rs/rs-module';
+import type { InboxItem, InboxItemType, TodoItem } from '@inbox-rs/rs-module';
 import type { Component } from 'svelte';
+
+/**
+ * Context passed by the AddEntryModal shell to a per-type form's `buildItem`
+ * function. The shell owns the id/createdAt allocation so the same identity
+ * survives an edit, and so that the modal's "Save" action can reach into the
+ * form for a finished item without the form needing to know about storage.
+ */
+export interface BuildItemContext {
+  id: string;
+  createdAt: string;
+  isEdit: boolean;
+  editItem?: InboxItem;
+}
+
+/**
+ * What a per-type form returns from `buildItem`. `fileData` is the binary
+ * payload to pass alongside the metadata-only item to `storeItem`. Returning
+ * `null` is a soft cancel — the form is in a state where save is meaningless
+ * (e.g. an image form with no file picked and no existing file to keep).
+ */
+export interface BuildItemResult {
+  item: InboxItem;
+  fileData?: ArrayBuffer;
+}
+
+/**
+ * Callable a per-type form exposes to the modal shell via $bindable. The
+ * shell calls this once on Save; per-type forms keep their own UI state and
+ * just translate it into an InboxItem when asked.
+ */
+export type BuildItemFn = (
+  ctx: BuildItemContext,
+) => Promise<BuildItemResult | null> | BuildItemResult | null;
+
+/** Get a filename's extension including the leading dot (or '' if none). */
+export function getFileExtension(filename: string): string {
+  const dot = filename.lastIndexOf('.');
+  return dot >= 0 ? filename.slice(dot) : '';
+}
+
+/**
+ * Format a recording timer as `m:ss`. Used by both the Add Audio form and
+ * any other place that might want to surface elapsed seconds in mm:ss.
+ */
+export function formatRecordingTimer(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
 
 const SUBMITTABLE_INPUT_TYPES = new Set([
   'text',

--- a/packages/web/src/lib/build-item.test.ts
+++ b/packages/web/src/lib/build-item.test.ts
@@ -1,0 +1,601 @@
+// @vitest-environment jsdom
+import type {
+  AudioItem,
+  BookmarkItem,
+  DocumentItem,
+  EmailItem,
+  ImageItem,
+  TodoItem,
+} from '@inbox-rs/rs-module';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type BuildContext,
+  buildAudioItem,
+  buildBookmarkItem,
+  buildDocumentItem,
+  buildEmailItem,
+  buildImageItem,
+  buildNoteItem,
+  buildTodoItem,
+} from './build-item';
+
+const FIXED_NOW = '2026-04-30T12:00:00.000Z';
+
+beforeEach(() => {
+  // Pin Date so completedAt stamping is deterministic.
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(FIXED_NOW));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const ctx = (overrides: Partial<BuildContext> = {}): BuildContext => ({
+  id: overrides.id ?? 'item-1',
+  createdAt: overrides.createdAt ?? '2026-04-29T08:00:00.000Z',
+  editItem: overrides.editItem,
+});
+
+describe('buildBookmarkItem', () => {
+  it('creates a new bookmark with title falling back to URL', () => {
+    const result = buildBookmarkItem(ctx(), {
+      url: 'https://example.com/article',
+      title: '',
+      description: '',
+    });
+
+    expect(result.fileData).toBeUndefined();
+    expect(result.item).toEqual({
+      id: 'item-1',
+      type: 'bookmark',
+      title: 'https://example.com/article',
+      url: 'https://example.com/article',
+      description: undefined,
+      createdAt: '2026-04-29T08:00:00.000Z',
+    });
+  });
+
+  it('uses the provided title when present and trims empty descriptions', () => {
+    const result = buildBookmarkItem(ctx(), {
+      url: 'https://example.com',
+      title: 'Best Article',
+      description: '   ',
+    });
+
+    expect((result.item as BookmarkItem).title).toBe('Best Article');
+    // Whitespace-only is left as-is by the form (it's a non-empty string),
+    // documenting current behaviour. If we ever want to trim, do it in the
+    // builder so this test guards the change.
+    expect((result.item as BookmarkItem).description).toBe('   ');
+  });
+
+  it('preserves extension-fetched metadata across edits', () => {
+    const editItem: BookmarkItem = {
+      id: 'item-1',
+      type: 'bookmark',
+      title: 'Old Title',
+      url: 'https://example.com',
+      createdAt: '2026-04-29T08:00:00.000Z',
+      favicon: 'https://example.com/favicon.ico',
+      ogImage: 'https://example.com/og.png',
+      siteName: 'Example',
+      body: 'embedded tweet text',
+      filePath: 'files/abc.png',
+      mimeType: 'image/png',
+    };
+
+    const result = buildBookmarkItem(ctx({ editItem }), {
+      url: 'https://example.com',
+      title: 'New Title',
+      description: 'note',
+    });
+
+    expect(result.item).toMatchObject({
+      title: 'New Title',
+      description: 'note',
+      favicon: 'https://example.com/favicon.ico',
+      ogImage: 'https://example.com/og.png',
+      siteName: 'Example',
+      body: 'embedded tweet text',
+      filePath: 'files/abc.png',
+      mimeType: 'image/png',
+    });
+  });
+
+  it('does not pull metadata from a non-bookmark editItem', () => {
+    // Defensive: parent shell normally hands in a same-type editItem, but
+    // we still guard against type-cross contamination in the builder.
+    const editItem = {
+      id: 'item-1',
+      type: 'note',
+      title: 'Some note',
+      body: 'body',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    } as const;
+
+    const result = buildBookmarkItem(ctx({ editItem }), {
+      url: 'https://example.com',
+      title: 'New',
+      description: '',
+    });
+
+    expect((result.item as BookmarkItem).body).toBeUndefined();
+    expect((result.item as BookmarkItem).filePath).toBeUndefined();
+  });
+});
+
+describe('buildNoteItem', () => {
+  it('falls back to first 50 chars of body when title is empty', () => {
+    const longBody = 'a'.repeat(80);
+    const result = buildNoteItem(ctx(), {
+      title: '',
+      body: longBody,
+      description: '',
+    });
+
+    expect(result.item.title).toBe('a'.repeat(50));
+    expect((result.item as { body: string }).body).toBe(longBody);
+  });
+
+  it('keeps body verbatim and converts empty description to undefined', () => {
+    const result = buildNoteItem(ctx(), {
+      title: 'Title',
+      body: 'Some body',
+      description: '',
+    });
+
+    expect(result.item).toMatchObject({
+      type: 'note',
+      title: 'Title',
+      body: 'Some body',
+      description: undefined,
+    });
+  });
+});
+
+describe('buildImageItem', () => {
+  it('returns null when neither a file nor an editItem image is available', async () => {
+    const result = await buildImageItem(ctx(), {
+      title: '',
+      description: '',
+      file: null,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('builds a fresh image with a new files/{id}.{ext} path', async () => {
+    const file = new File(['hello'], 'photo.png', { type: 'image/png' });
+    const result = await buildImageItem(ctx({ id: 'img-1' }), {
+      title: '',
+      description: '',
+      file,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.fileData).toBeInstanceOf(ArrayBuffer);
+    expect(result?.fileData?.byteLength).toBe(5);
+    expect(result?.item).toMatchObject({
+      type: 'image',
+      title: 'photo.png',
+      filePath: 'files/img-1.png',
+      mimeType: 'image/png',
+      description: undefined,
+    });
+  });
+
+  it('reuses the existing filePath when replacing the bytes during edit', async () => {
+    const editItem: ImageItem = {
+      id: 'img-1',
+      type: 'image',
+      title: 'Old',
+      filePath: 'files/img-1-original.png',
+      mimeType: 'image/png',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    };
+    const replacement = new File(['xyz'], 'replacement.jpg', {
+      type: 'image/jpeg',
+    });
+
+    const result = await buildImageItem(ctx({ id: 'img-1', editItem }), {
+      title: 'New title',
+      description: '',
+      file: replacement,
+    });
+
+    expect((result?.item as ImageItem).filePath).toBe(
+      'files/img-1-original.png',
+    );
+    expect((result?.item as ImageItem).mimeType).toBe('image/jpeg');
+    expect((result?.item as ImageItem).title).toBe('New title');
+  });
+
+  it('returns a metadata-only update when editing without replacing the file', async () => {
+    const editItem: ImageItem = {
+      id: 'img-1',
+      type: 'image',
+      title: 'Old',
+      filePath: 'files/img-1.png',
+      mimeType: 'image/png',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    };
+
+    const result = await buildImageItem(ctx({ id: 'img-1', editItem }), {
+      title: 'New',
+      description: 'a new caption',
+      file: null,
+    });
+
+    expect(result?.fileData).toBeUndefined();
+    expect(result?.item).toMatchObject({
+      filePath: 'files/img-1.png', // preserved
+      title: 'New',
+      description: 'a new caption',
+    });
+  });
+});
+
+describe('buildAudioItem', () => {
+  it('picks .webm extension for a webm-typed recording', async () => {
+    const blob = new Blob(['audio'], { type: 'audio/webm; codecs=opus' });
+
+    const result = await buildAudioItem(ctx({ id: 'rec-1' }), {
+      title: '',
+      body: '',
+      description: '',
+      file: null,
+      recordedBlob: blob,
+      recordingDuration: 12,
+      transcript: '',
+    });
+
+    expect((result?.item as AudioItem).filePath).toBe('files/rec-1.webm');
+    expect((result?.item as AudioItem).mimeType).toBe(
+      'audio/webm; codecs=opus',
+    );
+    expect((result?.item as AudioItem).duration).toBe(12);
+  });
+
+  it('picks .mp4 extension when the blob is mp4-typed', async () => {
+    const blob = new Blob(['audio'], { type: 'audio/mp4' });
+
+    const result = await buildAudioItem(ctx({ id: 'rec-2' }), {
+      title: '',
+      body: '',
+      description: '',
+      file: null,
+      recordedBlob: blob,
+      recordingDuration: 0,
+      transcript: '',
+    });
+
+    expect((result?.item as AudioItem).filePath).toBe('files/rec-2.mp4');
+    // Zero duration means "didn't measure" — collapse to undefined so the
+    // schema doesn't end up with a literal 0 second clip.
+    expect((result?.item as AudioItem).duration).toBeUndefined();
+  });
+
+  it('falls back to .ogg extension for unknown blob types', async () => {
+    const blob = new Blob(['audio'], { type: 'audio/something-weird' });
+
+    const result = await buildAudioItem(ctx({ id: 'rec-3' }), {
+      title: '',
+      body: '',
+      description: '',
+      file: null,
+      recordedBlob: blob,
+      recordingDuration: 5,
+      transcript: '',
+    });
+
+    expect((result?.item as AudioItem).filePath).toBe('files/rec-3.ogg');
+  });
+
+  it('uses transcript as title and body when both are empty', async () => {
+    const blob = new Blob(['audio'], { type: 'audio/webm' });
+
+    const result = await buildAudioItem(ctx({ id: 'rec-4' }), {
+      title: '',
+      body: '',
+      description: '',
+      file: null,
+      recordedBlob: blob,
+      recordingDuration: 0,
+      transcript: 'Hello there general Kenobi',
+      // transcript is the captured speech-to-text result; we want it to
+      // surface as the default title without forcing the user to type one.
+    });
+
+    expect((result?.item as AudioItem).title).toBe(
+      'Hello there general Kenobi',
+    );
+    expect((result?.item as AudioItem).body).toBe('Hello there general Kenobi');
+    expect((result?.item as AudioItem).transcribed).toBe(true);
+  });
+
+  it('defaults title to "Audio" when no transcript or user input is available', async () => {
+    const blob = new Blob(['audio'], { type: 'audio/webm' });
+
+    const result = await buildAudioItem(ctx(), {
+      title: '',
+      body: '',
+      description: '',
+      file: null,
+      recordedBlob: blob,
+      recordingDuration: 0,
+      transcript: '',
+    });
+
+    expect((result?.item as AudioItem).title).toBe('Audio');
+    // No transcript and no user-typed body → don't lie that it was
+    // transcribed. The recorder ran, but we have nothing to show.
+    expect((result?.item as AudioItem).transcribed).toBe(true);
+  });
+
+  it('uses uploaded file extension when no recording is present', async () => {
+    const file = new File(['audio'], 'memo.m4a', { type: 'audio/mp4' });
+
+    const result = await buildAudioItem(ctx({ id: 'rec-5' }), {
+      title: 'My memo',
+      body: '',
+      description: '',
+      file,
+      recordedBlob: null,
+      recordingDuration: 0,
+      transcript: '',
+    });
+
+    expect((result?.item as AudioItem).filePath).toBe('files/rec-5.m4a');
+    expect((result?.item as AudioItem).mimeType).toBe('audio/mp4');
+  });
+
+  it('returns null when neither recording, file, nor edit-target is set', async () => {
+    const result = await buildAudioItem(ctx(), {
+      title: '',
+      body: '',
+      description: '',
+      file: null,
+      recordedBlob: null,
+      recordingDuration: 0,
+      transcript: '',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns metadata-only update on edit without re-uploading bytes', async () => {
+    const editItem: AudioItem = {
+      id: 'rec-6',
+      type: 'audio',
+      title: 'Old title',
+      filePath: 'files/rec-6.webm',
+      mimeType: 'audio/webm',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    };
+
+    const result = await buildAudioItem(ctx({ id: 'rec-6', editItem }), {
+      title: 'New title',
+      body: 'New body',
+      description: 'desc',
+      file: null,
+      recordedBlob: null,
+      recordingDuration: 0,
+      transcript: '',
+    });
+
+    expect(result?.fileData).toBeUndefined();
+    expect(result?.item).toMatchObject({
+      filePath: 'files/rec-6.webm',
+      title: 'New title',
+      body: 'New body',
+      description: 'desc',
+    });
+  });
+});
+
+describe('buildDocumentItem', () => {
+  it('returns null without a file or edit target', async () => {
+    expect(
+      await buildDocumentItem(ctx(), {
+        title: '',
+        description: '',
+        file: null,
+      }),
+    ).toBeNull();
+  });
+
+  it('captures fileSize and fileName from the picked file', async () => {
+    const file = new File(['hello'], 'report.pdf', {
+      type: 'application/pdf',
+    });
+
+    const result = await buildDocumentItem(ctx({ id: 'doc-1' }), {
+      title: '',
+      description: '',
+      file,
+    });
+
+    expect(result?.item).toMatchObject({
+      type: 'document',
+      filePath: 'files/doc-1.pdf',
+      mimeType: 'application/pdf',
+      fileSize: 5,
+      fileName: 'report.pdf',
+      title: 'report.pdf',
+    });
+  });
+
+  it('reuses the existing filePath on replacement edit', async () => {
+    const editItem: DocumentItem = {
+      id: 'doc-1',
+      type: 'document',
+      title: 'Old',
+      filePath: 'files/doc-1.pdf',
+      mimeType: 'application/pdf',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    };
+
+    const file = new File(['hi'], 'updated.pdf', {
+      type: 'application/pdf',
+    });
+
+    const result = await buildDocumentItem(ctx({ id: 'doc-1', editItem }), {
+      title: '',
+      description: '',
+      file,
+    });
+
+    expect((result?.item as DocumentItem).filePath).toBe('files/doc-1.pdf');
+  });
+});
+
+describe('buildEmailItem', () => {
+  it('falls back to "Untitled email" when subject is blank', () => {
+    const result = buildEmailItem(ctx(), {
+      title: '',
+      body: 'Hello world',
+      from: '',
+      notes: '',
+    });
+
+    expect((result.item as EmailItem).title).toBe('Untitled email');
+    expect((result.item as EmailItem).from).toBeUndefined();
+    expect((result.item as EmailItem).notes).toBeUndefined();
+    expect((result.item as EmailItem).messageUrl).toBeUndefined();
+  });
+
+  it('preserves messageUrl from edit target', () => {
+    const editItem: EmailItem = {
+      id: 'mail-1',
+      type: 'email',
+      title: 'Hello',
+      body: 'orig',
+      messageUrl: 'mid:abc@example.com',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    };
+
+    const result = buildEmailItem(ctx({ id: 'mail-1', editItem }), {
+      title: 'Hello',
+      body: 'updated',
+      from: 'sender@example.com',
+      notes: '',
+    });
+
+    expect(result.item).toMatchObject({
+      title: 'Hello',
+      body: 'updated',
+      from: 'sender@example.com',
+      messageUrl: 'mid:abc@example.com',
+    });
+  });
+
+  it('does not preserve messageUrl when crossing types', () => {
+    const editItem = {
+      id: 'note-1',
+      type: 'note',
+      title: 'Old note',
+      body: 'note body',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    } as const;
+
+    const result = buildEmailItem(ctx({ editItem }), {
+      title: 'New email',
+      body: 'b',
+      from: '',
+      notes: '',
+    });
+
+    expect((result.item as EmailItem).messageUrl).toBeUndefined();
+  });
+});
+
+describe('buildTodoItem', () => {
+  it('stamps completedAt on a fresh false→true completion', () => {
+    const result = buildTodoItem(ctx({ id: 'todo-1' }), {
+      title: 'Buy milk',
+      body: '',
+      description: '',
+      completed: true,
+    });
+
+    expect((result.item as TodoItem).completed).toBe(true);
+    expect((result.item as TodoItem).completedAt).toBe(FIXED_NOW);
+    expect((result.item as TodoItem).isTodo).toBe(true);
+  });
+
+  it('preserves the historical completedAt when re-saving an already-completed todo', () => {
+    const editItem: TodoItem = {
+      id: 'todo-1',
+      type: 'todo',
+      title: 'Buy milk',
+      completed: true,
+      completedAt: '2025-12-01T00:00:00.000Z',
+      isTodo: true,
+      createdAt: '2025-11-30T00:00:00.000Z',
+    };
+
+    const result = buildTodoItem(ctx({ id: 'todo-1', editItem }), {
+      title: 'Buy milk (and bread)',
+      body: '',
+      description: '',
+      completed: true,
+    });
+
+    expect((result.item as TodoItem).completedAt).toBe(
+      '2025-12-01T00:00:00.000Z',
+    );
+  });
+
+  it('keeps the historical completedAt even when the user unchecks completed', () => {
+    // Regression guard: a previous refactor draft cleared completedAt on
+    // uncheck, which silently lost completion history. We intentionally
+    // pass the old timestamp through so downstream UI can still surface
+    // "previously completed at <time>" if it wants to.
+    const editItem: TodoItem = {
+      id: 'todo-1',
+      type: 'todo',
+      title: 'Buy milk',
+      completed: true,
+      completedAt: '2025-12-01T00:00:00.000Z',
+      isTodo: true,
+      createdAt: '2025-11-30T00:00:00.000Z',
+    };
+
+    const result = buildTodoItem(ctx({ id: 'todo-1', editItem }), {
+      title: 'Buy milk',
+      body: '',
+      description: '',
+      completed: false,
+    });
+
+    expect((result.item as TodoItem).completed).toBe(false);
+    expect((result.item as TodoItem).completedAt).toBe(
+      '2025-12-01T00:00:00.000Z',
+    );
+  });
+
+  it('leaves completedAt undefined when neither the form nor the edit target had completion', () => {
+    const result = buildTodoItem(ctx(), {
+      title: 'New todo',
+      body: '',
+      description: '',
+      completed: false,
+    });
+
+    expect((result.item as TodoItem).completed).toBe(false);
+    expect((result.item as TodoItem).completedAt).toBeUndefined();
+  });
+
+  it('coerces empty body and description to undefined', () => {
+    const result = buildTodoItem(ctx(), {
+      title: 'Title',
+      body: '',
+      description: '',
+      completed: false,
+    });
+
+    expect((result.item as TodoItem).body).toBeUndefined();
+    expect((result.item as TodoItem).description).toBeUndefined();
+  });
+});

--- a/packages/web/src/lib/build-item.ts
+++ b/packages/web/src/lib/build-item.ts
@@ -1,0 +1,307 @@
+/**
+ * Pure per-item-type builders that translate the AddEntryModal's per-type
+ * form state into a fully-formed `InboxItem` (plus optional `fileData` for
+ * binary types). Pulled out of the Svelte form components so the
+ * field-shaping rules — title fallbacks, edit-time metadata preservation,
+ * file extension picking, completedAt stamping — can be unit-tested
+ * without mounting the UI.
+ *
+ * Each function takes a `ctx` (id/createdAt/editItem) plus a typed `data`
+ * bag of the form's own state. Synchronous types return `BuildItemResult`
+ * directly; file-backed types are async because they have to materialise
+ * `arrayBuffer()` from a `File` or `Blob`. Functions that can fail in a
+ * non-error way (e.g. an Image form with no file picked and no existing
+ * file to keep) return `null` — the caller treats that as "save is a
+ * no-op right now".
+ */
+
+import type {
+  AudioItem,
+  BookmarkItem,
+  DocumentItem,
+  EmailItem,
+  ImageItem,
+  InboxItem,
+  NoteItem,
+  TodoItem,
+} from '@inbox-rs/rs-module';
+import { type BuildItemResult, getFileExtension } from './add-entry-modal';
+
+export interface BuildContext {
+  id: string;
+  createdAt: string;
+  editItem?: InboxItem;
+}
+
+export interface BookmarkFormData {
+  url: string;
+  title: string;
+  description: string;
+}
+
+export function buildBookmarkItem(
+  ctx: BuildContext,
+  data: BookmarkFormData,
+): BuildItemResult {
+  const bookmark: BookmarkItem = {
+    id: ctx.id,
+    type: 'bookmark',
+    title: data.title || data.url,
+    url: data.url,
+    description: data.description || undefined,
+    createdAt: ctx.createdAt,
+  };
+  // Preserve enrichment metadata fetched by the extension (favicon,
+  // ogImage, siteName, embedded body, downloaded image) — the web form
+  // doesn't surface these fields, so we'd lose them if we didn't copy
+  // them through on edit.
+  if (ctx.editItem && ctx.editItem.type === 'bookmark') {
+    if (ctx.editItem.favicon) bookmark.favicon = ctx.editItem.favicon;
+    if (ctx.editItem.ogImage) bookmark.ogImage = ctx.editItem.ogImage;
+    if (ctx.editItem.siteName) bookmark.siteName = ctx.editItem.siteName;
+    if (ctx.editItem.body) bookmark.body = ctx.editItem.body;
+    if (ctx.editItem.filePath) bookmark.filePath = ctx.editItem.filePath;
+    if (ctx.editItem.mimeType) bookmark.mimeType = ctx.editItem.mimeType;
+  }
+  return { item: bookmark };
+}
+
+export interface NoteFormData {
+  title: string;
+  body: string;
+  description: string;
+}
+
+export function buildNoteItem(
+  ctx: BuildContext,
+  data: NoteFormData,
+): BuildItemResult {
+  const item: NoteItem = {
+    id: ctx.id,
+    type: 'note',
+    title: data.title || data.body.slice(0, 50),
+    body: data.body,
+    description: data.description || undefined,
+    createdAt: ctx.createdAt,
+  };
+  return { item };
+}
+
+export interface ImageFormData {
+  title: string;
+  description: string;
+  file: File | null;
+}
+
+export async function buildImageItem(
+  ctx: BuildContext,
+  data: ImageFormData,
+): Promise<BuildItemResult | null> {
+  if (data.file) {
+    // On edit, reuse the original file path so the new bytes overwrite
+    // the existing storage location instead of leaving the old blob behind.
+    const existingPath =
+      ctx.editItem?.type === 'image' ? ctx.editItem.filePath : undefined;
+    const ext = getFileExtension(data.file.name);
+    const filePath = existingPath || `files/${ctx.id}${ext}`;
+    const fileData = await data.file.arrayBuffer();
+    const item: ImageItem = {
+      id: ctx.id,
+      type: 'image',
+      title: data.title || data.file.name,
+      filePath,
+      mimeType: data.file.type,
+      description: data.description || undefined,
+      createdAt: ctx.createdAt,
+    };
+    return { item, fileData };
+  }
+  if (ctx.editItem && ctx.editItem.type === 'image') {
+    const item: ImageItem = {
+      ...ctx.editItem,
+      title: data.title || ctx.editItem.title,
+      description: data.description || undefined,
+    };
+    return { item };
+  }
+  return null;
+}
+
+export interface AudioFormData {
+  title: string;
+  body: string;
+  description: string;
+  file: File | null;
+  recordedBlob: Blob | null;
+  recordingDuration: number;
+  transcript: string;
+}
+
+export async function buildAudioItem(
+  ctx: BuildContext,
+  data: AudioFormData,
+): Promise<BuildItemResult | null> {
+  if (data.recordedBlob || data.file) {
+    const existingPath =
+      ctx.editItem?.type === 'audio' ? ctx.editItem.filePath : undefined;
+    let filePath: string;
+    let mimeType: string;
+    let duration: number | undefined;
+    let fileData: ArrayBuffer;
+    if (data.recordedBlob) {
+      const ext = data.recordedBlob.type.includes('webm')
+        ? '.webm'
+        : data.recordedBlob.type.includes('mp4')
+          ? '.mp4'
+          : '.ogg';
+      filePath = existingPath || `files/${ctx.id}${ext}`;
+      mimeType = data.recordedBlob.type || 'audio/webm';
+      fileData = await data.recordedBlob.arrayBuffer();
+      duration = data.recordingDuration || undefined;
+    } else if (data.file) {
+      const ext = getFileExtension(data.file.name);
+      filePath = existingPath || `files/${ctx.id}${ext}`;
+      mimeType = data.file.type;
+      fileData = await data.file.arrayBuffer();
+    } else {
+      return null;
+    }
+    const memoBody = data.body || data.transcript || undefined;
+    const autoTitle = data.title || data.transcript || 'Audio';
+    const transcribed =
+      !!(data.recordedBlob || data.transcript || data.body) || undefined;
+    const item: AudioItem = {
+      id: ctx.id,
+      type: 'audio',
+      title: autoTitle,
+      filePath,
+      mimeType,
+      duration,
+      body: memoBody,
+      transcribed,
+      description: data.description || undefined,
+      createdAt: ctx.createdAt,
+    };
+    return { item, fileData };
+  }
+  if (ctx.editItem && ctx.editItem.type === 'audio') {
+    const item: AudioItem = {
+      ...ctx.editItem,
+      title: data.title || ctx.editItem.title,
+      body: data.body || undefined,
+      description: data.description || undefined,
+    };
+    return { item };
+  }
+  return null;
+}
+
+export interface DocumentFormData {
+  title: string;
+  description: string;
+  file: File | null;
+}
+
+export async function buildDocumentItem(
+  ctx: BuildContext,
+  data: DocumentFormData,
+): Promise<BuildItemResult | null> {
+  if (data.file) {
+    const existingPath =
+      ctx.editItem?.type === 'document' ? ctx.editItem.filePath : undefined;
+    const ext = getFileExtension(data.file.name);
+    const filePath = existingPath || `files/${ctx.id}${ext}`;
+    const fileData = await data.file.arrayBuffer();
+    const item: DocumentItem = {
+      id: ctx.id,
+      type: 'document',
+      title: data.title || data.file.name,
+      filePath,
+      mimeType: data.file.type,
+      fileSize: data.file.size,
+      fileName: data.file.name,
+      description: data.description || undefined,
+      createdAt: ctx.createdAt,
+    };
+    return { item, fileData };
+  }
+  if (ctx.editItem && ctx.editItem.type === 'document') {
+    const item: DocumentItem = {
+      ...ctx.editItem,
+      title: data.title || ctx.editItem.title,
+      description: data.description || undefined,
+    };
+    return { item };
+  }
+  return null;
+}
+
+export interface EmailFormData {
+  title: string;
+  body: string;
+  from: string;
+  notes: string;
+}
+
+export function buildEmailItem(
+  ctx: BuildContext,
+  data: EmailFormData,
+): BuildItemResult {
+  // Preserve the mid: URI when editing — this links the captured email
+  // back to the user's mail client and isn't surfaced in the form.
+  const messageUrl =
+    ctx.editItem?.type === 'email' ? ctx.editItem.messageUrl : undefined;
+  const item: EmailItem = {
+    id: ctx.id,
+    type: 'email',
+    title: data.title || 'Untitled email',
+    body: data.body,
+    from: data.from || undefined,
+    notes: data.notes || undefined,
+    messageUrl,
+    createdAt: ctx.createdAt,
+  };
+  return { item };
+}
+
+export interface TodoFormData {
+  title: string;
+  body: string;
+  description: string;
+  completed: boolean;
+}
+
+export function buildTodoItem(
+  ctx: BuildContext,
+  data: TodoFormData,
+): BuildItemResult {
+  // Stamp `completedAt` only on the false→true transition. Otherwise we
+  // pass the editItem's existing value through untouched — including the
+  // case where the user *unchecks* a previously-completed todo, where we
+  // intentionally retain the historical timestamp instead of clearing
+  // it. This matches the pre-refactor behaviour and means downstream
+  // surfaces can still show "last completed at <time>" hints on a
+  // re-opened todo.
+  const wasCompleted =
+    ctx.editItem && 'completed' in ctx.editItem && !!ctx.editItem.completed;
+  const previousCompletedAt =
+    ctx.editItem && 'completedAt' in ctx.editItem
+      ? ctx.editItem.completedAt
+      : undefined;
+  const completedAt =
+    data.completed && !wasCompleted
+      ? new Date().toISOString()
+      : previousCompletedAt;
+  const item: TodoItem = {
+    id: ctx.id,
+    type: 'todo',
+    title: data.title,
+    body: data.body || undefined,
+    completed: data.completed,
+    completedAt,
+    description: data.description || undefined,
+    createdAt: ctx.createdAt,
+    isTodo: true,
+  };
+  return { item };
+}

--- a/packages/web/src/lib/code-indent.test.ts
+++ b/packages/web/src/lib/code-indent.test.ts
@@ -1,5 +1,8 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 import {
+  applyTextState,
+  createCodeKeydownHandler,
   dedentSelection,
   indentSelection,
   insertIndent,
@@ -249,5 +252,240 @@ describe('isOnClosingFence', () => {
   it('returns true for ``` with trailing whitespace', () => {
     const value = '```  ';
     expect(isOnClosingFence(value, value.length)).toBe(true);
+  });
+});
+
+/**
+ * Test helpers for the textarea handler. We construct a real textarea
+ * (jsdom env), populate it with `value`, place the cursor with
+ * `setSelectionRange`, then dispatch a synthetic KeyboardEvent through the
+ * handler. We don't actually mount it in a document because the handler
+ * only reads `currentTarget` from the event.
+ */
+function makeTextarea(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number = selectionStart,
+): HTMLTextAreaElement {
+  const ta = document.createElement('textarea');
+  ta.value = value;
+  ta.setSelectionRange(selectionStart, selectionEnd);
+  return ta;
+}
+
+function makeKeyEvent(
+  ta: HTMLTextAreaElement,
+  init: KeyboardEventInit & { key: string },
+): KeyboardEvent & { _defaultPrevented: boolean } {
+  const event = new KeyboardEvent('keydown', { bubbles: true, ...init });
+  // jsdom's KeyboardEvent doesn't have a writable `currentTarget`. Define
+  // it via Object.defineProperty so the handler can read it.
+  Object.defineProperty(event, 'currentTarget', {
+    value: ta,
+    enumerable: true,
+  });
+  // Track preventDefault for assertions without losing the original side
+  // effect. We splice a flag onto the event itself.
+  let prevented = false;
+  const originalPreventDefault = event.preventDefault.bind(event);
+  event.preventDefault = () => {
+    prevented = true;
+    originalPreventDefault();
+  };
+  Object.defineProperty(event, '_defaultPrevented', {
+    get: () => prevented,
+  });
+  return event as KeyboardEvent & { _defaultPrevented: boolean };
+}
+
+describe('applyTextState', () => {
+  it('writes the new value through setRangeText and fires an input event', () => {
+    const ta = makeTextarea('original', 0);
+    let inputFired = false;
+    ta.addEventListener('input', () => {
+      inputFired = true;
+    });
+
+    applyTextState(ta, {
+      value: 'replaced',
+      selectionStart: 4,
+      selectionEnd: 4,
+    });
+
+    expect(ta.value).toBe('replaced');
+    expect(ta.selectionStart).toBe(4);
+    expect(ta.selectionEnd).toBe(4);
+    expect(inputFired).toBe(true);
+  });
+});
+
+describe('createCodeKeydownHandler — Tab inside a code block', () => {
+  it('inserts a 2-space indent on Tab with no selection', () => {
+    const handler = createCodeKeydownHandler();
+    // Cursor sits inside a fenced block — `isInsideCodeBlock` returns true
+    // because we're past an unclosed opening fence.
+    const ta = makeTextarea('```\nfoo', 7);
+    const e = makeKeyEvent(ta, { key: 'Tab' });
+
+    handler(e);
+
+    expect(e._defaultPrevented).toBe(true);
+    expect(ta.value).toBe('```\nfoo  ');
+  });
+
+  it('indents all lines that overlap the selection', () => {
+    const handler = createCodeKeydownHandler();
+    const ta = makeTextarea('```\nline1\nline2', 4, 15);
+    const e = makeKeyEvent(ta, { key: 'Tab' });
+
+    handler(e);
+
+    expect(ta.value).toBe('```\n  line1\n  line2');
+  });
+
+  it('dedents all selected lines on Shift+Tab', () => {
+    const handler = createCodeKeydownHandler();
+    const ta = makeTextarea('```\n  line1\n  line2', 4, 19);
+    const e = makeKeyEvent(ta, { key: 'Tab', shiftKey: true });
+
+    handler(e);
+
+    expect(ta.value).toBe('```\nline1\nline2');
+  });
+
+  it('does nothing on Tab outside a code block', () => {
+    const handler = createCodeKeydownHandler();
+    // No fences anywhere → handler defers to the browser's native Tab
+    // behaviour (focus next element).
+    const ta = makeTextarea('plain text', 5);
+    const e = makeKeyEvent(ta, { key: 'Tab' });
+
+    handler(e);
+
+    expect(e._defaultPrevented).toBe(false);
+    expect(ta.value).toBe('plain text');
+  });
+});
+
+describe('createCodeKeydownHandler — Enter behaviour', () => {
+  it('preserves leading whitespace inside a code block', () => {
+    const handler = createCodeKeydownHandler();
+    const ta = makeTextarea('```\n    indented', 16);
+    const e = makeKeyEvent(ta, { key: 'Enter' });
+
+    handler(e);
+
+    expect(e._defaultPrevented).toBe(true);
+    expect(ta.value).toBe('```\n    indented\n    ');
+  });
+
+  it('lets Enter pass through on a closing fence so the fence stays on its own line', () => {
+    const handler = createCodeKeydownHandler();
+    const ta = makeTextarea('```\nbody\n```', 12);
+    const e = makeKeyEvent(ta, { key: 'Enter' });
+
+    handler(e);
+
+    // Handler returns without preventDefault so the browser/Svelte input
+    // bind handles the newline as usual. (We can't assert text changes
+    // here because we never dispatched a text-mutating event — the
+    // assertion is just that we didn't intercept the key.)
+    expect(e._defaultPrevented).toBe(false);
+  });
+});
+
+describe('createCodeKeydownHandler — Tab trap state machine', () => {
+  it('Escape unlatches the Tab trap so the next Tab moves focus', () => {
+    const handler = createCodeKeydownHandler();
+    const ta = makeTextarea('```\nfoo', 7);
+
+    handler(makeKeyEvent(ta, { key: 'Escape' }));
+
+    const tabEvent = makeKeyEvent(ta, { key: 'Tab' });
+    handler(tabEvent);
+
+    expect(tabEvent._defaultPrevented).toBe(false);
+    expect(ta.value).toBe('```\nfoo');
+  });
+
+  it('typing a regular key after Escape re-arms the Tab trap', () => {
+    const handler = createCodeKeydownHandler();
+    const ta = makeTextarea('```\nfoo', 7);
+
+    handler(makeKeyEvent(ta, { key: 'Escape' }));
+    // A regular character-producing key signals "user is editing again",
+    // which means the next Tab should indent rather than escape focus.
+    handler(makeKeyEvent(ta, { key: 'a' }));
+
+    const tabEvent = makeKeyEvent(ta, { key: 'Tab' });
+    handler(tabEvent);
+
+    expect(tabEvent._defaultPrevented).toBe(true);
+    expect(ta.value).toBe('```\nfoo  ');
+  });
+
+  it('modifier-only key presses do not re-arm the Tab trap', () => {
+    const handler = createCodeKeydownHandler();
+    const ta = makeTextarea('```\nfoo', 7);
+
+    handler(makeKeyEvent(ta, { key: 'Escape' }));
+    // Plain modifier keys (Shift/Alt/Ctrl/Meta) shouldn't re-arm the trap
+    // — otherwise holding Shift to extend a selection would re-trap Tab.
+    handler(makeKeyEvent(ta, { key: 'Shift' }));
+
+    const tabEvent = makeKeyEvent(ta, { key: 'Tab' });
+    handler(tabEvent);
+
+    expect(tabEvent._defaultPrevented).toBe(false);
+    expect(ta.value).toBe('```\nfoo');
+  });
+
+  it('returns an independent handler per call', () => {
+    // Two textareas, each with their own escape state. Escaping one
+    // shouldn't unlatch the other — that's the whole point of the
+    // factory returning a fresh closure each time.
+    const handlerA = createCodeKeydownHandler();
+    const handlerB = createCodeKeydownHandler();
+    const taA = makeTextarea('```\nfoo', 7);
+    const taB = makeTextarea('```\nbar', 7);
+
+    handlerA(makeKeyEvent(taA, { key: 'Escape' }));
+
+    const tabA = makeKeyEvent(taA, { key: 'Tab' });
+    const tabB = makeKeyEvent(taB, { key: 'Tab' });
+    handlerA(tabA);
+    handlerB(tabB);
+
+    expect(tabA._defaultPrevented).toBe(false);
+    expect(tabB._defaultPrevented).toBe(true);
+  });
+});
+
+describe('createCodeKeydownHandler — alwaysActive', () => {
+  it('indents on Tab even outside a fenced block when alwaysActive is set', () => {
+    const handler = createCodeKeydownHandler({ alwaysActive: true });
+    // Use a string with no space at the cursor so the assertion is
+    // unambiguous: 2 inserted spaces, no pre-existing space adjacency.
+    const ta = makeTextarea('plaintext', 5);
+    const e = makeKeyEvent(ta, { key: 'Tab' });
+
+    handler(e);
+
+    expect(e._defaultPrevented).toBe(true);
+    expect(ta.value).toBe('plain  text');
+  });
+
+  it('keeps preserving indentation on Enter even on closing-fence-shaped content', () => {
+    // With alwaysActive, the closing-fence escape hatch is bypassed —
+    // the entire textarea is treated as code, so Enter always preserves
+    // leading whitespace.
+    const handler = createCodeKeydownHandler({ alwaysActive: true });
+    const ta = makeTextarea('```', 3);
+    const e = makeKeyEvent(ta, { key: 'Enter' });
+
+    handler(e);
+
+    expect(e._defaultPrevented).toBe(true);
+    expect(ta.value).toBe('```\n');
   });
 });

--- a/packages/web/src/lib/code-indent.ts
+++ b/packages/web/src/lib/code-indent.ts
@@ -83,3 +83,80 @@ export function isOnClosingFence(
   const line = value.slice(lineStart, selectionStart);
   return /^\s*```\s*$/.test(line);
 }
+
+/**
+ * Apply a computed TextState to a textarea using setRangeText, which
+ * preserves native undo/redo and auto-fires the input event so any
+ * Svelte `bind:value` stays in sync.
+ */
+export function applyTextState(ta: HTMLTextAreaElement, next: TextState): void {
+  ta.setRangeText(next.value, 0, ta.value.length, 'end');
+  ta.selectionStart = next.selectionStart;
+  ta.selectionEnd = next.selectionEnd;
+  ta.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+/**
+ * Build a keydown handler that auto-indents inside fenced code blocks and
+ * preserves indentation on Enter. Each call returns a fresh closure with its
+ * own `tabTrapped` state so Tab→indent vs. Tab→focus-next decisions are
+ * per-textarea (Escape unlatches the trap, the next regular keypress re-arms
+ * it). Pass `alwaysActive: true` to skip the inside-code-block check —
+ * useful for textareas where the entire content is treated as code.
+ */
+export function createCodeKeydownHandler(
+  opts: { alwaysActive?: boolean } = {},
+): (e: KeyboardEvent) => void {
+  let tabTrapped = true;
+  return function handleKeydown(e: KeyboardEvent) {
+    const ta = e.currentTarget as HTMLTextAreaElement;
+
+    if (e.key === 'Escape') {
+      tabTrapped = false;
+      return;
+    }
+
+    // Any non-modifier key re-enables the Tab trap (user is typing again).
+    if (
+      !e.key.startsWith('Shift') &&
+      !e.key.startsWith('Alt') &&
+      !e.key.startsWith('Control') &&
+      !e.key.startsWith('Meta') &&
+      e.key !== 'Tab' &&
+      e.key !== 'Enter'
+    ) {
+      tabTrapped = true;
+    }
+
+    const active =
+      opts.alwaysActive || isInsideCodeBlock(ta.value, ta.selectionStart);
+    if (!active) return;
+
+    if (e.key === 'Tab' && tabTrapped) {
+      e.preventDefault();
+      const state = {
+        value: ta.value,
+        selectionStart: ta.selectionStart,
+        selectionEnd: ta.selectionEnd,
+      };
+      if (state.selectionStart === state.selectionEnd) {
+        applyTextState(ta, insertIndent(state));
+      } else if (e.shiftKey) {
+        applyTextState(ta, dedentSelection(state));
+      } else {
+        applyTextState(ta, indentSelection(state));
+      }
+    } else if (e.key === 'Enter') {
+      if (!opts.alwaysActive && isOnClosingFence(ta.value, ta.selectionStart))
+        return;
+
+      e.preventDefault();
+      const state = {
+        value: ta.value,
+        selectionStart: ta.selectionStart,
+        selectionEnd: ta.selectionEnd,
+      };
+      applyTextState(ta, insertNewlineWithIndent(state));
+    }
+  };
+}


### PR DESCRIPTION
Closes #86.

## Summary
- Split `AddEntryModal.svelte` and `ViewCardModal.svelte` into a thin shell + per-type components, so each item type's logic lives next to its UI and adding a new type no longer means editing one giant `if/else` block.
- New `packages/web/src/components/add-entry/{Bookmark,Note,Image,Audio,Document,Email,Todo}Form.svelte` — each owns its own state and exposes `canSubmit` + `buildItem` via `$bindable`.
- New `packages/web/src/components/view-card/{Bookmark,Note,Image,Audio,Document,Email,Todo}View.svelte` — each renders its own title, meta, and main content. The shell wraps the dispatch in `{#key item.id}` so per-item state (transcribe flags, blob URLs, lightbox) resets naturally on navigation.

## What stayed in the shell
- AddEntryModal: window-Escape handler, modal chrome, collection picker (with viewport-aware positioning), save flow, action buttons.
- ViewCardModal: header (badge, date, Make Todo / Make Reference), description, share button, delete confirm, move menu, make-todo menu.

## API changes (web internal)
- `lib/add-entry-modal.ts` adds `BuildItemContext`, `BuildItemResult`, `BuildItemFn`, plus tiny `getFileExtension` and `formatRecordingTimer` helpers used by the new forms.
- `lib/code-indent.ts` adds `applyTextState` and a `createCodeKeydownHandler({ alwaysActive? })` factory so forms with code-aware textareas (Note, Todo) can wire up the same keydown semantics without a copy-paste.

## Acceptance criteria
- [x] `AddEntryModal.svelte` materially smaller — script section: 537 → 228 lines.
- [x] `ViewCardModal.svelte` materially smaller — script section: 433 → 336 lines (rest is shared move/make-todo menus + CSS).
- [x] Item-type-specific logic now colocated with its UI in dedicated components.
- [x] Adding a new item type = one Form + one View + a single dispatch line in each shell.
- [x] Existing behavior preserved across all item types (verified against original via diff and a code review pass; one regression — the bookmark `body` content block — was caught and restored in `BookmarkView`).

## Test plan
- [x] `npx biome ci` — clean
- [x] `npm run build --workspace=packages/web` — builds
- [x] `npm test` — 417 unit tests pass across all workspaces (rs-module 67, extension 92, thunderbird 42, web 191, scripts 25)
- [ ] Manual smoke: open Add modal for each of bookmark/note/image/audio/document/email/todo, save a representative item, view it, edit it, delete it
- [ ] Manual smoke: convert a non-todo to a todo (filed and unfiled), and a todo back to a reference
- [ ] Manual smoke: replace the file on an edited image/audio/document
- [ ] CI: e2e PWA smoke (note creation through markdown editor) passes