### PR TITLE
feat(ui): make FAB the sole todo capture surface on mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4224,7 +4224,7 @@
     },
     "packages/extension": {
       "name": "@inbox-rs/extension",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "remotestoragejs": "^2.0.0-beta.9",
@@ -4415,7 +4415,7 @@
     },
     "packages/rs-module": {
       "name": "@inbox-rs/rs-module",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "dependencies": {
         "remotestoragejs": "^2.0.0-beta.9",
         "rs-migrate": "^1.0.2"
@@ -4427,7 +4427,7 @@
     },
     "packages/thunderbird": {
       "name": "@inbox-rs/thunderbird",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "dependencies": {
         "@inbox-rs/rs-module": "*"
       },
@@ -4615,7 +4615,7 @@
     },
     "packages/web": {
       "name": "@inbox-rs/web",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "@tiptap/core": "^3.22.1",
@@ -4820,7 +4820,7 @@
     },
     "scripts": {
       "name": "@inbox-rs/scripts",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "devDependencies": {
         "vitest": "^4.1.2"
       }

--- a/packages/extension/manifest.firefox.json
+++ b/packages/extension/manifest.firefox.json
@@ -3,15 +3,8 @@
   "name": "Inbox RS",
   "version": "2.1.7",
   "description": "Save links, text, and more to your remoteStorage inbox.",
-  "permissions": [
-    "contextMenus",
-    "activeTab",
-    "storage",
-    "identity"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["contextMenus", "activeTab", "storage", "identity"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Inbox RS",
@@ -22,9 +15,7 @@
     }
   },
   "background": {
-    "scripts": [
-      "service-worker.js"
-    ],
+    "scripts": ["service-worker.js"],
     "type": "module"
   },
   "browser_specific_settings": {
@@ -32,21 +23,15 @@
       "id": "inbox-rs@silverbucket.net",
       "strict_min_version": "126.0",
       "data_collection_permissions": {
-        "required": [
-          "none"
-        ],
+        "required": ["none"],
         "optional": []
       }
     }
   },
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content-metadata.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["content-metadata.js"],
       "run_at": "document_idle"
     }
   ],

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -3,15 +3,8 @@
   "name": "Inbox RS",
   "version": "2.1.7",
   "description": "Save links, text, and more to your remoteStorage inbox.",
-  "permissions": [
-    "contextMenus",
-    "activeTab",
-    "storage",
-    "identity"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["contextMenus", "activeTab", "storage", "identity"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Inbox RS",
@@ -27,12 +20,8 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content-metadata.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["content-metadata.js"],
       "run_at": "document_idle"
     }
   ],

--- a/packages/thunderbird/manifest.json
+++ b/packages/thunderbird/manifest.json
@@ -9,12 +9,7 @@
       "strict_min_version": "128.0"
     }
   },
-  "permissions": [
-    "messagesRead",
-    "storage",
-    "identity",
-    "<all_urls>"
-  ],
+  "permissions": ["messagesRead", "storage", "identity", "<all_urls>"],
   "message_display_action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Save to Inbox RS",
@@ -26,9 +21,7 @@
     }
   },
   "background": {
-    "scripts": [
-      "background.js"
-    ],
+    "scripts": ["background.js"],
     "type": "module"
   },
   "options_ui": {

--- a/packages/web/src/components/TodosPage.svelte
+++ b/packages/web/src/components/TodosPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { InboxItem } from '@inbox-rs/rs-module';
+  import { tick } from 'svelte';
   import { dndzone } from 'svelte-dnd-action';
   import { flip } from 'svelte/animate';
   import { slide, fade } from 'svelte/transition';
@@ -48,6 +49,10 @@
   let quickTitle = $state('');
   let quickSaving = $state(false);
   let quickError = $state('');
+  // Bound from the quick-add input so we can restore focus after a submit
+  // — `disabled` toggling during the save blurs the input, and the first
+  // todo also remounts the input as the page transitions hero → compact.
+  let quickInputEl = $state<HTMLInputElement | undefined>(undefined);
 
   // Quick-add collection target. Stored in localStorage rather than the
   // synced appConfig: it's a per-device preference, and a `config/app`
@@ -107,6 +112,13 @@
       quickError = error instanceof Error ? error.message : 'Failed to add todo';
     } finally {
       quickSaving = false;
+      // Return focus to the input so the user can keep capturing todos in
+      // succession from the keyboard. tick() lets the post-state DOM settle
+      // — the very first todo transitions the page from empty (hero input)
+      // to populated (compact input), remounting the element bind:this
+      // points at. Refocusing before that flip would target a detached node.
+      await tick();
+      quickInputEl?.focus();
     }
   }
 
