### PR TITLE
fix(ui): floor form-control font-size at 1rem to prevent iOS Safari zoom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ rs-data/
 # Extension build outputs (already covered by dist/, listed explicitly for clarity)
 *.xpi
 
+# Source-archive tarballs produced for Firefox AMO / Mozilla addon review.
+# Generated on demand; never tracked.
+packages/*/inbox-rs-src.tar.gz
+
 # Dev-only download staging area (copied into dist/ during build)
 packages/web/public/downloads/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,17 +73,25 @@ npm run build:extension  # Build browser extension only
 
 ## Pre-commit checks
 
-> **Always run lint and tests before committing.** Both must pass.
+> **Always run `npm run check` and `npm run test` before committing.** Both
+> must pass.
 >
 > ```bash
-> npm run lint   # biome lint — must report zero warnings/errors
-> npm run test   # full vitest suite across all workspaces
+> npm run check   # biome check — lint + format + organize-imports
+> npm run test    # full vitest suite across all workspaces
 > ```
 >
-> If either fails, fix the underlying issue and re-run. Don't `--no-verify`
-> past a failing hook and don't commit "I'll fix it in the next push" — the
-> next push is harder to land cleanly. CI will catch this anyway, so failing
-> locally just costs you a round-trip.
+> Use `npm run check`, **not** `npm run lint`. `biome lint` only runs the
+> linter and skips the formatter and import-sort passes — CI runs
+> `npx biome ci` (≈ `biome check`), so a passing `npm run lint` doesn't mean
+> CI will pass. If `npm run check` flags formatting or import-order issues,
+> `npx biome check --write` will auto-fix the safe ones; re-run `npm run
+> check` afterwards to confirm.
+>
+> If either step fails, fix the underlying issue and re-run. Don't
+> `--no-verify` past a failing hook and don't commit "I'll fix it in the
+> next push" — the next push is harder to land cleanly. CI will catch this
+> anyway, so failing locally just costs you a round-trip.
 
 ## Styling Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,16 +71,30 @@ npm run build:extension  # Build browser extension only
 - **No Node.js-only dependencies in runtime code.** Packages like `onnxruntime-node` must be optional — the app runs in-browser only.
 - Target both Chrome and Firefox for the extension.
 
+## Pre-commit checks
+
+> **Always run lint and tests before committing.** Both must pass.
+>
+> ```bash
+> npm run lint   # biome lint — must report zero warnings/errors
+> npm run test   # full vitest suite across all workspaces
+> ```
+>
+> If either fails, fix the underlying issue and re-run. Don't `--no-verify`
+> past a failing hook and don't commit "I'll fix it in the next push" — the
+> next push is harder to land cleanly. CI will catch this anyway, so failing
+> locally just costs you a round-trip.
+
 ## Styling Rules
 
 ### Form controls: never below 1rem
 
-Every CSS rule that applies to an `<input>`, `<textarea>`, or `<select>` must
-declare `font-size` at **`1rem` (16px) or larger**. iOS Safari auto-zooms the
-viewport when a focused form control's computed font-size is below 16px, and
-that zoom doesn't reset on blur — it persists and breaks the layout.
+CSS rules targeting `<input>`, `<textarea>`, or `<select>` must never set
+`font-size` below **`1rem` (16px)**. iOS Safari auto-zooms the viewport when
+a focused form control's computed font-size is below 16px, and that zoom
+doesn't reset on blur — it persists and breaks the layout.
 
-This applies to:
+The rule applies to:
 
 - Element selectors: `input`, `textarea`, `select`, and any compound (e.g.
   `input:focus`, `input::placeholder`, `input[type='text']`).
@@ -91,9 +105,18 @@ This applies to:
 Checkboxes, radios, and file inputs don't trigger the iOS zoom, but the floor
 applies repo-wide for consistency.
 
-Enforced by `packages/web/src/lib/input-font-size.test.ts` — that test scans
+If a form control omits `font-size` entirely it inherits from the root,
+which `packages/web/src/styles/global.css` sets to 16px (17px on narrow
+viewports) — so inheritance is safe and is the preferred default. Add an
+explicit `font-size` only when you need to override the inherited value;
+when you do, keep it `>= 1rem`.
+
+Enforced by `packages/web/src/lib/input-font-size.test.ts`. The scanner walks
 every `.svelte` and `.css` file under `packages/{web,extension,thunderbird}/src`
-and fails on any matching rule with `font-size` below 1rem (or below 16px /
-100% in equivalent units). When you add a class that's applied to a form
-control but doesn't include `input`/`textarea`/`select` as a token in its
-name (e.g. `.search`), add it to the `NAMED_INPUT_CLASSES` list in that test.
+and fails on any rule whose selector targets a form control AND explicitly
+declares `font-size` below 1rem (or below the equivalent in `px`/`em`/`%`).
+It does **not** flag rules that omit `font-size` (those are safe via
+inheritance) or rules that use the `font` shorthand (we don't use it on form
+controls anywhere). When you add a class that's applied to a form control but
+doesn't include `input`/`textarea`/`select` as a token in its name (e.g.
+`.search`), add it to the `NAMED_INPUT_CLASSES` list in that test.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,8 +123,17 @@ Enforced by `packages/web/src/lib/input-font-size.test.ts`. The scanner walks
 every `.svelte` and `.css` file under `packages/{web,extension,thunderbird}/src`
 and fails on any rule whose selector targets a form control AND explicitly
 declares `font-size` below 1rem (or below the equivalent in `px`/`em`/`%`).
-It does **not** flag rules that omit `font-size` (those are safe via
-inheritance) or rules that use the `font` shorthand (we don't use it on form
-controls anywhere). When you add a class that's applied to a form control but
-doesn't include `input`/`textarea`/`select` as a token in its name (e.g.
-`.search`), add it to the `NAMED_INPUT_CLASSES` list in that test.
+It does **not** flag:
+
+- Rules that omit `font-size` — safe via inheritance from the 16px root.
+- Rules that use the `font` shorthand — we don't use it on form controls
+  anywhere.
+- Values that are CSS-wide keywords (`inherit`, `initial`, `unset`, etc.).
+- `var(--…)` custom-property values — we don't statically resolve the
+  cascade, so the detector treats them as compliant. The codebase has zero
+  uses of `font-size: var(…)` on form controls today; **don't introduce
+  one** unless you can guarantee the variable never resolves below 1rem.
+
+When you add a class that's applied to a form control but doesn't include
+`input`/`textarea`/`select` as a token in its name (e.g. `.search`), add it
+to the `NAMED_INPUT_CLASSES` list in that test.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,30 @@ npm run build:extension  # Build browser extension only
 - **No server-side code.** Everything runs in the browser.
 - **No Node.js-only dependencies in runtime code.** Packages like `onnxruntime-node` must be optional — the app runs in-browser only.
 - Target both Chrome and Firefox for the extension.
+
+## Styling Rules
+
+### Form controls: never below 1rem
+
+Every CSS rule that applies to an `<input>`, `<textarea>`, or `<select>` must
+declare `font-size` at **`1rem` (16px) or larger**. iOS Safari auto-zooms the
+viewport when a focused form control's computed font-size is below 16px, and
+that zoom doesn't reset on blur — it persists and breaks the layout.
+
+This applies to:
+
+- Element selectors: `input`, `textarea`, `select`, and any compound (e.g.
+  `input:focus`, `input::placeholder`, `input[type='text']`).
+- Class selectors that are applied to a form control in the markup, e.g.
+  `.search`, `.abbrev-input`, `.code-input`, `.quick-add input`.
+- `:global(...)` wrappers used inside scoped Svelte styles.
+
+Checkboxes, radios, and file inputs don't trigger the iOS zoom, but the floor
+applies repo-wide for consistency.
+
+Enforced by `packages/web/src/lib/input-font-size.test.ts` — that test scans
+every `.svelte` and `.css` file under `packages/{web,extension,thunderbird}/src`
+and fails on any matching rule with `font-size` below 1rem (or below 16px /
+100% in equivalent units). When you add a class that's applied to a form
+control but doesn't include `input`/`textarea`/`select` as a token in its
+name (e.g. `.search`), add it to the `NAMED_INPUT_CLASSES` list in that test.

--- a/packages/extension/manifest.firefox.json
+++ b/packages/extension/manifest.firefox.json
@@ -3,15 +3,8 @@
   "name": "Inbox RS",
   "version": "2.1.5",
   "description": "Save links, text, and more to your remoteStorage inbox.",
-  "permissions": [
-    "contextMenus",
-    "activeTab",
-    "storage",
-    "identity"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["contextMenus", "activeTab", "storage", "identity"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Inbox RS",
@@ -22,9 +15,7 @@
     }
   },
   "background": {
-    "scripts": [
-      "service-worker.js"
-    ],
+    "scripts": ["service-worker.js"],
     "type": "module"
   },
   "browser_specific_settings": {
@@ -32,21 +23,15 @@
       "id": "inbox-rs@silverbucket.net",
       "strict_min_version": "126.0",
       "data_collection_permissions": {
-        "required": [
-          "none"
-        ],
+        "required": ["none"],
         "optional": []
       }
     }
   },
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content-metadata.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["content-metadata.js"],
       "run_at": "document_idle"
     }
   ],

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -3,15 +3,8 @@
   "name": "Inbox RS",
   "version": "2.1.5",
   "description": "Save links, text, and more to your remoteStorage inbox.",
-  "permissions": [
-    "contextMenus",
-    "activeTab",
-    "storage",
-    "identity"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["contextMenus", "activeTab", "storage", "identity"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Inbox RS",
@@ -27,12 +20,8 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content-metadata.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["content-metadata.js"],
       "run_at": "document_idle"
     }
   ],

--- a/packages/extension/src/popup/Popup.svelte
+++ b/packages/extension/src/popup/Popup.svelte
@@ -278,7 +278,8 @@
     padding: 0.5rem 0.75rem;
     color: var(--text);
     font-family: inherit;
-    font-size: 0.85rem;
+    /* Keep at >=1rem to avoid iOS Safari focus-zoom on touch devices. */
+    font-size: 1rem;
     outline: none;
     resize: vertical;
   }

