### PR TITLE
chore: apply biome formatting to extension and thunderbird manifests

### DIFF
--- a/packages/extension/manifest.firefox.json
+++ b/packages/extension/manifest.firefox.json
@@ -3,15 +3,8 @@
   "name": "Inbox RS",
   "version": "2.2.2",
   "description": "Save links, text, and more to your remoteStorage inbox.",
-  "permissions": [
-    "contextMenus",
-    "activeTab",
-    "storage",
-    "identity"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["contextMenus", "activeTab", "storage", "identity"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Inbox RS",
@@ -22,9 +15,7 @@
     }
   },
   "background": {
-    "scripts": [
-      "service-worker.js"
-    ],
+    "scripts": ["service-worker.js"],
     "type": "module"
   },
   "browser_specific_settings": {
@@ -32,21 +23,15 @@
       "id": "inbox-rs@silverbucket.net",
       "strict_min_version": "126.0",
       "data_collection_permissions": {
-        "required": [
-          "none"
-        ],
+        "required": ["none"],
         "optional": []
       }
     }
   },
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content-metadata.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["content-metadata.js"],
       "run_at": "document_idle"
     }
   ],

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -3,15 +3,8 @@
   "name": "Inbox RS",
   "version": "2.2.2",
   "description": "Save links, text, and more to your remoteStorage inbox.",
-  "permissions": [
-    "contextMenus",
-    "activeTab",
-    "storage",
-    "identity"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["contextMenus", "activeTab", "storage", "identity"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Inbox RS",
@@ -27,12 +20,8 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content-metadata.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["content-metadata.js"],
       "run_at": "document_idle"
     }
   ],

--- a/packages/thunderbird/manifest.json
+++ b/packages/thunderbird/manifest.json
@@ -9,12 +9,7 @@
       "strict_min_version": "128.0"
     }
   },
-  "permissions": [
-    "messagesRead",
-    "storage",
-    "identity",
-    "<all_urls>"
-  ],
+  "permissions": ["messagesRead", "storage", "identity", "<all_urls>"],
   "message_display_action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Save to Inbox RS",
@@ -26,9 +21,7 @@
     }
   },
   "background": {
-    "scripts": [
-      "background.js"
-    ],
+    "scripts": ["background.js"],
     "type": "module"
   },
   "options_ui": {


### PR DESCRIPTION
## Summary

The `biome ci` step (used in CI) was failing on formatting of the three browser extension manifest files, while local `npm run check` appeared clean. This was blocking the release workflow (which requires a green CI run on master).

This PR applies the canonical Biome formatting to:

- `packages/extension/manifest.json`
- `packages/extension/manifest.firefox.json`
- `packages/thunderbird/manifest.json`

No functional changes — only formatting to match the project's biome configuration.

## Verification
- `npm run check` passes
- All tests pass
- This should make the Lint job in CI green again

Refs the current CI failure preventing release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reformatted manifest configuration files for improved code consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/inbox-rs/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->