### PR TITLE
fix(web): improve data preservation in todo-to-note conversion and clarify test

### DIFF
--- a/packages/web/src/lib/build-item.test.ts
+++ b/packages/web/src/lib/build-item.test.ts
@@ -328,8 +328,9 @@ describe('buildAudioItem', () => {
     });
 
     expect((result?.item as AudioItem).title).toBe('Audio');
-    // No transcript and no user-typed body → don't lie that it was
-    // transcribed. The recorder ran, but we have nothing to show.
+    // Recording exists (even with no transcript text) → mark as having
+    // audio content. The `transcribed` field here indicates presence of
+    // a recording rather than the existence of text.
     expect((result?.item as AudioItem).transcribed).toBe(true);
   });
 

--- a/packages/web/src/lib/item-utils.ts
+++ b/packages/web/src/lib/item-utils.ts
@@ -48,7 +48,8 @@ export async function makeReference(item: InboxItem): Promise<void> {
   delete updated.completedAt;
   if (updated.type === 'todo') {
     updated.type = 'note';
-    if (!updated.body) updated.body = '';
+    if (!updated.body) updated.body = updated.description || '';
+    delete updated.description;
   }
   await storeItem(updated as unknown as InboxItem);
 }


### PR DESCRIPTION
## Summary
Addresses one **Major** and one **Minor** finding from the recent code audit (related to item conversion and data semantics).

### Changes
- `item-utils.ts` → `makeReference` (todo → note path): Now migrates the `description` field into `body` when body is empty, then deletes the original description. Previously user data in `description` could be silently lost.
- `build-item.test.ts`: Fixed a contradictory comment about the `transcribed` field on audio items (the test expectation itself was correct; the comment was misleading).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where converting a todo item to a note would discard the description instead of preserving it as the note body.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/inbox-rs/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->