@@ -204,6 +216,7 @@
         the gate is mainly load-bearing for desktop with existing todos.
       -->
       <input
+        bind:this={quickInputEl}
         type="text"
         bind:value={quickTitle}
         placeholder={compact ? 'Add a todo…' : 'What needs doing?'}

--- a/packages/web/src/components/TodosPage.svelte
+++ b/packages/web/src/components/TodosPage.svelte
@@ -8,7 +8,7 @@
     collections, sortedGroups, groupCollections, appConfig, updateConfig,
   } from '../lib/stores';
   import { canCaptureTodo, makeUnfiledTodo } from '../lib/add-entry-modal';
-  import { autofocus } from '../lib/actions';
+  import { autofocusIf } from '../lib/actions';
   import TodoRow from './TodoRow.svelte';
   import Fab from './Fab.svelte';
 
@@ -197,13 +197,19 @@
         addQuickTodo();
       }}
     >
+      <!--
+        Autofocus only the hero (empty-state) variant. The compact variant
+        renders above an existing list; stealing focus there would interrupt
+        a user trying to scroll or click rows. Mobile is hidden via CSS so
+        the gate is mainly load-bearing for desktop with existing todos.
+      -->
       <input
         type="text"
         bind:value={quickTitle}
         placeholder={compact ? 'Add a todo…' : 'What needs doing?'}
         aria-label="Todo title"
         disabled={quickSaving}
-        use:autofocus
+        use:autofocusIf={!compact}
       />
       <!-- Empty-string sentinel maps to undefined (Unfiled) on save. -->
       <select

--- a/packages/web/src/components/TodosPage.svelte
+++ b/packages/web/src/components/TodosPage.svelte
@@ -8,6 +8,7 @@
     collections, sortedGroups, groupCollections, appConfig, updateConfig,
   } from '../lib/stores';
   import { canCaptureTodo, makeUnfiledTodo } from '../lib/add-entry-modal';
+  import { autofocus } from '../lib/actions';
   import TodoRow from './TodoRow.svelte';
   import Fab from './Fab.svelte';
 
@@ -61,10 +62,6 @@
     }
   }
   let storedQuickAddId = $state<string | undefined>(readStoredQuickAddId());
-
-  function _focusOnMount(node: HTMLInputElement) {
-    node.focus();
-  }
 
   // Trailing "Other" optgroup — without this, a user with only ungrouped
   // collections would see no options beyond "Unfiled".
@@ -206,7 +203,7 @@
         placeholder={compact ? 'Add a todo…' : 'What needs doing?'}
         aria-label="Todo title"
         disabled={quickSaving}
-        use:focusOnMount
+        use:autofocus
       />
       <!-- Empty-string sentinel maps to undefined (Unfiled) on save. -->
       <select
@@ -248,7 +245,10 @@
     <div class="empty-state" in:fade={{ duration: 180 }}>
       <p class="empty-title">Jot a todo</p>
       {@render quickAddComposer(false)}
-      <p class="empty-hint">Capture it now. Organize it later.</p>
+      <p class="empty-hint empty-hint--desktop">Capture it now. Organize it later.</p>
+      <!-- Mobile: the inline composer is hidden in favour of the floating
+           FAB, so the hint needs to point at it. CSS swaps which line shows. -->
+      <p class="empty-hint empty-hint--mobile">Tap + to capture one. Organize it later.</p>
       <!-- Persistent aria-live region — kept in the DOM so screen readers
            reliably announce errors as they appear. The visually-empty state
            collapses via the `:empty` selector below. -->
@@ -525,6 +525,13 @@
     margin: 0;
   }
 
+  /* Mobile-only sibling — hidden by default, revealed in the mobile media
+     query below. Keeps both lines in the DOM so screen readers see only the
+     one that's currently visible. */
+  .empty-hint--mobile {
+    display: none;
+  }
+
   .quick-error {
     margin: 0;
     color: var(--danger);
@@ -542,35 +549,39 @@
     text-align: left;
   }
 
