### PR TITLE
fix(extension): add size and timeout limits to image downloads in service worker

### DIFF
--- a/packages/extension/src/background/service-worker.test.ts
+++ b/packages/extension/src/background/service-worker.test.ts
@@ -114,7 +114,11 @@ describe('service-worker', () => {
         { id: 1, title: 'Test Page' },
       );
 
-      expect(mockFetch).toHaveBeenCalledWith('https://example.com/photo.jpg');
+      // fetch is now called with an AbortSignal for timeout protection
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://example.com/photo.jpg',
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
 
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining('/inbox/files/test-uuid-1234.jpg'),
@@ -237,6 +241,30 @@ describe('service-worker', () => {
           type: 'download-and-store-image',
           url: 'https://example.com/missing.png',
           filePath: 'files/abc.png',
+        },
+        {},
+      );
+
+      expect(result).toEqual({ ok: false });
+    });
+
+    it('rejects oversized images (Content-Length guard)', async () => {
+      const huge = String(30 * 1024 * 1024); // > 25 MiB limit
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({
+          'content-type': 'image/jpeg',
+          'content-length': huge,
+        }),
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      });
+
+      const handler = onMessageListeners[0];
+      const result = await handler(
+        {
+          type: 'download-and-store-image',
+          url: 'https://example.com/huge.jpg',
+          filePath: 'files/huge.jpg',
         },
         {},
       );

--- a/packages/extension/src/background/service-worker.test.ts
+++ b/packages/extension/src/background/service-worker.test.ts
@@ -272,6 +272,47 @@ describe('service-worker', () => {
       expect(result).toEqual({ ok: false });
     });
 
+    it('rejects non-image Content-Type', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-type': 'text/html' }),
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(100)),
+      });
+
+      const handler = onMessageListeners[0];
+      const result = await handler(
+        {
+          type: 'download-and-store-image',
+          url: 'https://example.com/page.html',
+          filePath: 'files/page.html',
+        },
+        {},
+      );
+
+      expect(result).toEqual({ ok: false });
+    });
+
+    it('rejects oversized images when Content-Length is absent', async () => {
+      const huge = new ArrayBuffer(30 * 1024 * 1024); // > 25 MiB
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-type': 'image/jpeg' }),
+        arrayBuffer: () => Promise.resolve(huge),
+      });
+
+      const handler = onMessageListeners[0];
+      const result = await handler(
+        {
+          type: 'download-and-store-image',
+          url: 'https://example.com/huge.jpg',
+          filePath: 'files/huge.jpg',
+        },
+        {},
+      );
+
+      expect(result).toEqual({ ok: false });
+    });
+
     it('returns ok:false when config is missing', async () => {
       mockStorageGet.mockResolvedValue({});
 

--- a/packages/extension/src/background/service-worker.ts
+++ b/packages/extension/src/background/service-worker.ts
@@ -45,9 +45,10 @@ async function fetchImageData(
     if (!resp.ok) return null;
 
     // Enforce size limit using Content-Length when present (cheap early exit).
-    // Use parseInt for stricter integer validation on the header value.
-    const len = resp.headers.get('content-length');
-    const contentLength = len ? parseInt(len, 10) : NaN;
+    // Require the entire (trimmed) header value to be pure digits to avoid
+    // partial parses like "123abc" or "20MB" bypassing the early guard.
+    const len = resp.headers.get('content-length')?.trim();
+    const contentLength = len && /^\d+$/.test(len) ? Number(len) : NaN;
     if (!Number.isNaN(contentLength) && contentLength > MAX_IMAGE_BYTES) {
       return null;
     }

--- a/packages/extension/src/background/service-worker.ts
+++ b/packages/extension/src/background/service-worker.ts
@@ -24,19 +24,50 @@ browser.runtime.onInstalled.addListener(() => {
   });
 });
 
-/** Download an image and return the binary data + detected mime type */
+/** Max size for images fetched via the extension (25 MiB). */
+const MAX_IMAGE_BYTES = 25 * 1024 * 1024;
+/** Hard timeout for image fetches (network can be slow on some RS servers). */
+const FETCH_TIMEOUT_MS = 20_000;
+
+/** Download an image and return the binary data + detected mime type.
+ *  Applies size and timeout limits to avoid DoS / excessive memory use in the
+ *  service worker (which has <all_urls> and is triggered by context menus or
+ *  the popup on arbitrary pages).
+ */
 async function fetchImageData(
   url: string,
 ): Promise<{ data: ArrayBuffer; mimeType: string } | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
   try {
-    const resp = await fetch(url);
+    const resp = await fetch(url, { signal: controller.signal });
     if (!resp.ok) return null;
+
+    // Enforce size limit using Content-Length when present (cheap early exit).
+    const len = resp.headers.get('content-length');
+    if (len && Number(len) > MAX_IMAGE_BYTES) {
+      return null;
+    }
+
     const mimeType =
       resp.headers.get('content-type')?.split(';')[0] || 'image/png';
+
+    // Guard against non-image responses from weird servers / redirects.
+    if (!mimeType.startsWith('image/')) {
+      return null;
+    }
+
     const data = await resp.arrayBuffer();
+    if (data.byteLength > MAX_IMAGE_BYTES) {
+      return null;
+    }
+
     return { data, mimeType };
   } catch {
     return null;
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/packages/extension/src/background/service-worker.ts
+++ b/packages/extension/src/background/service-worker.ts
@@ -45,8 +45,10 @@ async function fetchImageData(
     if (!resp.ok) return null;
 
     // Enforce size limit using Content-Length when present (cheap early exit).
+    // Use parseInt for stricter integer validation on the header value.
     const len = resp.headers.get('content-length');
-    if (len && Number(len) > MAX_IMAGE_BYTES) {
+    const contentLength = len ? parseInt(len, 10) : NaN;
+    if (!Number.isNaN(contentLength) && contentLength > MAX_IMAGE_BYTES) {
       return null;
     }
 


### PR DESCRIPTION
## Summary

Hardens the privileged service worker fetch path used for saving images (context menu "Save image to Inbox" and popup "save page as image").

### Why
The extension declares `host_permissions: ["<all_urls>"]` and a content script on all pages. `fetchImageData` was a raw `fetch(url)` with no size or time bounds. A large or slow image (og:image, tweet photo, direct image context menu) could exhaust memory or hang the SW.

### Changes
- 25 MiB ceiling (checked via `Content-Length` header before body + post-`arrayBuffer` verification).
- 20 second hard timeout using `AbortController`.
- Early rejection of responses whose MIME does not start with `image/`.
- All failure modes still return the shapes the callers already handle (`null` or `{ok:false}`).

One test assertion was loosened to accept the new `{ signal }` option passed to `fetch`.

### Testing
- `npm run check` clean
- Extension workspace: 93 tests passing (including new oversized-image rejection case + the updated call-site assertion)

This is a defensive hardening with no user-visible behavior change on normal-sized images.

Refs review finding #2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image downloads now enforce a 25 MiB size limit and a 20s timeout, plus stricter content validation to reliably reject oversized, non-image, or slow responses.

* **Tests**
  * Updated tests to validate abort/timeout behavior and cover oversized or non-image responses and missing size headers.

* **Chores**
  * Reformatted extension manifest JSON files for Firefox, Chrome, and Thunderbird (array formatting).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/inbox-rs/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->