### PR TITLE
chore: re-format manifests to satisfy biome ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4224,7 +4224,7 @@
     },
     "packages/extension": {
       "name": "@inbox-rs/extension",
-      "version": "2.1.4",
+      "version": "2.1.6",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "remotestoragejs": "^2.0.0-beta.9",
@@ -4415,7 +4415,7 @@
     },
     "packages/rs-module": {
       "name": "@inbox-rs/rs-module",
-      "version": "2.1.4",
+      "version": "2.1.6",
       "dependencies": {
         "remotestoragejs": "^2.0.0-beta.9",
         "rs-migrate": "^1.0.2"
@@ -4427,7 +4427,7 @@
     },
     "packages/thunderbird": {
       "name": "@inbox-rs/thunderbird",
-      "version": "2.1.4",
+      "version": "2.1.6",
       "dependencies": {
         "@inbox-rs/rs-module": "*"
       },
@@ -4615,7 +4615,7 @@
     },
     "packages/web": {
       "name": "@inbox-rs/web",
-      "version": "2.1.4",
+      "version": "2.1.6",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "@tiptap/core": "^3.22.1",
@@ -4820,7 +4820,7 @@
     },
     "scripts": {
       "name": "@inbox-rs/scripts",
-      "version": "2.1.4",
+      "version": "2.1.6",
       "devDependencies": {
         "vitest": "^4.1.2"
       }

--- a/packages/extension/manifest.firefox.json
+++ b/packages/extension/manifest.firefox.json
@@ -3,15 +3,8 @@
   "name": "Inbox RS",
   "version": "2.1.6",
   "description": "Save links, text, and more to your remoteStorage inbox.",
-  "permissions": [
-    "contextMenus",
-    "activeTab",
-    "storage",
-    "identity"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["contextMenus", "activeTab", "storage", "identity"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Inbox RS",
@@ -22,9 +15,7 @@
     }
   },
   "background": {
-    "scripts": [
-      "service-worker.js"
-    ],
+    "scripts": ["service-worker.js"],
     "type": "module"
   },
   "browser_specific_settings": {
@@ -32,21 +23,15 @@
       "id": "inbox-rs@silverbucket.net",
       "strict_min_version": "126.0",
       "data_collection_permissions": {
-        "required": [
-          "none"
-        ],
+        "required": ["none"],
         "optional": []
       }
     }
   },
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content-metadata.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["content-metadata.js"],
       "run_at": "document_idle"
     }
   ],

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -3,15 +3,8 @@
   "name": "Inbox RS",
   "version": "2.1.6",
   "description": "Save links, text, and more to your remoteStorage inbox.",
-  "permissions": [
-    "contextMenus",
-    "activeTab",
-    "storage",
-    "identity"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["contextMenus", "activeTab", "storage", "identity"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Inbox RS",
@@ -27,12 +20,8 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content-metadata.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["content-metadata.js"],
       "run_at": "document_idle"
     }
   ],

--- a/packages/thunderbird/manifest.json
+++ b/packages/thunderbird/manifest.json
@@ -9,12 +9,7 @@
       "strict_min_version": "128.0"
     }
   },
-  "permissions": [
-    "messagesRead",
-    "storage",
-    "identity",
-    "<all_urls>"
-  ],
+  "permissions": ["messagesRead", "storage", "identity", "<all_urls>"],
   "message_display_action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Save to Inbox RS",
@@ -26,9 +21,7 @@
     }
   },
   "background": {
-    "scripts": [
-      "background.js"
-    ],
+    "scripts": ["background.js"],
     "type": "module"
   },
   "options_ui": {


### PR DESCRIPTION
## Summary
- The v2.1.6 release re-expanded short arrays in the extension and thunderbird manifest JSON files, which biome's formatter wants collapsed onto a single line.
- Re-running `npm run format` collapses them so `npm run check` and `npm run lint` pass again. Same fix as commit 0e078af, since the release script keeps re-expanding these.

## Test plan
- [x] `npm run check` — clean (165 files, 0 errors)
- [x] `npm run lint` — clean (165 files, 0 errors)