### PR TITLE
fix(web): add error handling for storeItem and async operations

### DIFF
--- a/packages/web/src/components/CollectionTodoTile.svelte
+++ b/packages/web/src/components/CollectionTodoTile.svelte
@@ -78,7 +78,12 @@
       completed: nowCompleted,
       completedAt: nowCompleted ? new Date().toISOString() : undefined,
     };
-    await storeItem(cleanForStorage(updated));
+    try {
+      await storeItem(cleanForStorage(updated));
+    } catch (error) {
+      console.error('Failed to toggle todo completion', error);
+      // Checkbox reverts on next render because the item prop is unchanged
+    }
   }
 
   async function handleExpandToggle() {

--- a/packages/web/src/components/DeleteConfirm.svelte
+++ b/packages/web/src/components/DeleteConfirm.svelte
@@ -21,7 +21,7 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" role="dialog" aria-modal="true" onclick={onCancel}>
+<div class="overlay" role="dialog" aria-modal="true" onclick={() => { if (!deleting) onCancel(); }}>
   <div class="dialog" onclick={(e) => e.stopPropagation()}>
     <p>{message}</p>
     <div class="actions">

--- a/packages/web/src/components/TodoRow.svelte
+++ b/packages/web/src/components/TodoRow.svelte
@@ -63,7 +63,12 @@
       completed: nowCompleted,
       completedAt: nowCompleted ? new Date().toISOString() : undefined,
     };
-    await storeItem(cleanForStorage(updated) as InboxItem);
+    try {
+      await storeItem(cleanForStorage(updated) as InboxItem);
+    } catch (err) {
+      console.error('Failed to update todo:', err);
+      // Checkbox reverts on next render because the `todo` prop is unchanged
+    }
   }
 
   function handleClick(e: MouseEvent) {

--- a/packages/web/src/components/add-entry/AudioForm.svelte
+++ b/packages/web/src/components/add-entry/AudioForm.svelte
@@ -45,6 +45,7 @@
   let transcriptionId = 0;
   let mediaRecorder: MediaRecorder | null = null;
   let recordingInterval: ReturnType<typeof setInterval> | null = null;
+  let recordingError = $state('');
 
   $effect(() => {
     if (recording) {
@@ -77,6 +78,7 @@
   }
 
   async function startRecording() {
+    recordingError = '';
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       const chunks: Blob[] = [];
@@ -102,8 +104,9 @@
       recordingInterval = setInterval(() => {
         recordingDuration++;
       }, 1000);
-    } catch {
-      // Mic permission denied or unavailable
+    } catch (error) {
+      recordingError = 'Microphone access denied or unavailable';
+      console.warn('Failed to start recording:', error);
     }
   }
 
@@ -175,6 +178,9 @@
         <button type="button" class="rec-btn rec-start" onclick={startRecording}
           >Start Recording</button
         >
+        {#if recordingError}
+          <p class="status-text">{recordingError}</p>
+        {/if}
       {/if}
     </div>
   </div>

--- a/packages/web/src/components/view-card/DocumentView.svelte
+++ b/packages/web/src/components/view-card/DocumentView.svelte
@@ -80,5 +80,5 @@
   {docLoading ? 'Loading...' : 'Download'}
 </button>
 {#if docError}
-  <p class="status-text">Failed to load document</p>
+  <p class="status-text" role="alert">Failed to load document</p>
 {/if}

--- a/packages/web/src/components/view-card/DocumentView.svelte
+++ b/packages/web/src/components/view-card/DocumentView.svelte
@@ -7,6 +7,7 @@
 
   let docBlobUrl = $state<string | null>(null);
   let docLoading = $state(false);
+  let docError = $state(false);
 
   // The parent shell wraps the per-type view in `{#key item.id}`, so
   // navigating between documents fully remounts this component and
@@ -32,6 +33,7 @@
       return;
     }
     docLoading = true;
+    docError = false;
     try {
       const file = await rs.inbox.getFile(item.filePath);
       if (file?.data) {
@@ -39,7 +41,12 @@
           new Blob([file.data], { type: item.mimeType }),
         );
         openDownload(docBlobUrl);
+      } else {
+        docError = true;
       }
+    } catch (e) {
+      console.error('Failed to download document:', e);
+      docError = true;
     } finally {
       docLoading = false;
     }
@@ -72,3 +79,6 @@
 >
   {docLoading ? 'Loading...' : 'Download'}
 </button>
+{#if docError}
+  <p class="status-text">Failed to load document</p>
+{/if}

--- a/packages/web/src/components/view-card/DocumentView.svelte
+++ b/packages/web/src/components/view-card/DocumentView.svelte
@@ -42,6 +42,7 @@
         );
         openDownload(docBlobUrl);
       } else {
+        console.error('Document file data is missing or empty', item.filePath);
         docError = true;
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
Addresses several **Minor** findings from the recent code audit (error handling / silent failure patterns).

### Changes
- `TodoRow.svelte` + `CollectionTodoTile.svelte`: Wrapped todo completion toggles in `try/catch`. On failure the checkbox visually reverts (because the prop is unchanged).
- `DocumentView.svelte`: Added `docError` state and user-visible feedback when a document download fails.
- `AudioForm.svelte`: Added `recordingError` state + clear message when microphone permission is denied (was a silent catch).
- `DeleteConfirm.svelte`: Backdrop click now respects the `deleting` guard (consistent with the Escape key and action buttons).

All fixes are minimal and follow patterns already used elsewhere in the app.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for todo updates so failures revert the checkbox and log the issue.
  * Prevented the delete dialog from cancelling while a deletion is in progress.
  * Surface clear error messages when audio recording fails or microphone access is denied.
  * Show a user-facing error state when document downloads or loading fail, alongside existing loading/disabled states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/inbox-rs/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->