### PR TITLE
fix(web): restore quick-add todo and import-export progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,13 @@ rs-data/
 .context/
 .DS_Store
 
+# Per-developer Claude Code overrides. The `*.local` pattern above
+# doesn't match `*.local.json`, so list explicitly. Project-wide
+# `.claude/settings.json` IS committed — only the personal override
+# file is private.
+.claude/settings.local.json
+.claude/settings.local*.json
+
 # Extension build outputs (already covered by dist/, listed explicitly for clarity)
 *.xpi
 

--- a/packages/web/src/components/ImportExportModal.svelte
+++ b/packages/web/src/components/ImportExportModal.svelte
@@ -84,13 +84,19 @@
     return '';
   }
 
-  function _progressPercent(s: ModalState): number {
-    if (s.kind === 'exporting' || s.kind === 'importing') {
-      const p = 'progress' in s ? s.progress : null;
-      if (p && p.total > 0) return Math.round((p.current / p.total) * 100);
+  // A `$derived` rather than a helper function so the value is referenced
+  // as `{progressPercent}` directly in the template — biome's Svelte
+  // parser tracks reactive bindings used in template expressions, but not
+  // function calls inlined inside attribute string templates like
+  // `style="width: {fn(...)}%"`. Using `$derived` keeps the lint rule
+  // useful instead of forcing an override.
+  const progressPercent = $derived.by(() => {
+    if (!state || (state.kind !== 'exporting' && state.kind !== 'importing')) {
+      return 0;
     }
-    return 0;
-  }
+    const p = state.progress;
+    return p.total > 0 ? Math.round((p.current / p.total) * 100) : 0;
+  });
 </script>
 
 <svelte:window onkeydown={onKeydown} />
@@ -113,7 +119,7 @@
         <h3>{state.kind === 'exporting' ? 'Exporting' : 'Importing'}...</h3>
         <p class="progress-label">{progressLabel(state)}</p>
         <div class="progress-bar">
-          <div class="progress-fill" style="width: {progressPercent(state)}%"></div>
+          <div class="progress-fill" style="width: {progressPercent}%"></div>
         </div>
 
       {:else if state.kind === 'done'}

--- a/packages/web/src/components/TodosPage.svelte
+++ b/packages/web/src/components/TodosPage.svelte
@@ -8,6 +8,7 @@
     collections, sortedGroups, groupCollections, appConfig, updateConfig,
   } from '../lib/stores';
   import { canCaptureTodo, makeUnfiledTodo } from '../lib/add-entry-modal';
+  import { autofocus } from '../lib/actions';
   import TodoRow from './TodoRow.svelte';
   import Fab from './Fab.svelte';
 
@@ -61,10 +62,6 @@
     }
   }
   let storedQuickAddId = $state<string | undefined>(readStoredQuickAddId());
-
-  function _focusOnMount(node: HTMLInputElement) {
-    node.focus();
-  }
 
   // Trailing "Other" optgroup — without this, a user with only ungrouped
   // collections would see no options beyond "Unfiled".
@@ -206,7 +203,7 @@
         placeholder={compact ? 'Add a todo…' : 'What needs doing?'}
         aria-label="Todo title"
         disabled={quickSaving}
-        use:focusOnMount
+        use:autofocus
       />
       <!-- Empty-string sentinel maps to undefined (Unfiled) on save. -->
       <select

