### PR TITLE
fix(web): harden Lightbox redirect page against XSS and buffer issues

### DIFF
--- a/packages/web/src/components/Lightbox.svelte
+++ b/packages/web/src/components/Lightbox.svelte
@@ -127,12 +127,24 @@
   }
 
   function buildRedirectPage(url: string): ArrayBuffer {
+    // Validate protocol to prevent javascript: or other dangerous schemes
+    try {
+      const parsed = new URL(url);
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        throw new Error('Invalid protocol');
+      }
+    } catch {
+      throw new Error('Invalid URL for redirect page');
+    }
+
     const html = `<!DOCTYPE html>
 <html><head>
 <meta http-equiv="refresh" content="0;url=${url.replace(/"/g, '&quot;')}">
 <style>body{margin:0;display:flex;align-items:center;justify-content:center;min-height:100vh;font-family:system-ui;background:#111;color:#ccc}a{color:#6cf}</style>
 </head><body><a href="${url.replace(/"/g, '&quot;')}">View image</a></body></html>`;
-    return new TextEncoder().encode(html).buffer;
+
+    const encoded = new TextEncoder().encode(html);
+    return encoded.buffer.slice(encoded.byteOffset, encoded.byteOffset + encoded.byteLength);
   }
 
   async function share() {


### PR DESCRIPTION
## Summary
Addresses the **Major** security finding from the recent code audit.

### Changes in `Lightbox.svelte` → `buildRedirectPage`
- Added protocol validation — only `http:` and `https:` are allowed (prevents `javascript:`, `data:`, etc. schemes).
- Fixed buffer handling to use a properly sliced exact-sized `ArrayBuffer` instead of returning the underlying (potentially larger) buffer from `TextEncoder`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced URL validation for redirects to reject invalid protocols and improve encoding safety for redirect payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/inbox-rs/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->