### PR TITLE
refactor(web): extract shared collection-todo helpers

### DIFF
--- a/packages/extension/manifest.firefox.json
+++ b/packages/extension/manifest.firefox.json
@@ -3,15 +3,8 @@
   "name": "Inbox RS",
   "version": "2.2.0",
   "description": "Save links, text, and more to your remoteStorage inbox.",
-  "permissions": [
-    "contextMenus",
-    "activeTab",
-    "storage",
-    "identity"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["contextMenus", "activeTab", "storage", "identity"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Inbox RS",
@@ -22,9 +15,7 @@
     }
   },
   "background": {
-    "scripts": [
-      "service-worker.js"
-    ],
+    "scripts": ["service-worker.js"],
     "type": "module"
   },
   "browser_specific_settings": {
@@ -32,21 +23,15 @@
       "id": "inbox-rs@silverbucket.net",
       "strict_min_version": "126.0",
       "data_collection_permissions": {
-        "required": [
-          "none"
-        ],
+        "required": ["none"],
         "optional": []
       }
     }
   },
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content-metadata.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["content-metadata.js"],
       "run_at": "document_idle"
     }
   ],

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -3,15 +3,8 @@
   "name": "Inbox RS",
   "version": "2.2.0",
   "description": "Save links, text, and more to your remoteStorage inbox.",
-  "permissions": [
-    "contextMenus",
-    "activeTab",
-    "storage",
-    "identity"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["contextMenus", "activeTab", "storage", "identity"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Inbox RS",
@@ -27,12 +20,8 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content-metadata.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["content-metadata.js"],
       "run_at": "document_idle"
     }
   ],

--- a/packages/thunderbird/manifest.json
+++ b/packages/thunderbird/manifest.json
@@ -9,12 +9,7 @@
       "strict_min_version": "128.0"
     }
   },
-  "permissions": [
-    "messagesRead",
-    "storage",
-    "identity",
-    "<all_urls>"
-  ],
+  "permissions": ["messagesRead", "storage", "identity", "<all_urls>"],
   "message_display_action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Save to Inbox RS",
