### PR TITLE
fix(web): add !important to global input font-size rule for iOS zoom prevention

### DIFF
--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -138,6 +138,7 @@ a:hover {
   input:not([type="checkbox"]):not([type="radio"]):not([type="file"]),
   textarea,
   select {
-    font-size: 16px;
+    /* biome-ignore lint/complexity/noImportantStyles: Required to beat Svelte scoped selectors (.svelte-xxx) so the iOS zoom prevention floor is effective. See comment above. */
+    font-size: 16px !important;
   }
 }


### PR DESCRIPTION
## Summary
Addresses the **Critical** finding from the recent code audit.

The iOS Safari zoom-prevention rule in `global.css` (the 16px font-size floor on touch/narrow viewports) was missing `!important`. This allowed component-scoped Svelte styles to override it, re-introducing the viewport zoom bug.

The file already documented that `!important` is intentional for this exact reason (to beat `.svelte-xxx` scoped selectors).

### Changes
- Added `!important` to the three form-control selectors inside the `@media (pointer: coarse), (max-width: 600px)` block.
- Added a targeted `biome-ignore` comment (the linter otherwise flags `!important`).

### Verification
- `npm run check` passes
- `input-font-size.test.ts` (the enforcement test) still passes cleanly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text zoom prevention on iOS touch devices with enhanced CSS rule specificity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/inbox-rs/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->