--- a/packages/thunderbird/manifest.json
+++ b/packages/thunderbird/manifest.json
@@ -9,12 +9,7 @@
       "strict_min_version": "128.0"
     }
   },
-  "permissions": [
-    "messagesRead",
-    "storage",
-    "identity",
-    "<all_urls>"
-  ],
+  "permissions": ["messagesRead", "storage", "identity", "<all_urls>"],
   "message_display_action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Save to Inbox RS",
@@ -26,9 +21,7 @@
     }
   },
   "background": {
-    "scripts": [
-      "background.js"
-    ],
+    "scripts": ["background.js"],
     "type": "module"
   },
   "options_ui": {

--- a/packages/thunderbird/src/popup/Popup.svelte
+++ b/packages/thunderbird/src/popup/Popup.svelte
@@ -169,7 +169,8 @@
     padding: 0.5rem 0.75rem;
     color: var(--text);
     font-family: inherit;
-    font-size: 0.85rem;
+    /* Keep at >=1rem to avoid iOS Safari focus-zoom on touch devices. */
+    font-size: 1rem;
     outline: none;
     resize: vertical;
   }

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -557,7 +557,8 @@
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     padding: 0.5rem 0.75rem;
-    font-size: 0.85rem;
+    /* Keep at >=1rem to avoid iOS Safari focus-zoom on touch devices. */
+    font-size: 1rem;
     color: var(--text);
     font-family: inherit;
     resize: vertical;