@@ -26,9 +21,7 @@
     }
   },
   "background": {
-    "scripts": [
-      "background.js"
-    ],
+    "scripts": ["background.js"],
     "type": "module"
   },
   "options_ui": {

--- a/packages/web/src/components/CollectionTodoTile.svelte
+++ b/packages/web/src/components/CollectionTodoTile.svelte
@@ -4,14 +4,14 @@
   import { slide } from 'svelte/transition';
   import {
     collectionItems, storeItem, deleteItem,
-    appConfig, updateConfig,
+    appConfig, updateConfig, reorderCollectionItems,
   } from '../lib/stores';
   import { cleanForStorage } from '../lib/clean-for-storage';
   import {
-    applyOpenTodoReorder,
     filterCompletedTodos,
     filterOpenTodos,
     filterTodos,
+    spliceOpenTodoOrder,
   } from '../lib/collection-todos';
   import { typeBadge, todoNote } from '../lib/item-utils';
   import AddEntryModal from './AddEntryModal.svelte';
@@ -57,11 +57,12 @@
     const previous = openTodos.map(t => ({ ...t }));
     dndOpen = e.detail.items;
     try {
-      await applyOpenTodoReorder(
-        collection,
+      const newItemIds = spliceOpenTodoOrder(
+        collection.itemIds,
         previous.map(t => t.id),
         dndOpen.map(t => t.id),
       );
+      await reorderCollectionItems(collection.id, newItemIds);
     } catch (error) {
       console.error('Failed to reorder collection todos', error);
       dndOpen = previous;

--- a/packages/web/src/components/CollectionTodoTile.svelte
+++ b/packages/web/src/components/CollectionTodoTile.svelte
@@ -4,9 +4,15 @@
   import { slide } from 'svelte/transition';
   import {
     collectionItems, storeItem, deleteItem,
-    appConfig, updateConfig, reorderCollectionItems,
+    appConfig, updateConfig,
   } from '../lib/stores';
   import { cleanForStorage } from '../lib/clean-for-storage';
+  import {
+    applyOpenTodoReorder,
+    filterCompletedTodos,
+    filterOpenTodos,
+    filterTodos,
+  } from '../lib/collection-todos';
   import { typeBadge, todoNote } from '../lib/item-utils';
   import AddEntryModal from './AddEntryModal.svelte';
 
@@ -17,9 +23,9 @@
   } = $props();
 
   const items = $derived($collectionItems[collection.id] ?? []);
-  const todoItems = $derived(items.filter(i => i.isTodo || i.type === 'todo'));
-  const openTodos = $derived(todoItems.filter(t => !t.completed));
-  const completedTodos = $derived(todoItems.filter(t => t.completed));
+  const todoItems = $derived(filterTodos(items));
+  const openTodos = $derived(filterOpenTodos(todoItems));
+  const completedTodos = $derived(filterCompletedTodos(todoItems));
 
   // Collapse state persists in appConfig.expandedCollections. Collections
   // default to collapsed; expanding a tile adds its id to the set.
@@ -50,13 +56,12 @@
   async function handleDndFinalize(e: CustomEvent<{ items: Array<InboxItem & { id: string }> }>) {
     const previous = openTodos.map(t => ({ ...t }));
     dndOpen = e.detail.items;
-    // Preserve order of completed todos and non-todo items
-    const openIds = new Set(openTodos.map(t => t.id));
-    const newOpenIds = dndOpen.map(t => t.id);
-    const rest = collection.itemIds.filter(id => !openIds.has(id));
-    const newItemIds = [...newOpenIds, ...rest];
     try {
-      await reorderCollectionItems(collection.id, newItemIds);
+      await applyOpenTodoReorder(
+        collection,
+        previous.map(t => t.id),
+        dndOpen.map(t => t.id),
+      );
     } catch (error) {
       console.error('Failed to reorder collection todos', error);
       dndOpen = previous;

--- a/packages/web/src/components/CollectionView.svelte
+++ b/packages/web/src/components/CollectionView.svelte
@@ -4,17 +4,17 @@
     collectionItems,
     deleteItem,
     sortedGroups, moveCollectionToGroup,
-    appConfig, updateConfig,
+    appConfig, updateConfig, reorderCollectionItems,
     groups,
   } from '../lib/stores';
   import { makeTodo } from '../lib/item-utils';
   import {
-    applyOpenTodoReorder,
     filterCompletedTodos,
     filterOpenTodos,
     filterReferenceItems,
     filterTodos,
     sortCompletedTodosByCompletedAt,
+    spliceOpenTodoOrder,
   } from '../lib/collection-todos';
   import { slide, fade } from 'svelte/transition';
   import { flip } from 'svelte/animate';
@@ -94,11 +94,12 @@
     const previous = openTodos.map(t => ({ ...t }));
     dndOpen = e.detail.items;
     try {
-      await applyOpenTodoReorder(
-        collection,
+      const newItemIds = spliceOpenTodoOrder(
+        collection.itemIds,
         previous.map(t => t.id),
         dndOpen.map(t => t.id),
       );
+      await reorderCollectionItems(collection.id, newItemIds);
     } catch (error) {
       console.error('Failed to reorder collection todos', error);
       dndOpen = previous;

--- a/packages/web/src/components/CollectionView.svelte
+++ b/packages/web/src/components/CollectionView.svelte
@@ -4,10 +4,18 @@
     collectionItems,
     deleteItem,
     sortedGroups, moveCollectionToGroup,
-    appConfig, updateConfig, reorderCollectionItems,
+    appConfig, updateConfig,
     groups,
   } from '../lib/stores';
   import { makeTodo } from '../lib/item-utils';
+  import {
+    applyOpenTodoReorder,
+    filterCompletedTodos,
+    filterOpenTodos,
+    filterReferenceItems,
+    filterTodos,
+    sortCompletedTodosByCompletedAt,
+  } from '../lib/collection-todos';
   import { slide, fade } from 'svelte/transition';
   import { flip } from 'svelte/animate';
   import { dndzone } from 'svelte-dnd-action';
@@ -29,15 +37,12 @@
   // reference items (the existing masonry grid below) so the page keeps all
   // data in context while the flat Todos page shows the cross-collection view.
   const items = $derived($collectionItems[collection.id] ?? []);
-  const todoItems = $derived(items.filter(i => i.isTodo || i.type === 'todo'));
-  const openTodos = $derived(todoItems.filter(t => !t.completed));
+  const todoItems = $derived(filterTodos(items));
+  const openTodos = $derived(filterOpenTodos(todoItems));
   const completedTodos = $derived(
-    todoItems.filter(t => t.completed)
-      .slice()
-      .sort((a, b) => new Date(b.completedAt ?? b.createdAt).getTime()
-                     - new Date(a.completedAt ?? a.createdAt).getTime())
+    sortCompletedTodosByCompletedAt(filterCompletedTodos(todoItems))
   );
-  const referenceItems = $derived(items.filter(i => !i.isTodo && i.type !== 'todo'));
+  const referenceItems = $derived(filterReferenceItems(items));
 
   // Shared group lookup for TodoRow styling — collection's own color takes
   // priority, but we also supply the group so the pill colour degrades
@@ -88,14 +93,12 @@
   async function handleDndFinalize(e: CustomEvent<{ items: Array<InboxItem & { id: string }> }>) {
     const previous = openTodos.map(t => ({ ...t }));
     dndOpen = e.detail.items;
-    const newOpenIds = dndOpen.map(t => t.id);
     try {
-      // Splice the new open-todo order into itemIds while preserving the
-      // relative order of completed todos and reference items — otherwise a
-      // drag of a single open todo would also scramble the refs grid.
-      const openIds = new Set(openTodos.map(t => t.id));
-      const rest = collection.itemIds.filter(id => !openIds.has(id));
-      await reorderCollectionItems(collection.id, [...newOpenIds, ...rest]);
+      await applyOpenTodoReorder(
+        collection,
+        previous.map(t => t.id),
+        dndOpen.map(t => t.id),
+      );
     } catch (error) {
       console.error('Failed to reorder collection todos', error);
       dndOpen = previous;

--- a/packages/web/src/lib/collection-todos.test.ts
+++ b/packages/web/src/lib/collection-todos.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import type { InboxItem, NoteItem, TodoItem } from '@inbox-rs/rs-module';
 import { describe, expect, it } from 'vitest';
 import {

--- a/packages/web/src/lib/collection-todos.test.ts
+++ b/packages/web/src/lib/collection-todos.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import type { InboxItem, NoteItem, TodoItem } from '@inbox-rs/rs-module';
+import { describe, expect, it } from 'vitest';
+import {
+  filterCompletedTodos,
+  filterOpenTodos,
+  filterReferenceItems,
+  filterTodos,
+  sortCompletedTodosByCompletedAt,
+  spliceOpenTodoOrder,
+} from './collection-todos';
+
+function todo(id: string, completed: boolean, completedAt?: string): TodoItem {
+  return {
+    id,
+    type: 'todo',
+    title: id,
+    isTodo: true,
+    completed,
+    completedAt,
+    createdAt: '2026-04-01T00:00:00.000Z',
+  };
+}
+
+function flaggedTodo(id: string): NoteItem {
+  // A note item that's been promoted to a todo via isTodo=true (reference
+  // items can be converted in place, so the union allows the flag without a
+  // type change).
+  return {
+    id,
+    type: 'note',
+    title: id,
+    body: '',
+    isTodo: true,
+    completed: false,
+    createdAt: '2026-04-01T00:00:00.000Z',
+  } as NoteItem;
+}
+
+function ref(id: string): NoteItem {
+  return {
+    id,
+    type: 'note',
+    title: id,
+    body: '',
+    createdAt: '2026-04-01T00:00:00.000Z',
+  };
+}
+
+describe('filterTodos', () => {
+  it('includes items with type "todo" and items flagged isTodo', () => {
+    const items: InboxItem[] = [
+      todo('t1', false),
+      flaggedTodo('t2'),
+      ref('r1'),
+    ];
+    expect(filterTodos(items).map((i) => i.id)).toEqual(['t1', 't2']);
+  });
+});
+
+describe('filterOpenTodos / filterCompletedTodos', () => {
+  it('partitions todos by completed flag', () => {
+    const todos: InboxItem[] = [
+      todo('t1', false),
+      todo('t2', true, '2026-04-02T00:00:00.000Z'),
+      todo('t3', false),
+    ];
+    expect(filterOpenTodos(todos).map((t) => t.id)).toEqual(['t1', 't3']);
+    expect(filterCompletedTodos(todos).map((t) => t.id)).toEqual(['t2']);
+  });
+});
+
+describe('filterReferenceItems', () => {
+  it('excludes both type=todo and isTodo-flagged items', () => {
+    const items: InboxItem[] = [
+      ref('r1'),
+      todo('t1', false),
+      flaggedTodo('t2'),
+      ref('r2'),
+    ];
+    expect(filterReferenceItems(items).map((i) => i.id)).toEqual(['r1', 'r2']);
+  });
+});
+
+describe('sortCompletedTodosByCompletedAt', () => {
+  it('returns most recently completed first; falls back to createdAt when completedAt is missing', () => {
+    const completed: InboxItem[] = [
+      { ...todo('a', true, '2026-04-02T00:00:00.000Z') },
+      { ...todo('b', true, '2026-04-05T00:00:00.000Z') },
+      // Missing completedAt — should sort by createdAt (which is 2026-04-01).
+      { ...todo('c', true), completedAt: undefined },
+    ];
+    expect(sortCompletedTodosByCompletedAt(completed).map((t) => t.id)).toEqual(
+      ['b', 'a', 'c'],
+    );
+  });
+
+  it('does not mutate the input array', () => {
+    const completed: InboxItem[] = [
+      todo('a', true, '2026-04-02T00:00:00.000Z'),
+      todo('b', true, '2026-04-05T00:00:00.000Z'),
+    ];
+    const before = completed.map((t) => t.id);
+    sortCompletedTodosByCompletedAt(completed);
+    expect(completed.map((t) => t.id)).toEqual(before);
+  });
+});
+
+describe('spliceOpenTodoOrder', () => {
+  it('places reordered open todos first, preserves rest order', () => {
+    // itemIds: o1, c1, o2, r1, o3 — open todos are o1/o2/o3, rest is c1, r1.
+    const result = spliceOpenTodoOrder(
+      ['o1', 'c1', 'o2', 'r1', 'o3'],
+      ['o1', 'o2', 'o3'],
+      ['o3', 'o1', 'o2'],
+    );
+    expect(result).toEqual(['o3', 'o1', 'o2', 'c1', 'r1']);
+  });
+
+  it('keeps completed and reference order stable when only one open todo moves', () => {
+    const result = spliceOpenTodoOrder(
+      ['o1', 'o2', 'c1', 'r1', 'r2'],
+      ['o1', 'o2'],
+      ['o2', 'o1'],
+    );
+    expect(result).toEqual(['o2', 'o1', 'c1', 'r1', 'r2']);
+  });
+
+  it('handles a collection with no rest items', () => {
+    const result = spliceOpenTodoOrder(
+      ['o1', 'o2', 'o3'],
+      ['o1', 'o2', 'o3'],
+      ['o2', 'o3', 'o1'],
+    );
+    expect(result).toEqual(['o2', 'o3', 'o1']);
+  });
+
+  it('handles a collection with no open todos in the previous set', () => {
+    // Edge case: previousOpenIds is empty, so all current ids become "rest".
+    // newOpenIds prepends ahead of them.
+    const result = spliceOpenTodoOrder(['c1', 'r1'], [], []);
+    expect(result).toEqual(['c1', 'r1']);
+  });
+});

--- a/packages/web/src/lib/collection-todos.ts
+++ b/packages/web/src/lib/collection-todos.ts
@@ -1,5 +1,4 @@
-import type { Collection, InboxItem } from '@inbox-rs/rs-module';
-import { reorderCollectionItems } from './stores';
+import type { InboxItem } from '@inbox-rs/rs-module';
 
 export function filterTodos(items: InboxItem[]): InboxItem[] {
   return items.filter((i) => i.isTodo || i.type === 'todo');
@@ -42,19 +41,4 @@ export function spliceOpenTodoOrder(
   const openSet = new Set(previousOpenIds);
   const rest = currentItemIds.filter((id) => !openSet.has(id));
   return [...newOpenIds, ...rest];
-}
-
-// Persist a new open-todo order. Errors propagate so the caller can roll back
-// its local dnd UI state.
-export async function applyOpenTodoReorder(
-  collection: Collection,
-  previousOpenIds: string[],
-  newOpenIds: string[],
-): Promise<void> {
-  const newItemIds = spliceOpenTodoOrder(
-    collection.itemIds,
-    previousOpenIds,
-    newOpenIds,
-  );
-  await reorderCollectionItems(collection.id, newItemIds);
 }

--- a/packages/web/src/lib/collection-todos.ts
+++ b/packages/web/src/lib/collection-todos.ts
@@ -1,0 +1,60 @@
+import type { Collection, InboxItem } from '@inbox-rs/rs-module';
+import { reorderCollectionItems } from './stores';
+
+export function filterTodos(items: InboxItem[]): InboxItem[] {
+  return items.filter((i) => i.isTodo || i.type === 'todo');
+}
+
+export function filterOpenTodos(todos: InboxItem[]): InboxItem[] {
+  return todos.filter((t) => !t.completed);
+}
+
+export function filterCompletedTodos(todos: InboxItem[]): InboxItem[] {
+  return todos.filter((t) => t.completed);
+}
+
+export function filterReferenceItems(items: InboxItem[]): InboxItem[] {
+  return items.filter((i) => !i.isTodo && i.type !== 'todo');
+}
+
+export function sortCompletedTodosByCompletedAt(
+  completed: InboxItem[],
+): InboxItem[] {
+  return completed
+    .slice()
+    .sort(
+      (a, b) =>
+        new Date(b.completedAt ?? b.createdAt).getTime() -
+        new Date(a.completedAt ?? a.createdAt).getTime(),
+    );
+}
+
+// Splice a new open-todo order into a collection's full itemIds list while
+// preserving the relative position of completed todos and reference items.
+// Anything not in `previousOpenIds` keeps its current position after the
+// reordered open todos; this is what makes a single-todo drag avoid scrambling
+// the references grid below it.
+export function spliceOpenTodoOrder(
+  currentItemIds: string[],
+  previousOpenIds: string[],
+  newOpenIds: string[],
+): string[] {
+  const openSet = new Set(previousOpenIds);
+  const rest = currentItemIds.filter((id) => !openSet.has(id));
+  return [...newOpenIds, ...rest];
+}
+
+// Persist a new open-todo order. Errors propagate so the caller can roll back
+// its local dnd UI state.
+export async function applyOpenTodoReorder(
+  collection: Collection,
+  previousOpenIds: string[],
+  newOpenIds: string[],
+): Promise<void> {
+  const newItemIds = spliceOpenTodoOrder(
+    collection.itemIds,
+    previousOpenIds,
+    newOpenIds,
+  );
+  await reorderCollectionItems(collection.id, newItemIds);
+}


### PR DESCRIPTION
Closes #29.

## Summary

- New `packages/web/src/lib/collection-todos.ts` exposes `filterTodos` / `filterOpenTodos` / `filterCompletedTodos` / `filterReferenceItems`, `sortCompletedTodosByCompletedAt`, `spliceOpenTodoOrder`, and an async `applyOpenTodoReorder` wrapper around the store call.
- `CollectionView.svelte` and `CollectionTodoTile.svelte` now consume these helpers in place of inline filters and the duplicated dnd-finalize splice logic.
- Unit tests cover the filter/sort helpers and four cases for the splice helper (single-todo move, mixed open/completed/reference, no rest, empty previous-open set).

## Behavior

Preserved exactly:

- `CollectionView` continues to sort completed todos by `completedAt` desc.
- `CollectionTodoTile` continues to leave completed todos in insertion order.
- `CollectionView`'s typed `todos-collection-${id}` dnd zone, the global vs. local completed-toggle behavior, and each component's add-modal ownership are untouched.

## Out of scope (per rescoped #29)

- Splitting `CollectionView` into sub-components.
- Converging the two completed-toggle UX paths.
- Inline `<li>` vs `TodoRow` rendering.

## Test plan

- [x] `npm run check` clean
- [x] `npm run test --workspace=packages/web` — 260 tests pass (9 new)
- [x] `npm run build` succeeds
- [ ] Manual: dnd-reorder open todos in an expanded `CollectionView` on the collections page; verify completed-todo and reference-item order is preserved.
- [ ] Manual: dnd-reorder open todos in a `CollectionTodoTile` on the todos page; verify completed-todo order is preserved.