### PR TITLE
Harden web transcription asset loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ packages/*/inbox-rs-src.tar.gz
 
 # Dev-only download staging area (copied into dist/ during build)
 packages/web/public/downloads/
+packages/web/public/ml/
 
 # End-to-end test artefacts (see tests/e2e/README.md)
 tests/e2e/playwright-report/

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "npm run dev --workspace=packages/web",
     "build": "npm run build --workspace=packages/web",
     "vendor:transcription-assets": "npm run vendor:transcription-assets --workspace=packages/web",
+    "vendor:transcription-assets:refresh": "npm run vendor:transcription-assets:refresh --workspace=packages/web",
     "package:plugins": "node scripts/package-plugins.mjs",
     "build:extension": "npm run build --workspace=packages/extension",
     "build:thunderbird": "npm run build --workspace=packages/thunderbird",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "npm run dev --workspace=packages/web",
     "build": "npm run build --workspace=packages/web",
+    "vendor:transcription-assets": "npm run vendor:transcription-assets --workspace=packages/web",
     "package:plugins": "node scripts/package-plugins.mjs",
     "build:extension": "npm run build --workspace=packages/extension",
     "build:thunderbird": "npm run build --workspace=packages/thunderbird",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -5,10 +5,12 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "predev": "node ../../scripts/gen-plugin-metadata.mjs",
-    "prebuild": "node ../../scripts/package-plugins.mjs",
+    "predev": "npm run vendor:transcription-assets && node ../../scripts/gen-plugin-metadata.mjs",
+    "prebuild": "npm run vendor:transcription-assets && node ../../scripts/package-plugins.mjs",
     "build": "vite build",
     "preview": "vite preview",
+    "pretest": "npm run vendor:transcription-assets",
+    "vendor:transcription-assets": "node ../../scripts/vendor-transcription-assets.mjs",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview",
     "pretest": "npm run vendor:transcription-assets",
     "vendor:transcription-assets": "node ../../scripts/vendor-transcription-assets.mjs",
+    "vendor:transcription-assets:refresh": "FORCE_VENDOR_TRANSCRIPTION_ASSETS=1 node ../../scripts/vendor-transcription-assets.mjs --refresh",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/web/src/lib/transcribe.test.ts
+++ b/packages/web/src/lib/transcribe.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  configureTranscriptionEnv,
+  TRANSCRIPTION_MODEL_BASE_PATH,
+  TRANSCRIPTION_MODEL_FILES,
+  TRANSCRIPTION_MODEL_ID,
+  TRANSCRIPTION_MODEL_REVISION,
+  TRANSCRIPTION_WASM_BASE_PATH,
+  TRANSCRIPTION_WASM_FILES,
+} from './transcribe';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../../..');
+const publicRoot = path.join(repoRoot, 'packages/web/public');
+const modelBaseDir = TRANSCRIPTION_MODEL_BASE_PATH.replace(/^\/+/, '');
+const wasmBaseDir = TRANSCRIPTION_WASM_BASE_PATH.replace(/^\/+/, '');
+
+describe('configureTranscriptionEnv', () => {
+  it('forces same-origin transcription assets', () => {
+    const env = {
+      allowLocalModels: false,
+      allowRemoteModels: true,
+      localModelPath: '/',
+      backends: {
+        onnx: {
+          wasm: {
+            wasmPaths: '/cdn/',
+          },
+        },
+      },
+    };
+
+    configureTranscriptionEnv(env);
+
+    expect(env.allowLocalModels).toBe(true);
+    expect(env.allowRemoteModels).toBe(false);
+    expect(env.localModelPath).toBe(TRANSCRIPTION_MODEL_BASE_PATH);
+    expect(env.backends.onnx.wasm.wasmPaths).toBe(TRANSCRIPTION_WASM_BASE_PATH);
+  });
+});
+
+describe('vendored transcription assets', () => {
+  it('pins the whisper snapshot used for local transcription assets', () => {
+    expect(TRANSCRIPTION_MODEL_ID).toBe('Xenova/whisper-tiny');
+    expect(TRANSCRIPTION_MODEL_REVISION).toBe(
+      '5332fcc35e32a33b86612b9a57a89be7906102b1',
+    );
+  });
+
+  it('ships every required whisper file under public/ml/models', () => {
+    for (const relativeFile of TRANSCRIPTION_MODEL_FILES) {
+      const file = path.join(
+        publicRoot,
+        modelBaseDir,
+        TRANSCRIPTION_MODEL_ID,
+        relativeFile,
+      );
+      expect(
+        existsSync(file),
+        `Missing transcription model asset: ${path.relative(repoRoot, file)}`,
+      ).toBe(true);
+    }
+  });
+
+  it('ships the local ONNX Runtime WASM payloads under public/ml/onnxruntime', () => {
+    for (const relativeFile of TRANSCRIPTION_WASM_FILES) {
+      const file = path.join(publicRoot, wasmBaseDir, relativeFile);
+      expect(
+        existsSync(file),
+        `Missing ONNX Runtime asset: ${path.relative(repoRoot, file)}`,
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/web/src/lib/transcribe.ts
+++ b/packages/web/src/lib/transcribe.ts
@@ -6,8 +6,53 @@ type Transcriber = (
   options: { language: string; task: string },
 ) => Promise<{ text?: string }>;
 
+type TransformersEnv = {
+  allowLocalModels: boolean;
+  allowRemoteModels: boolean;
+  localModelPath: string;
+  backends: {
+    onnx: {
+      wasm: {
+        wasmPaths: string;
+      };
+    };
+  };
+};
+
+export const TRANSCRIPTION_MODEL_ID = 'Xenova/whisper-tiny';
+export const TRANSCRIPTION_MODEL_REVISION =
+  '5332fcc35e32a33b86612b9a57a89be7906102b1';
+export const TRANSCRIPTION_MODEL_BASE_PATH = '/ml/models/';
+export const TRANSCRIPTION_WASM_BASE_PATH = '/ml/onnxruntime/';
+export const TRANSCRIPTION_MODEL_FILES = [
+  'config.json',
+  'generation_config.json',
+  'preprocessor_config.json',
+  'tokenizer.json',
+  'tokenizer_config.json',
+  'onnx/encoder_model_quantized.onnx',
+  'onnx/decoder_model_merged_quantized.onnx',
+] as const;
+export const TRANSCRIPTION_WASM_FILES = [
+  'ort-wasm.wasm',
+  'ort-wasm-simd.wasm',
+  'ort-wasm-threaded.wasm',
+  'ort-wasm-threaded.js',
+  'ort-wasm-threaded.worker.js',
+  'ort-wasm-simd-threaded.wasm',
+] as const;
+
 let transcriber: Transcriber | null = null;
 let loadPromise: Promise<Transcriber> | null = null;
+
+export function configureTranscriptionEnv(env: TransformersEnv) {
+  // Keep inference entirely same-origin so the runtime does not fall back to
+  // remote models or CDN-hosted ONNX assets.
+  env.allowLocalModels = true;
+  env.allowRemoteModels = false;
+  env.localModelPath = TRANSCRIPTION_MODEL_BASE_PATH;
+  env.backends.onnx.wasm.wasmPaths = TRANSCRIPTION_WASM_BASE_PATH;
+}
 
 async function getTranscriber() {
   if (transcriber) return transcriber;
@@ -15,10 +60,10 @@ async function getTranscriber() {
   loadPromise = (async () => {
     try {
       const { pipeline, env } = await import('@xenova/transformers');
-      env.allowLocalModels = false;
+      configureTranscriptionEnv(env as TransformersEnv);
       transcriber = (await pipeline(
         'automatic-speech-recognition',
-        'Xenova/whisper-tiny',
+        TRANSCRIPTION_MODEL_ID,
         {
           quantized: true,
         },

--- a/scripts/vendor-transcription-assets.mjs
+++ b/scripts/vendor-transcription-assets.mjs
@@ -1,4 +1,5 @@
-import { copyFile, mkdir, stat, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { copyFile, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -7,22 +8,74 @@ const repoRoot = path.resolve(__dirname, '..');
 
 const MODEL_ID = 'Xenova/whisper-tiny';
 const MODEL_REVISION = '5332fcc35e32a33b86612b9a57a89be7906102b1';
-const MODEL_FILES = [
-  'config.json',
-  'generation_config.json',
-  'preprocessor_config.json',
-  'tokenizer.json',
-  'tokenizer_config.json',
-  'onnx/encoder_model_quantized.onnx',
-  'onnx/decoder_model_merged_quantized.onnx',
+const MODEL_ASSETS = [
+  {
+    file: 'config.json',
+    size: 2248,
+    sha256: '2b2e4e519084e0ea028b19b153f95202735a971870d6844aa26e559edd292e94',
+  },
+  {
+    file: 'generation_config.json',
+    size: 3716,
+    sha256: '68ac791fcb4999461a313472125042934656240ba1cba7d1c2627fcbb19ac24c',
+  },
+  {
+    file: 'preprocessor_config.json',
+    size: 339,
+    sha256: 'a6a76d28c93edb273669eb9e0b0636a2bddbb1272c3261e47b7ca6dfdbac1b8d',
+  },
+  {
+    file: 'tokenizer.json',
+    size: 2480466,
+    sha256: '27fc476bfe7f17299480be2273fc0608e4d5a99aba2ab5dec5374b4482d1a566',
+  },
+  {
+    file: 'tokenizer_config.json',
+    size: 282683,
+    sha256: '2a4c4281cf9f51ac6ccc406fdc711a087afe6530f671fa7b80953edc498275ce',
+  },
+  {
+    file: 'onnx/encoder_model_quantized.onnx',
+    size: 10124910,
+    sha256: 'fd9d995b9dcb0520f0dbf6cf68651af639fc385f594d9d876e69ca2802dc438e',
+  },
+  {
+    file: 'onnx/decoder_model_merged_quantized.onnx',
+    size: 30727765,
+    sha256: '6c0c125986b007d2e3734bec84c18bda0152071b90b87fadac6d7764499927a0',
+  },
 ];
-const ORT_WASM_FILES = [
-  'ort-wasm.wasm',
-  'ort-wasm-simd.wasm',
-  'ort-wasm-threaded.wasm',
-  'ort-wasm-threaded.js',
-  'ort-wasm-threaded.worker.js',
-  'ort-wasm-simd-threaded.wasm',
+const ORT_WASM_ASSETS = [
+  {
+    file: 'ort-wasm.wasm',
+    size: 9223228,
+    sha256: 'bbdcb6b3c7d294577d806077630460be4e13ca35a345acb5e81188e9649fa74a',
+  },
+  {
+    file: 'ort-wasm-simd.wasm',
+    size: 10014674,
+    sha256: '9bd07bababc65f53d061f457233eeae501be7ceb8a2adb9eef52d87fe776d865',
+  },
+  {
+    file: 'ort-wasm-threaded.wasm',
+    size: 9149637,
+    sha256: '2ee2f715093aaacc0344bfb1610313eb49a3474e8afde5e4635f30ddfc7615c8',
+  },
+  {
+    file: 'ort-wasm-threaded.js',
+    size: 32695,
+    sha256: '9cddaf5dd8043de8b33c423b6ac29231547e5f89a0016c82c36c934089e065d1',
+  },
+  {
+    file: 'ort-wasm-threaded.worker.js',
+    size: 2366,
+    sha256: '0cf0d14ffa4dcbece952a66ee317ff656915784aa5cb6b86e0c0beb2d1d8a5e9',
+  },
+  {
+    file: 'ort-wasm-simd-threaded.wasm',
+    size: 9960821,
+    sha256: 'ac23f2f3cbd519a65a0796f7c79eb34ead4c1f6f31eb06e14ed8a9579d697ef6',
+  },
 ];
 
 const publicRoot = path.join(repoRoot, 'packages/web/public/ml');
@@ -30,23 +83,31 @@ const modelRoot = path.join(publicRoot, 'models', MODEL_ID);
 const ortRoot = path.join(publicRoot, 'onnxruntime');
 const ortSourceRoot = path.join(repoRoot, 'node_modules/onnxruntime-web/dist');
 const modelBaseUrl = `https://huggingface.co/${MODEL_ID}/resolve/${MODEL_REVISION}`;
+const forceRefresh =
+  process.argv.includes('--refresh') ||
+  process.env.FORCE_VENDOR_TRANSCRIPTION_ASSETS === '1';
 
 async function ensureDir(dir) {
   await mkdir(dir, { recursive: true });
 }
 
-async function fileExistsWithSize(file, expectedSize) {
+function sha256(buffer) {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+async function fileMatchesManifest(file, asset) {
   try {
     const info = await stat(file);
-    return info.size === expectedSize;
+    if (info.size !== asset.size) return false;
+    const buffer = await readFile(file);
+    return sha256(buffer) === asset.sha256;
   } catch {
     return false;
   }
 }
 
-async function copyStaticFile(source, destination) {
-  const info = await stat(source);
-  if (await fileExistsWithSize(destination, info.size)) {
+async function copyStaticFile(source, destination, asset) {
+  if (!forceRefresh && (await fileMatchesManifest(destination, asset))) {
     console.log(
       `[vendor-transcription-assets] kept ${path.relative(repoRoot, destination)}`,
     );
@@ -59,7 +120,14 @@ async function copyStaticFile(source, destination) {
   );
 }
 
-async function downloadStaticFile(url, destination) {
+async function downloadStaticFile(url, destination, asset) {
+  if (!forceRefresh && (await fileMatchesManifest(destination, asset))) {
+    console.log(
+      `[vendor-transcription-assets] kept ${path.relative(repoRoot, destination)}`,
+    );
+    return;
+  }
+
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(
@@ -67,11 +135,8 @@ async function downloadStaticFile(url, destination) {
     );
   }
   const buffer = Buffer.from(await response.arrayBuffer());
-  if (await fileExistsWithSize(destination, buffer.byteLength)) {
-    console.log(
-      `[vendor-transcription-assets] kept ${path.relative(repoRoot, destination)}`,
-    );
-    return;
+  if (buffer.byteLength !== asset.size || sha256(buffer) !== asset.sha256) {
+    throw new Error(`Downloaded asset did not match manifest: ${url}`);
   }
   await ensureDir(path.dirname(destination));
   await writeFile(destination, buffer);
@@ -81,17 +146,19 @@ async function downloadStaticFile(url, destination) {
 }
 
 async function main() {
-  for (const file of ORT_WASM_FILES) {
+  for (const asset of ORT_WASM_ASSETS) {
     await copyStaticFile(
-      path.join(ortSourceRoot, file),
-      path.join(ortRoot, file),
+      path.join(ortSourceRoot, asset.file),
+      path.join(ortRoot, asset.file),
+      asset,
     );
   }
 
-  for (const file of MODEL_FILES) {
+  for (const asset of MODEL_ASSETS) {
     await downloadStaticFile(
-      `${modelBaseUrl}/${file}`,
-      path.join(modelRoot, file),
+      `${modelBaseUrl}/${asset.file}`,
+      path.join(modelRoot, asset.file),
+      asset,
     );
   }
 }

--- a/scripts/vendor-transcription-assets.mjs
+++ b/scripts/vendor-transcription-assets.mjs
@@ -1,0 +1,102 @@
+import { copyFile, mkdir, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+const MODEL_ID = 'Xenova/whisper-tiny';
+const MODEL_REVISION = '5332fcc35e32a33b86612b9a57a89be7906102b1';
+const MODEL_FILES = [
+  'config.json',
+  'generation_config.json',
+  'preprocessor_config.json',
+  'tokenizer.json',
+  'tokenizer_config.json',
+  'onnx/encoder_model_quantized.onnx',
+  'onnx/decoder_model_merged_quantized.onnx',
+];
+const ORT_WASM_FILES = [
+  'ort-wasm.wasm',
+  'ort-wasm-simd.wasm',
+  'ort-wasm-threaded.wasm',
+  'ort-wasm-threaded.js',
+  'ort-wasm-threaded.worker.js',
+  'ort-wasm-simd-threaded.wasm',
+];
+
+const publicRoot = path.join(repoRoot, 'packages/web/public/ml');
+const modelRoot = path.join(publicRoot, 'models', MODEL_ID);
+const ortRoot = path.join(publicRoot, 'onnxruntime');
+const ortSourceRoot = path.join(repoRoot, 'node_modules/onnxruntime-web/dist');
+const modelBaseUrl = `https://huggingface.co/${MODEL_ID}/resolve/${MODEL_REVISION}`;
+
+async function ensureDir(dir) {
+  await mkdir(dir, { recursive: true });
+}
+
+async function fileExistsWithSize(file, expectedSize) {
+  try {
+    const info = await stat(file);
+    return info.size === expectedSize;
+  } catch {
+    return false;
+  }
+}
+
+async function copyStaticFile(source, destination) {
+  const info = await stat(source);
+  if (await fileExistsWithSize(destination, info.size)) {
+    console.log(
+      `[vendor-transcription-assets] kept ${path.relative(repoRoot, destination)}`,
+    );
+    return;
+  }
+  await ensureDir(path.dirname(destination));
+  await copyFile(source, destination);
+  console.log(
+    `[vendor-transcription-assets] copied ${path.relative(repoRoot, destination)}`,
+  );
+}
+
+async function downloadStaticFile(url, destination) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download ${url}: ${response.status} ${response.statusText}`,
+    );
+  }
+  const buffer = Buffer.from(await response.arrayBuffer());
+  if (await fileExistsWithSize(destination, buffer.byteLength)) {
+    console.log(
+      `[vendor-transcription-assets] kept ${path.relative(repoRoot, destination)}`,
+    );
+    return;
+  }
+  await ensureDir(path.dirname(destination));
+  await writeFile(destination, buffer);
+  console.log(
+    `[vendor-transcription-assets] downloaded ${path.relative(repoRoot, destination)}`,
+  );
+}
+
+async function main() {
+  for (const file of ORT_WASM_FILES) {
+    await copyStaticFile(
+      path.join(ortSourceRoot, file),
+      path.join(ortRoot, file),
+    );
+  }
+
+  for (const file of MODEL_FILES) {
+    await downloadStaticFile(
+      `${modelBaseUrl}/${file}`,
+      path.join(modelRoot, file),
+    );
+  }
+}
+
+main().catch((error) => {
+  console.error('[vendor-transcription-assets] failed:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- force the web transcription path to use only same-origin model and ONNX runtime assets
- add a pinned asset vendoring script and wire it into the web app's dev/build/test lifecycle
- add regression tests that verify the local asset contract and env configuration

## Testing
- npm run test
- npm run check
- npm run build --workspace=packages/rs-module
- node scripts/gen-plugin-metadata.mjs
- npx vite build

Closes #75.