--- a/tests/e2e/desktop/todos-quick-add.spec.ts
+++ b/tests/e2e/desktop/todos-quick-add.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression: the Todos quick-add composer must render and save.
+ *
+ * History: a biome lint pass renamed `focusOnMount` to `_focusOnMount`
+ * (biome's "intentionally unused" convention) without updating the
+ * `use:focusOnMount` action reference in the template. The result: the
+ * input mount threw `ReferenceError: focusOnMount is not defined`, the
+ * whole `quickAddComposer` snippet failed to render, and the user could
+ * neither see nor use the form. The empty-state path was the only way
+ * to capture a first todo, so brand-new and mobile users were stuck.
+ *
+ * This test exercises the full path — render → type → submit → see —
+ * so any future rename, action-binding break, or save-flow regression
+ * fails here loudly instead of in production.
+ */
+
+import { expect, test } from '../helpers/fixtures';
+import { assertNoConsoleErrors, attachConsoleCapture } from '../helpers/pwa';
+
+test('quick-add composer captures a todo from the empty state', async ({
+  connectedPage,
+  webOrigin,
+}) => {
+  const log = attachConsoleCapture(connectedPage);
+  await connectedPage.goto(`${webOrigin}/#/todos`);
+  await connectedPage.waitForLoadState('networkidle');
+
+  // Empty-state hero variant — the placeholder differs from the compact
+  // (above-list) variant, so this also asserts which branch rendered.
+  const input = connectedPage.getByPlaceholder('What needs doing?');
+  await expect(input).toBeVisible();
+
+  // The action-binding bug manifested as the input never auto-focusing
+  // (and, in fact, the whole snippet failing to mount). Asserting focus
+  // is the cheapest signal that `use:focusOnMount` actually fired.
+  await expect(input).toBeFocused();
+
+  const sentinel = 'playwright-quick-add-α';
+  await input.fill(sentinel);
+
+  // Form submission via Enter exercises the `onsubmit` handler, which is
+  // the same code path the visible "Add" button rides.
+  await input.press('Enter');
+
+  // The todo row carries the title text. Wait long enough for the RS
+  // round-trip; everything before this is in-memory but `storeItem` does
+  // an actual remote PUT.
+  await expect(connectedPage.getByText(sentinel)).toBeVisible({
+    timeout: 10_000,
+  });
+
+  assertNoConsoleErrors(log);
+});

--- a/tests/e2e/desktop/todos-quick-add.spec.ts
+++ b/tests/e2e/desktop/todos-quick-add.spec.ts
@@ -21,7 +21,11 @@
  */
 
 import { expect, test } from '../helpers/fixtures';
-import { assertNoConsoleErrors, attachConsoleCapture, seedRsSession } from '../helpers/pwa';
+import {
+  assertNoConsoleErrors,
+  attachConsoleCapture,
+  seedRsSession,
+} from '../helpers/pwa';
 
 test('quick-add composer captures a todo from the empty state', async ({
   context,

--- a/tests/e2e/desktop/todos-quick-add.spec.ts
+++ b/tests/e2e/desktop/todos-quick-add.spec.ts
@@ -12,27 +12,40 @@
  * This test exercises the full path — render → type → submit → see —
  * so any future rename, action-binding break, or save-flow regression
  * fails here loudly instead of in production.
+ *
+ * Uses `freshRsUser` / `freshRsToken` (per-test) rather than the shared
+ * worker `connectedPage`: the empty-state branch only renders when the
+ * account has zero todos, and we both rely on that *and* create a todo
+ * during the test. A fresh per-test user keeps the assertion stable no
+ * matter what runs alongside this spec.
  */
 
 import { expect, test } from '../helpers/fixtures';
-import { assertNoConsoleErrors, attachConsoleCapture } from '../helpers/pwa';
+import { assertNoConsoleErrors, attachConsoleCapture, seedRsSession } from '../helpers/pwa';
 
 test('quick-add composer captures a todo from the empty state', async ({
-  connectedPage,
+  context,
+  freshRsUser,
+  freshRsToken,
   webOrigin,
 }) => {
-  const log = attachConsoleCapture(connectedPage);
-  await connectedPage.goto(`${webOrigin}/#/todos`);
-  await connectedPage.waitForLoadState('networkidle');
+  await seedRsSession(context, freshRsUser, freshRsToken, {
+    clientOrigin: webOrigin,
+  });
+  const page = await context.newPage();
+  const log = attachConsoleCapture(page);
+
+  await page.goto(`${webOrigin}/#/todos`);
+  await page.waitForLoadState('networkidle');
 
   // Empty-state hero variant — the placeholder differs from the compact
   // (above-list) variant, so this also asserts which branch rendered.
-  const input = connectedPage.getByPlaceholder('What needs doing?');
+  const input = page.getByPlaceholder('What needs doing?');
   await expect(input).toBeVisible();
 
   // The action-binding bug manifested as the input never auto-focusing
   // (and, in fact, the whole snippet failing to mount). Asserting focus
-  // is the cheapest signal that `use:focusOnMount` actually fired.
+  // is the cheapest signal that `use:autofocus` actually fired.
   await expect(input).toBeFocused();
 
   const sentinel = 'playwright-quick-add-α';
@@ -45,7 +58,7 @@ test('quick-add composer captures a todo from the empty state', async ({
   // The todo row carries the title text. Wait long enough for the RS
   // round-trip; everything before this is in-memory but `storeItem` does
   // an actual remote PUT.
-  await expect(connectedPage.getByText(sentinel)).toBeVisible({
+  await expect(page.getByText(sentinel)).toBeVisible({
     timeout: 10_000,
   });
 


### PR DESCRIPTION
## Summary

- A biome lint pass renamed two template-referenced helpers to the `_unused` convention but missed their call sites, throwing `ReferenceError` on every render. Quick-add todo creation broke entirely (worst on mobile, where the empty-state composer is the only first-todo capture path); the import/export progress bar broke too.
- Refactored both sites to patterns biome's Svelte parser already tracks — `use:autofocus` from `lib/actions` (matching every other form in the codebase), and a `$derived` for the progress percent — so the lint rule stays useful and the same false-positive fix can't recur.
- Added an e2e regression test that exercises the empty-state composer end-to-end (render → focus → fill → submit → see the new todo render), so any future break of this path fails the suite instead of shipping silently.

## Root cause

Commit `8e7b9be` (chore: fix all biome lint issues across the codebase) renamed:

- `focusOnMount` → `_focusOnMount` in `TodosPage.svelte` while leaving `use:focusOnMount` in the template.
- `progressPercent` → `_progressPercent` in `ImportExportModal.svelte` while leaving `style="width: {progressPercent(state)}%"` in the template.

Biome's Svelte parser doesn't see `use:` action directive references nor function calls inside attribute string templates, so both helpers were flagged "unused" and the rename slipped through review.

## Why these patterns instead of a biome override

The original suggestion was to add `correctness.noUnusedVariables: off` to the `*.svelte` override. We rejected that — it gives up real coverage to paper over a false positive that only fires for two specific patterns. Aligning with patterns biome already tracks correctly (imported actions, `$derived` reactive values) keeps the rule useful everywhere else.

## Test plan

- [x] `npx biome check` clean (full repo).
- [x] `npm test --workspace=packages/web` — 251 passed.
- [ ] CI runs the new `tests/e2e/desktop/todos-quick-add.spec.ts` against the production preview.
- [ ] Manual: visit `/#/todos` on a fresh account, type into "What needs doing?", press Enter, see the todo appear.
- [ ] Manual: trigger Export Data, watch the progress bar fill (no longer stuck at 0).