### PR TITLE
fix(web): revoke blob URLs on item delete and disconnect

### DIFF
--- a/packages/extension/manifest.firefox.json
+++ b/packages/extension/manifest.firefox.json
@@ -3,15 +3,8 @@
   "name": "Inbox RS",
   "version": "2.2.1",
   "description": "Save links, text, and more to your remoteStorage inbox.",
-  "permissions": [
-    "contextMenus",
-    "activeTab",
-    "storage",
-    "identity"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["contextMenus", "activeTab", "storage", "identity"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Inbox RS",
@@ -22,9 +15,7 @@
     }
   },
   "background": {
-    "scripts": [
-      "service-worker.js"
-    ],
+    "scripts": ["service-worker.js"],
     "type": "module"
   },
   "browser_specific_settings": {
@@ -32,21 +23,15 @@
       "id": "inbox-rs@silverbucket.net",
       "strict_min_version": "126.0",
       "data_collection_permissions": {
-        "required": [
-          "none"
-        ],
+        "required": ["none"],
         "optional": []
       }
     }
   },
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content-metadata.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["content-metadata.js"],
       "run_at": "document_idle"
     }
   ],

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -3,15 +3,8 @@
   "name": "Inbox RS",
   "version": "2.2.1",
   "description": "Save links, text, and more to your remoteStorage inbox.",
-  "permissions": [
-    "contextMenus",
-    "activeTab",
-    "storage",
-    "identity"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["contextMenus", "activeTab", "storage", "identity"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Inbox RS",
@@ -27,12 +20,8 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content-metadata.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["content-metadata.js"],
       "run_at": "document_idle"
     }
   ],

--- a/packages/thunderbird/manifest.json
+++ b/packages/thunderbird/manifest.json
@@ -9,12 +9,7 @@
       "strict_min_version": "128.0"
     }
   },
-  "permissions": [
-    "messagesRead",
-    "storage",
-    "identity",
-    "<all_urls>"
-  ],
+  "permissions": ["messagesRead", "storage", "identity", "<all_urls>"],
   "message_display_action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Save to Inbox RS",