@@ -571,7 +572,9 @@
   }
 
   .form :global(input[type='file']) {
-    font-size: 0.85rem;
+    /* Keep at >=1rem for consistency with the other form controls. iOS doesn't
+       zoom on file inputs specifically, but the floor applies repo-wide. */
+    font-size: 1rem;
     color: var(--text-muted);
   }
 
@@ -585,7 +588,9 @@
 
   .form :global(.code-input) {
     font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
-    font-size: 0.8rem;
+    /* `.code-input` is applied to a <textarea>; keep >=1rem to avoid iOS
+       Safari focus-zoom on touch devices. */
+    font-size: 1rem;
     line-height: 1.5;
     tab-size: 2;
   }

--- a/packages/web/src/components/CollectionFormModal.svelte
+++ b/packages/web/src/components/CollectionFormModal.svelte
@@ -141,7 +141,8 @@
     border-radius: var(--radius-sm);
     color: var(--text);
     padding: 0.5rem 0.65rem;
-    font-size: 0.9rem;
+    /* Keep at >=1rem to avoid iOS Safari focus-zoom on touch devices. */
+    font-size: 1rem;
     font-family: inherit;
     cursor: pointer;
   }

--- a/packages/web/src/components/CollectionItemPicker.svelte
+++ b/packages/web/src/components/CollectionItemPicker.svelte
@@ -116,7 +116,9 @@
     border-radius: var(--radius-sm);
     color: var(--text);
     padding: 0.5rem 0.65rem;
-    font-size: 0.9rem;
+    /* `.search` is applied to an <input>; keep >=1rem to avoid iOS Safari
+       focus-zoom on touch devices. */
+    font-size: 1rem;
     font-family: inherit;
     margin-bottom: 0.75rem;
   }