-  /* Mobile-only: reserve room so the fixed-position FAB doesn't float over
-     the last todo when scrolled to the bottom. Desktop renders the add
-     button inline in the toolbar, so no bottom reservation is needed. */
+  /*
+   * Mobile: the floating FAB is the canonical capture surface, and the inline
+   * quick-add composer was eating vertical space that's better spent on the
+   * todo list itself. Hide it (both hero and compact variants) along with its
+   * inline error region, and swap the empty-state hint to one that points at
+   * the FAB. The composer's submit path stays mounted but unreachable, which
+   * is fine — `quickError` only fills when the form is submitted.
+   *
+   * Desktop renders the add button inline in the toolbar, so no
+   * bottom-padding reservation is needed there.
+   */
   @media (max-width: 768px) {
     .todos-page {
       padding-bottom: 5rem;
+    }
+
+    .quick-add,
+    .quick-error--inline {
+      display: none;
+    }
+
+    .empty-hint--desktop {
+      display: none;
+    }
+
+    .empty-hint--mobile {
+      display: block;
     }
   }
 
   @media (max-width: 600px) {
     .todos-page {
       padding-bottom: 4.5rem;
-    }
-
-    .empty-state {
-      align-items: stretch;
-      text-align: left;
-      padding-inline: 0;
-    }
-
-    /* Hero variant stacks vertically on phones; compact stays single-row. */
-    .quick-add:not(.quick-add--compact) {
-      grid-template-columns: 1fr;
-    }
-
-    .quick-add:not(.quick-add--compact) button,
-    .quick-add:not(.quick-add--compact) .quick-add__collection {
-      width: 100%;
-      max-width: none;
     }
   }
 </style>

--- a/packages/web/src/lib/actions.ts
+++ b/packages/web/src/lib/actions.ts
@@ -22,3 +22,26 @@
 export function autofocus(node: HTMLElement) {
   requestAnimationFrame(() => node.focus());
 }
+
+/**
+ * Conditional variant of {@link autofocus}. Focuses the bound element on the
+ * next animation frame only when `enabled` is true.
+ *
+ * Use when the same `<input>` markup is rendered in multiple branches and
+ * only some branches should grab focus on mount — for example, an empty-state
+ * hero composer that should autofocus vs. a compact composer rendered above
+ * an existing list, where stealing focus would interrupt the user.
+ *
+ * Example:
+ * ```svelte
+ * <input use:autofocusIf={!compact} type="text" bind:value={title} />
+ * ```
+ *
+ * Lives here (rather than as a local helper in the consuming component) so
+ * biome's Svelte parser can see the import is used — local helpers
+ * referenced only via `use:` directives are invisible to biome's
+ * unused-variable analysis and get falsely flagged.
+ */
+export function autofocusIf(node: HTMLElement, enabled: boolean) {
+  if (enabled) requestAnimationFrame(() => node.focus());
+}


### PR DESCRIPTION
## Summary

The Todos page rendered two parallel capture surfaces on mobile — the floating FAB *and* an inline quick-add composer (input + collection select + Add button). The composer's three-column grid had no mobile breakpoint override, so on a ~360px viewport the input collapsed to ~100px and pushed list rows below the fold for a control most users would skip in favour of the FAB anyway.

This PR keeps both surfaces on desktop (where the composer earns its space and the FAB renders inline) and on mobile collapses to the FAB only.

### Changes

- `TodosPage.svelte`: hide `.quick-add` (both hero and compact variants) plus the `.quick-error--inline` line at `≤768px`. Swap the empty-state hint from "Capture it now. Organize it later." → "Tap + to capture one. Organize it later." so the FAB has a clear textual handoff. Drop the now-irrelevant 600px overrides (`align-items: stretch`, single-column grid, etc.) that only existed to make the composer fit on phones.
- Stale-rename fix: the empty-state input had `use:focusOnMount` but the local function was named `_focusOnMount`, so autofocus never fired. Replaced with the shared `autofocus` action from `lib/actions.ts`, which is rAF-deferred for Safari.
- Fix quick-todo focus


### Behaviour

- **Desktop (>768px):** unchanged. Hero composer in empty state, compact composer above the list, inline `+ New todo` pill in the toolbar.
- **Mobile (≤768px):** no inline composer anywhere. Empty state is title + the new mobile hint + the floating FAB. Populated state goes from the toolbar (count badge) straight into the todo list, with the floating FAB as the sole entry point.

The FAB → `AddEntryModal` → `TodoForm` path remains the only way to capture a todo *with* a body/details on first entry; other details can still be added later via the row → view → edit flow.

## Test plan

- [ ] Desktop wide (>768px): empty state shows hero composer + inline FAB pill; composer autofocuses on page load; submit creates todo.
- [ ] Desktop narrow / mobile (≤768px): empty state shows title + "Tap + to capture one." with floating FAB visible; composer is gone; tapping FAB opens modal.
- [ ] Mobile populated state: list renders directly under the toolbar; no quick-add bar above the list.
- [ ] FAB-modal capture still files into the chosen collection.
- [ ] Per-row "+" still pre-selects the row's collection (unchanged).