@@ -26,9 +21,7 @@
     }
   },
   "background": {
-    "scripts": [
-      "background.js"
-    ],
+    "scripts": ["background.js"],
     "type": "module"
   },
   "options_ui": {

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -65,6 +65,7 @@ import {
   createCollection,
   deleteCollection,
   deleteGroup,
+  deleteItem,
   groupCollections,
   groups,
   items,
@@ -273,6 +274,64 @@ describe('loadFileBlobUrl', () => {
     });
 
     expect(mockFetchFileBlobUrl).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('blob URL cleanup (memory leak prevention)', () => {
+  let revokeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    blobUrls.set({});
+    connected.set(true);
+    // Spy on revoke so we can assert cleanup behavior.
+    // Do NOT call vi.clearAllMocks() here — it would wipe the captured
+    // rs.on() calls that other tests (and emitRsEvent) rely on.
+    revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    revokeSpy?.mockRestore();
+    blobUrls.set({});
+  });
+
+  it('revokes and removes blob URL when deleteItem is called with a file-backed item', async () => {
+    blobUrls.set({ 'files/photo.jpg': 'blob:mem/abc123' });
+
+    const fileItem: InboxItem = {
+      id: 'note-with-photo',
+      type: 'note',
+      title: 'test',
+      body: '',
+      createdAt: new Date().toISOString(),
+      filePath: 'files/photo.jpg',
+    } as any;
+
+    await deleteItem('note-with-photo', fileItem);
+
+    expect(revokeSpy).toHaveBeenCalledWith('blob:mem/abc123');
+    expect(get(blobUrls)['files/photo.jpg']).toBeUndefined();
+  });
+
+  it('revokes all blob URLs on disconnect (via captured handler)', () => {
+    blobUrls.set({
+      'files/a.jpg': 'blob:mem/a',
+      'files/b.mp3': 'blob:mem/b',
+    });
+
+    // Use the test helper that fires all captured handlers for the event.
+    // This avoids mutating mock state.
+    emitRsEvent('disconnected');
+
+    expect(revokeSpy).toHaveBeenCalledWith('blob:mem/a');
+    expect(revokeSpy).toHaveBeenCalledWith('blob:mem/b');
+    expect(get(blobUrls)).toEqual({});
+  });
+
+  it('does not throw when revoking during disconnect with no blobs', () => {
+    blobUrls.set({});
+
+    expect(() => emitRsEvent('disconnected')).not.toThrow();
+    expect(get(blobUrls)).toEqual({});
   });
 });
 

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -371,6 +371,18 @@ rs.on('connected', async () => {
 });
 
 rs.on('disconnected', () => {
+  // Revoke all blob URLs to prevent memory leaks across reconnects / long sessions.
+  const currentBlobs = get(blobUrls);
+  for (const url of Object.values(currentBlobs)) {
+    try {
+      URL.revokeObjectURL(url);
+    } catch {
+      // ignore revoke errors during shutdown
+    }
+  }
+  blobUrls.set({});
+  pendingBlobLoads.clear();
+
   connected.set(false);
   userAddress.set('');
   localStorage.removeItem('inbox-rs:userAddress');
@@ -694,6 +706,31 @@ export async function storeItem(item: InboxItem, fileData?: ArrayBuffer) {
 export async function deleteItem(id: string, item?: InboxItem) {
   const inbox = getInbox();
   await inbox.remove(id, item);
+
+  // Revoke and remove any associated blob URL to prevent memory leaks.
+  // All current callers pass the full item; we also do a defensive lookup.
+  const filePath =
+    (item && 'filePath' in item && (item as { filePath?: string }).filePath) ||
+    (get(items)[id] &&
+      'filePath' in get(items)[id] &&
+      (get(items)[id] as { filePath?: string }).filePath);
+
+  if (typeof filePath === 'string' && filePath) {
+    const existing = get(blobUrls)[filePath];
+    if (existing) {
+      try {
+        URL.revokeObjectURL(existing);
+      } catch {
+        // ignore
+      }
+      blobUrls.update((current) => {
+        const next = { ...current };
+        delete next[filePath];
+        return next;
+      });
+    }
+  }
+
   rawItems.update((current) => {
     const next = { ...current };
     for (const key of Object.keys(next)) {

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -372,6 +372,10 @@ rs.on('connected', async () => {
 
 rs.on('disconnected', () => {
   // Revoke all blob URLs to prevent memory leaks across reconnects / long sessions.
+  // Bump the generation so any in-flight loadFileBlobUrl promises from
+  // before this disconnect are ignored when they resolve (prevents stale
+  // blob URLs from being re-added after cleanup).
+  blobLoadGeneration++;
   const currentBlobs = get(blobUrls);
   for (const url of Object.values(currentBlobs)) {
     try {
@@ -651,32 +655,38 @@ export const collectionItems = derived(
 
 // ---- File blob URL loading ----
 
-const pendingBlobLoads = new Set<string>();
+/** Incremented on full blob URL revocation (e.g. disconnect) to invalidate in-flight loads. */
+let blobLoadGeneration = 0;
+const pendingBlobLoads = new Map<string, number>();
 
 /**
  * Fetch a file from RS and create a blob URL, stored in blobUrls for reactive display.
  * No-ops if already loaded or in progress. Components should call this on mount.
  *
- * Callers should pass `mimeType` when they know it (e.g. from item metadata) so the
- * resulting blob is created with a clean image/audio/... type regardless of what the
- * server echoes back in its Content-Type header. See `fetchFileWithAuth` for the
- * `charset=binary` quirk that makes this necessary.
+ * A generation number is captured at start time. After a disconnect (or other
+ * full revocation), the generation is bumped so stale promises cannot
+ * re-populate blobUrls with URLs created after cleanup.
  */
 export function loadFileBlobUrl(filePath: string, mimeType?: string): void {
   if (!filePath) return;
   if (get(blobUrls)[filePath] || pendingBlobLoads.has(filePath)) return;
   if (!get(connected)) return;
-  pendingBlobLoads.add(filePath);
+  const gen = blobLoadGeneration;
+  pendingBlobLoads.set(filePath, gen);
   fetchFileBlobUrl(filePath, mimeType)
     .then((url) => {
-      if (url) {
+      // Only act on the result if this load was not invalidated by a later
+      // full revocation (e.g. disconnect).
+      if (url && pendingBlobLoads.get(filePath) === gen) {
         const old = get(blobUrls)[filePath];
         if (old) URL.revokeObjectURL(old);
         blobUrls.update((current) => ({ ...current, [filePath]: url }));
       }
     })
     .finally(() => {
-      pendingBlobLoads.delete(filePath);
+      if (pendingBlobLoads.get(filePath) === gen) {
+        pendingBlobLoads.delete(filePath);
+      }
     });
 }
 
@@ -729,6 +739,8 @@ export async function deleteItem(id: string, item?: InboxItem) {
         return next;
       });
     }
+    // Also drop any in-flight load for this specific file (no global gen bump needed).
+    pendingBlobLoads.delete(filePath);
   }
 
   rawItems.update((current) => {

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -386,6 +386,7 @@ rs.on('disconnected', () => {
   }
   blobUrls.set({});
   pendingBlobLoads.clear();
+  revokedBlobPaths.clear();
 
   connected.set(false);
   userAddress.set('');
@@ -658,6 +659,8 @@ export const collectionItems = derived(
 /** Incremented on full blob URL revocation (e.g. disconnect) to invalidate in-flight loads. */
 let blobLoadGeneration = 0;
 const pendingBlobLoads = new Map<string, number>();
+/** Paths for which we have explicitly revoked (via deleteItem) so in-flight loads don't re-insert. */
+const revokedBlobPaths = new Set<string>();
 
 /**
  * Fetch a file from RS and create a blob URL, stored in blobUrls for reactive display.
@@ -669,19 +672,30 @@ const pendingBlobLoads = new Map<string, number>();
  */
 export function loadFileBlobUrl(filePath: string, mimeType?: string): void {
   if (!filePath) return;
+  // A new explicit load attempt clears any prior delete tombstone for this path.
+  revokedBlobPaths.delete(filePath);
   if (get(blobUrls)[filePath] || pendingBlobLoads.has(filePath)) return;
   if (!get(connected)) return;
   const gen = blobLoadGeneration;
   pendingBlobLoads.set(filePath, gen);
   fetchFileBlobUrl(filePath, mimeType)
     .then((url) => {
-      // Only act on the result if this load was not invalidated by a later
-      // full revocation (e.g. disconnect).
-      if (url && pendingBlobLoads.get(filePath) === gen) {
-        const old = get(blobUrls)[filePath];
-        if (old) URL.revokeObjectURL(old);
-        blobUrls.update((current) => ({ ...current, [filePath]: url }));
+      if (!url) return;
+      // Ignore (and revoke) results that are stale due to disconnect, delete, etc.
+      if (
+        pendingBlobLoads.get(filePath) !== gen ||
+        revokedBlobPaths.has(filePath)
+      ) {
+        try {
+          URL.revokeObjectURL(url);
+        } catch {
+          // ignore
+        }
+        return;
       }
+      const old = get(blobUrls)[filePath];
+      if (old) URL.revokeObjectURL(old);
+      blobUrls.update((current) => ({ ...current, [filePath]: url }));
     })
     .finally(() => {
       if (pendingBlobLoads.get(filePath) === gen) {
@@ -741,6 +755,8 @@ export async function deleteItem(id: string, item?: InboxItem) {
     }
     // Also drop any in-flight load for this specific file (no global gen bump needed).
     pendingBlobLoads.delete(filePath);
+    // Mark as revoked so any concurrent in-flight load for this exact path is ignored on resolution.
+    revokedBlobPaths.add(filePath);
   }
 
   rawItems.update((current) => {


### PR DESCRIPTION
## Summary

Fixes a memory leak where `URL.createObjectURL` results for images, audio, and documents were never revoked when items were deleted or when the remoteStorage session ended.

### Root cause
- `blobUrls` store + `loadFileBlobUrl` created object URLs on demand.
- They were only revoked on *replacement* (same `filePath` got new bytes).
- `deleteItem()` and the `disconnected` handler cleared the item stores but left the blob URLs (and their underlying memory) alive for the tab lifetime (and across reconnects).

### Changes
- `deleteItem`: now revokes the associated blob (using the passed `item`, with defensive lookup from the items store) and removes it from the map.
- `disconnected` handler: revokes every remaining blob URL, clears the map, and clears the in-flight load set.
- New focused tests in `stores.test.ts` that assert `revokeObjectURL` calls and map cleanup on both paths.

### Testing
- `npm run check` — clean (biome)
- `npm test` — all workspaces green (102 stores tests including the 3 new cleanup cases)

This is a pure bugfix with no behavior change for normal usage.

Refs review finding #1 (blob URL memory leak).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale file blob loads and memory leaks by ensuring file-backed blob URLs are revoked and cleared when items are deleted or when the connection is lost.

* **Tests**
  * Added tests verifying blob URL revocation on item deletion, on connection disconnect, and that disconnect is a no-op when no blobs exist.

* **Chores**
  * Reformatted extension manifest JSON arrays for a more compact, consistent layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/inbox-rs/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->