--- a/packages/web/src/components/EntityFormModal.svelte
+++ b/packages/web/src/components/EntityFormModal.svelte
@@ -200,7 +200,8 @@
     border-radius: var(--radius-sm);
     color: var(--text);
     padding: 0.5rem 0.65rem;
-    font-size: 0.9rem;
+    /* Keep at >=1rem to avoid iOS Safari focus-zoom on touch devices. */
+    font-size: 1rem;
     font-family: inherit;
     resize: vertical;
   }

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -457,7 +457,8 @@
     border: 1px solid var(--accent);
     background: var(--accent-subtle);
     color: var(--accent);
-    font-size: 0.85rem;
+    /* Keep at >=1rem to avoid iOS Safari focus-zoom on touch devices. */
+    font-size: 1rem;
     font-weight: 700;
     text-align: center;
     text-transform: uppercase;
@@ -720,7 +721,8 @@
     border-radius: var(--radius-sm);
     padding: 0.4rem 0.6rem;
     color: var(--text);
-    font-size: 0.82rem;
+    /* Keep at >=1rem to avoid iOS Safari focus-zoom on touch devices. */
+    font-size: 1rem;
     outline: none;
     transition: border-color 150ms;
     width: 100%;

--- a/packages/web/src/lib/input-font-size.test.ts
+++ b/packages/web/src/lib/input-font-size.test.ts
@@ -6,9 +6,14 @@ import { describe, expect, it } from 'vitest';
 /*
  * iOS Safari auto-zooms the viewport when a focused <input>/<textarea>/<select>
  * has a computed font-size below 16px (1rem at the 16px root default), and
- * that zoom doesn't reset on blur — it persists and breaks the layout. This
- * test enforces a repo-wide floor: every CSS rule that targets a form control
- * must declare font-size at >= 1rem.
+ * that zoom doesn't reset on blur — it persists and breaks the layout.
+ *
+ * What this test enforces: every CSS rule that targets a form control AND
+ * explicitly declares `font-size` must declare it at >= 1rem. Rules that omit
+ * `font-size` entirely (and therefore inherit from the root, which the app
+ * sets to 16px in `global.css`) are NOT flagged. Rules that set the size via
+ * the `font` shorthand are also NOT flagged — we don't currently use the
+ * shorthand for form controls anywhere in the repo.
  *
  * See AGENTS.md → "Form controls: never below 1rem".
  */
@@ -82,10 +87,11 @@ function stripCssComments(css: string): string {
 function svelteStyleChunks(source: string): CssChunk[] {
   const chunks: CssChunk[] = [];
   const re = /<style\b[^>]*>([\s\S]*?)<\/style>/g;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(source)) !== null) {
+  let m = re.exec(source);
+  while (m !== null) {
     const bodyOffset = m.index + m[0].indexOf(m[1]);
     chunks.push({ text: m[1], offset: bodyOffset });
+    m = re.exec(source);
   }
   return chunks;
 }
@@ -105,28 +111,30 @@ function findViolations(
   const violations: Violation[] = [];
   const css = stripCssComments(chunk.text);
   const ruleRe = /([^{}\s][^{}]*?)\s*\{([^{}]*)\}/g;
-  let m: RegExpExecArray | null;
-  while ((m = ruleRe.exec(css)) !== null) {
+  let m = ruleRe.exec(css);
+  while (m !== null) {
     const selector = m[1].trim();
-    if (selector.startsWith('@')) continue;
-    if (!selectorTargetsFormControl(selector)) continue;
-
-    const body = m[2];
-    const fsRe = /font-size\s*:\s*([^;}]+?)\s*(?:!important)?\s*(?:;|$)/gi;
-    let fs: RegExpExecArray | null;
-    while ((fs = fsRe.exec(body)) !== null) {
-      const value = fs[1].trim();
-      if (!isBelow1rem(value)) continue;
-      const declAbsOffset =
-        chunk.offset + m.index + m[0].indexOf(body) + fs.index;
-      const line = source.slice(0, declAbsOffset).split('\n').length;
-      violations.push({
-        file,
-        line,
-        selector,
-        declaration: `font-size: ${value}`,
-      });
+    if (!selector.startsWith('@') && selectorTargetsFormControl(selector)) {
+      const body = m[2];
+      const fsRe = /font-size\s*:\s*([^;}]+?)\s*(?:!important)?\s*(?:;|$)/gi;
+      let fs = fsRe.exec(body);
+      while (fs !== null) {
+        const value = fs[1].trim();
+        if (isBelow1rem(value)) {
+          const declAbsOffset =
+            chunk.offset + m.index + m[0].indexOf(body) + fs.index;
+          const line = source.slice(0, declAbsOffset).split('\n').length;
+          violations.push({
+            file,
+            line,
+            selector,
+            declaration: `font-size: ${value}`,
+          });
+        }
+        fs = fsRe.exec(body);
+      }
     }
+    m = ruleRe.exec(css);
   }
   return violations;
 }
@@ -142,7 +150,7 @@ function findFileViolations(file: string): Violation[] {
 }
 
 describe('form-control font-size floor (iOS Safari focus-zoom prevention)', () => {
-  it('every input/textarea/select rule has font-size >= 1rem', () => {
+  it('no form-control rule explicitly declares font-size below 1rem', () => {
     const files = SCAN_DIRS.flatMap((d) => collectStyleFiles(d));
     const violations = files.flatMap(findFileViolations);
     const formatted = violations.map(
@@ -151,8 +159,8 @@ describe('form-control font-size floor (iOS Safari focus-zoom prevention)', () =
     );
     expect(
       formatted,
-      'Form-control font-size must be >= 1rem to avoid iOS Safari focus-zoom.\n' +
-        'See AGENTS.md → "Form controls: never below 1rem".\n' +
+      'Form-control rules must not declare font-size below 1rem (iOS Safari ' +
+        'focus-zoom).\nSee AGENTS.md → "Form controls: never below 1rem".\n' +
         `Violations:\n  ${formatted.join('\n  ')}`,
     ).toEqual([]);
   });

--- a/packages/web/src/lib/input-font-size.test.ts
+++ b/packages/web/src/lib/input-font-size.test.ts
@@ -1,0 +1,259 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/*
+ * iOS Safari auto-zooms the viewport when a focused <input>/<textarea>/<select>
+ * has a computed font-size below 16px (1rem at the 16px root default), and
+ * that zoom doesn't reset on blur — it persists and breaks the layout. This
+ * test enforces a repo-wide floor: every CSS rule that targets a form control
+ * must declare font-size at >= 1rem.
+ *
+ * See AGENTS.md → "Form controls: never below 1rem".
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// __dirname = .../packages/web/src/lib  →  repo root is four levels up.
+const REPO_ROOT = join(__dirname, '..', '..', '..', '..');
+
+const SCAN_DIRS = [
+  join(REPO_ROOT, 'packages/web/src'),
+  join(REPO_ROOT, 'packages/extension/src'),
+  join(REPO_ROOT, 'packages/thunderbird/src'),
+];
+
+/*
+ * Class-only selectors that are applied to <input>/<textarea>/<select> in the
+ * markup but don't include an input-element token in their name. Add an entry
+ * here when you introduce such a class. Selectors like `.abbrev-input` and
+ * `.code-input` are handled automatically by INPUT_ELEMENT_RE (both contain
+ * `\binput\b` because `-` is a word boundary).
+ */
+const NAMED_INPUT_CLASSES = ['search'];
+
+const INPUT_ELEMENT_RE = /\b(?:input|textarea|select)\b/;
+
+function selectorTargetsFormControl(selector: string): boolean {
+  if (INPUT_ELEMENT_RE.test(selector)) return true;
+  return NAMED_INPUT_CLASSES.some((cls) =>
+    new RegExp(`\\.${cls}\\b`).test(selector),
+  );
+}
+
+function isBelow1rem(value: string): boolean {
+  const trimmed = value.trim().toLowerCase();
+  if (/^(inherit|initial|unset|revert|currentcolor)$/.test(trimmed)) return false;
+  if (trimmed.startsWith('var(')) return false;
+  const m = trimmed.match(/^(\d+(?:\.\d+)?)(rem|em|px|%)?$/);
+  if (!m) return false;
+  const num = Number.parseFloat(m[1]);
+  const unit = m[2] ?? '';
+  if (unit === 'px') return num < 16;
+  if (unit === '%') return num < 100;
+  return num < 1;
+}
+
+function collectStyleFiles(dir: string, accum: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist' || entry === '.git') continue;
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      collectStyleFiles(fullPath, accum);
+    } else if (fullPath.endsWith('.svelte') || fullPath.endsWith('.css')) {
+      accum.push(fullPath);
+    }
+  }
+  return accum;
+}
+
+interface CssChunk {
+  text: string;
+  offset: number;
+}
+
+function stripCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, (match) =>
+    match.replace(/[^\n]/g, ' '),
+  );
+}
+
+function svelteStyleChunks(source: string): CssChunk[] {
+  const chunks: CssChunk[] = [];
+  const re = /<style\b[^>]*>([\s\S]*?)<\/style>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(source)) !== null) {
+    const bodyOffset = m.index + m[0].indexOf(m[1]);
+    chunks.push({ text: m[1], offset: bodyOffset });
+  }
+  return chunks;
+}
+
+interface Violation {
+  file: string;
+  line: number;
+  selector: string;
+  declaration: string;
+}
+
+function findViolations(
+  file: string,
+  source: string,
+  chunk: CssChunk,
+): Violation[] {
+  const violations: Violation[] = [];
+  const css = stripCssComments(chunk.text);
+  const ruleRe = /([^{}\s][^{}]*?)\s*\{([^{}]*)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = ruleRe.exec(css)) !== null) {
+    const selector = m[1].trim();
+    if (selector.startsWith('@')) continue;
+    if (!selectorTargetsFormControl(selector)) continue;
+
+    const body = m[2];
+    const fsRe = /font-size\s*:\s*([^;}]+?)\s*(?:!important)?\s*(?:;|$)/gi;
+    let fs: RegExpExecArray | null;
+    while ((fs = fsRe.exec(body)) !== null) {
+      const value = fs[1].trim();
+      if (!isBelow1rem(value)) continue;
+      const declAbsOffset =
+        chunk.offset + m.index + m[0].indexOf(body) + fs.index;
+      const line = source.slice(0, declAbsOffset).split('\n').length;
+      violations.push({
+        file,
+        line,
+        selector,
+        declaration: `font-size: ${value}`,
+      });
+    }
+  }
+  return violations;
+}
+
+function findFileViolations(file: string): Violation[] {
+  const source = readFileSync(file, 'utf-8');
+  if (file.endsWith('.svelte')) {
+    return svelteStyleChunks(source).flatMap((chunk) =>
+      findViolations(file, source, chunk),
+    );
+  }
+  return findViolations(file, source, { text: source, offset: 0 });
+}
+
+describe('form-control font-size floor (iOS Safari focus-zoom prevention)', () => {
+  it('every input/textarea/select rule has font-size >= 1rem', () => {
+    const files = SCAN_DIRS.flatMap((d) => collectStyleFiles(d));
+    const violations = files.flatMap(findFileViolations);
+    const formatted = violations.map(
+      (v) =>
+        `${relative(REPO_ROOT, v.file)}:${v.line}  {${v.selector}}  ${v.declaration}`,
+    );
+    expect(
+      formatted,
+      'Form-control font-size must be >= 1rem to avoid iOS Safari focus-zoom.\n' +
+        'See AGENTS.md → "Form controls: never below 1rem".\n' +
+        `Violations:\n  ${formatted.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  describe('detector self-tests', () => {
+    it('selectorTargetsFormControl matches form-control selectors', () => {
+      const positives = [
+        'input',
+        'textarea',
+        'select',
+        'input, textarea',
+        'input:focus',
+        'input::placeholder',
+        "input[type='text']",
+        ".form :global(input[type='text'])",
+        '.connect-form input',
+        '.abbrev-input',
+        '.code-input',
+        '.search',
+        '.search:focus',
+      ];
+      for (const sel of positives) {
+        expect(selectorTargetsFormControl(sel), sel).toBe(true);
+      }
+    });
+
+    it('selectorTargetsFormControl ignores non-form-control selectors', () => {
+      const negatives = [
+        '.btn-primary',
+        '.title',
+        'h2',
+        '.modal',
+        '.add-strip',
+      ];
+      for (const sel of negatives) {
+        expect(selectorTargetsFormControl(sel), sel).toBe(false);
+      }
+    });
+
+    it('isBelow1rem treats values correctly', () => {
+      expect(isBelow1rem('0.85rem')).toBe(true);
+      expect(isBelow1rem('0.99rem')).toBe(true);
+      expect(isBelow1rem('1rem')).toBe(false);
+      expect(isBelow1rem('1.0rem')).toBe(false);
+      expect(isBelow1rem('1.1rem')).toBe(false);
+      expect(isBelow1rem('15px')).toBe(true);
+      expect(isBelow1rem('15.9px')).toBe(true);
+      expect(isBelow1rem('16px')).toBe(false);
+      expect(isBelow1rem('17px')).toBe(false);
+      expect(isBelow1rem('0.9em')).toBe(true);
+      expect(isBelow1rem('1em')).toBe(false);
+      expect(isBelow1rem('99%')).toBe(true);
+      expect(isBelow1rem('100%')).toBe(false);
+      expect(isBelow1rem('inherit')).toBe(false);
+      expect(isBelow1rem('initial')).toBe(false);
+      expect(isBelow1rem('var(--font-size)')).toBe(false);
+    });
+
+    it('catches a synthetic rem violation', () => {
+      const css = '.ok-style {} input { font-size: 0.85rem; }';
+      const v = findViolations('fake.svelte', css, { text: css, offset: 0 });
+      expect(v).toHaveLength(1);
+      expect(v[0].selector).toBe('input');
+      expect(v[0].declaration).toBe('font-size: 0.85rem');
+    });
+
+    it('catches a sub-16px violation', () => {
+      const css = 'textarea { font-size: 14px; }';
+      const v = findViolations('fake.svelte', css, { text: css, offset: 0 });
+      expect(v).toHaveLength(1);
+    });
+
+    it('does not flag a 1rem rule', () => {
+      const css = 'input { font-size: 1rem; }';
+      const v = findViolations('fake.svelte', css, { text: css, offset: 0 });
+      expect(v).toEqual([]);
+    });
+
+    it('does not flag font-size on non-form-control rules', () => {
+      const css = '.title { font-size: 0.85rem; }';
+      const v = findViolations('fake.svelte', css, { text: css, offset: 0 });
+      expect(v).toEqual([]);
+    });
+
+    it('honors !important values', () => {
+      const css = 'input { font-size: 0.5rem !important; }';
+      const v = findViolations('fake.svelte', css, { text: css, offset: 0 });
+      expect(v).toHaveLength(1);
+      expect(v[0].declaration).toBe('font-size: 0.5rem');
+    });
+
+    it('handles rules nested inside @media', () => {
+      const css = '@media (max-width: 600px) { input { font-size: 0.7rem; } }';
+      const v = findViolations('fake.svelte', css, { text: css, offset: 0 });
+      expect(v).toHaveLength(1);
+    });
+
+    it('ignores braces inside CSS comments', () => {
+      const css = '/* example: input { font-size: 0.5rem } */ .ok { color: red; }';
+      const v = findViolations('fake.svelte', css, { text: css, offset: 0 });
+      expect(v).toEqual([]);
+    });
+  });
+});

--- a/packages/web/src/lib/input-font-size.test.ts
+++ b/packages/web/src/lib/input-font-size.test.ts
@@ -9,11 +9,24 @@ import { describe, expect, it } from 'vitest';
  * that zoom doesn't reset on blur — it persists and breaks the layout.
  *
  * What this test enforces: every CSS rule that targets a form control AND
- * explicitly declares `font-size` must declare it at >= 1rem. Rules that omit
- * `font-size` entirely (and therefore inherit from the root, which the app
- * sets to 16px in `global.css`) are NOT flagged. Rules that set the size via
- * the `font` shorthand are also NOT flagged — we don't currently use the
- * shorthand for form controls anywhere in the repo.
+ * explicitly declares `font-size` with a numeric literal must declare it at
+ * >= 1rem. The detector intentionally does NOT flag:
+ *
+ * - Rules that omit `font-size` entirely (they inherit from the root, which
+ *   `global.css` sets to 16px / 17px on narrow viewports — safe).
+ * - Rules that set the size via the `font` shorthand. We don't use the
+ *   shorthand for form controls anywhere in the repo today.
+ * - Rules where the value is a CSS-wide keyword (`inherit`, `initial`,
+ *   `unset`, `revert`, `currentcolor`).
+ * - Rules where the value is a `var(--…)` custom property. We can't
+ *   statically resolve the variable's value (or its fallback chain) without
+ *   building a real CSS-cascade evaluator, so any `var()` is treated as
+ *   compliant. This is a real gap — if someone introduces
+ *   `font-size: var(--foo)` on a form control and `--foo` resolves below
+ *   1rem, this test won't catch it. Today the codebase has zero uses of
+ *   `font-size: var(…)` (verified by grep at the time of writing); avoid
+ *   introducing one for a form control unless you can guarantee the variable
+ *   never resolves below 1rem.
  *
  * See AGENTS.md → "Form controls: never below 1rem".
  */

--- a/packages/web/src/lib/input-font-size.test.ts
+++ b/packages/web/src/lib/input-font-size.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -48,7 +48,8 @@ function selectorTargetsFormControl(selector: string): boolean {
 
 function isBelow1rem(value: string): boolean {
   const trimmed = value.trim().toLowerCase();
-  if (/^(inherit|initial|unset|revert|currentcolor)$/.test(trimmed)) return false;
+  if (/^(inherit|initial|unset|revert|currentcolor)$/.test(trimmed))
+    return false;
   if (trimmed.startsWith('var(')) return false;
   const m = trimmed.match(/^(\d+(?:\.\d+)?)(rem|em|px|%)?$/);
   if (!m) return false;
@@ -61,7 +62,8 @@ function isBelow1rem(value: string): boolean {
 
 function collectStyleFiles(dir: string, accum: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {
-    if (entry === 'node_modules' || entry === 'dist' || entry === '.git') continue;
+    if (entry === 'node_modules' || entry === 'dist' || entry === '.git')
+      continue;
     const fullPath = join(dir, entry);
     const stat = statSync(fullPath);
     if (stat.isDirectory()) {
@@ -259,7 +261,8 @@ describe('form-control font-size floor (iOS Safari focus-zoom prevention)', () =
     });
 
     it('ignores braces inside CSS comments', () => {
-      const css = '/* example: input { font-size: 0.5rem } */ .ok { color: red; }';
+      const css =
+        '/* example: input { font-size: 0.5rem } */ .ok { color: red; }';
       const v = findViolations('fake.svelte', css, { text: css, offset: 0 });
       expect(v).toEqual([]);
     });


### PR DESCRIPTION
## Summary
- iOS Safari auto-zooms when a focused `<input>` / `<textarea>` / `<select>` has a computed font-size below 16px, and the zoom doesn't reset on blur. Floors every form-control rule at 1rem (10 rules across 8 files) and locks the constraint in with a vitest scan.
- The previous defensive `@media (pointer: coarse)` rule in `global.css` had a comment claiming `!important` was intentional, but the declaration was missing it. Component-scoped `:global(input[type='text'])` selectors with equal specificity were winning on touch devices, re-introducing the zoom on every add-entry title input. Fixing the floor at the source removes that fragility.
- Adds a "Form controls: never below 1rem" section to `AGENTS.md` documenting the rule, the selectors covered (element, scoped, `:global()`, named classes), and how to extend the test for new class names.

## Files changed (font-size bumps)
| File | Selector | Old → New |
|---|---|---|
| `extension/src/popup/Popup.svelte` | `input, textarea` | `0.85rem` → `1rem` |
| `thunderbird/src/popup/Popup.svelte` | `input, textarea` | `0.85rem` → `1rem` |
| `web/components/EntityFormModal.svelte` | `input, textarea` | `0.9rem` → `1rem` |
| `web/components/AddEntryModal.svelte` | `:global(input[type='text'\|'url'\|textarea])` | `0.85rem` → `1rem` |
| `web/components/AddEntryModal.svelte` | `:global(input[type='file'])` | `0.85rem` → `1rem` |
| `web/components/AddEntryModal.svelte` | `:global(.code-input)` | `0.8rem` → `1rem` |
| `web/components/CollectionFormModal.svelte` | `select` | `0.9rem` → `1rem` |
| `web/components/UserMenu.svelte` | `.abbrev-input` | `0.85rem` → `1rem` |
| `web/components/UserMenu.svelte` | `.connect-form input` | `0.82rem` → `1rem` |
| `web/components/CollectionItemPicker.svelte` | `.search` | `0.9rem` → `1rem` |

## New regression test
`packages/web/src/lib/input-font-size.test.ts` walks every `.svelte`/`.css` under `packages/{web,extension,thunderbird}/src`, parses style blocks (handling `<style>` extraction, `@media` nesting, and CSS comments), and fails on any rule whose selector targets a form control with `font-size < 1rem` (with parallel handling for `px`, `em`, and `%`). Includes 10 detector self-tests so the parser can't silently break and let regressions slip through.

## Test plan
- [x] `npm run test` — all 5 workspaces green (477/477 tests, +11 new).
- [x] `npm run test --workspace=packages/web -- input-font-size` — 11/11 pass.
- [x] Verified the test catches a synthetic violation by temporarily reverting one bump (test failed with file:line + selector + value).
- [ ] Manual smoke on iPhone Safari: tap each title input in the add-entry forms — should not trigger viewport zoom on focus.