### PR TITLE
feat(web): add quick capture PWA

### DIFF
--- a/packages/rs-module/package.json
+++ b/packages/rs-module/package.json
@@ -5,6 +5,16 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./runtime": {
+      "types": "./dist/runtime.d.ts",
+      "default": "./dist/runtime.js"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/web/capture/index.html
+++ b/packages/web/capture/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Inbox RS Capture</title>
+    <link rel="icon" href="/src/assets/logos/favicon-shield.svg" type="image/svg+xml" />
+    <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
+    <meta name="theme-color" content="#111827" />
+    <link rel="manifest" href="/capture/manifest.webmanifest" />
+  </head>
+  <body>
+    <div id="capture-app"></div>
+    <script type="module" src="/src/capture/main.ts"></script>
+  </body>
+</html>

--- a/packages/web/public/capture/manifest.webmanifest
+++ b/packages/web/public/capture/manifest.webmanifest
@@ -1,0 +1,29 @@
+{
+  "name": "Inbox RS Quick Capture",
+  "short_name": "Capture",
+  "description": "A fast input-only capture app for Inbox RS.",
+  "start_url": "/capture/",
+  "scope": "/capture/",
+  "display": "standalone",
+  "background_color": "#111827",
+  "theme_color": "#111827",
+  "icons": [
+    {
+      "src": "/favicon-32.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    },
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/packages/web/src/capture/App.svelte
+++ b/packages/web/src/capture/App.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import {
+    clearConfig,
+    enqueueCapture,
+    finishConnectFromRedirect,
+    flushQueue,
+    getConfig,
+    getQueue,
+    startConnect,
+    type CaptureType,
+  } from './store';
+
+  type BeforeInstallPromptEvent = Event & {
+    prompt: () => Promise<void>;
+    userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+  };
+
+  let type = $state<CaptureType>('note');
+  let input = $state('');
+  let userAddress = $state('');
+  let connectedAddress = $state('');
+  let queueCount = $state(0);
+  let status = $state('Ready');
+  let syncing = $state(false);
+  let installPrompt = $state<BeforeInstallPromptEvent | null>(null);
+  let isIos = $state(false);
+
+  onMount(() => {
+    const config = finishConnectFromRedirect() ?? getConfig();
+    connectedAddress = config?.userAddress ?? '';
+    userAddress = connectedAddress;
+    queueCount = getQueue().length;
+    isIos = /iphone|ipad|ipod/i.test(navigator.userAgent);
+    void syncNow();
+
+    const onOnline = () => void syncNow();
+    const onInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      installPrompt = event as BeforeInstallPromptEvent;
+    };
+    window.addEventListener('online', onOnline);
+    window.addEventListener('beforeinstallprompt', onInstallPrompt);
+    return () => {
+      window.removeEventListener('online', onOnline);
+      window.removeEventListener('beforeinstallprompt', onInstallPrompt);
+    };
+  });
+
+  async function saveCapture() {
+    const value = input.trim();
+    if (!value) return;
+    if (type === 'bookmark' && !value.includes('.')) {
+      status = 'Enter a URL for bookmarks';
+      return;
+    }
+    enqueueCapture(type, value);
+    input = '';
+    queueCount = getQueue().length;
+    status = navigator.onLine ? 'Saved. Syncing...' : 'Saved offline';
+    await syncNow();
+  }
+
+  async function syncNow() {
+    if (syncing) return;
+    const config = getConfig();
+    if (!config?.href || !config.token) {
+      queueCount = getQueue().length;
+      status = queueCount ? 'Saved locally. Connect to sync.' : 'Ready';
+      return;
+    }
+    syncing = true;
+    try {
+      const remaining = await flushQueue(config);
+      queueCount = remaining.length;
+      connectedAddress = config.userAddress;
+      status = queueCount ? `${queueCount} waiting to sync` : 'Synced';
+    } finally {
+      syncing = false;
+    }
+  }
+
+  async function connect() {
+    if (!userAddress.trim()) return;
+    status = 'Opening remoteStorage login...';
+    await startConnect(userAddress);
+  }
+
+  function disconnect() {
+    clearConfig();
+    connectedAddress = '';
+    status = queueCount ? 'Saved locally. Connect to sync.' : 'Disconnected';
+  }
+
+  async function install() {
+    if (!installPrompt) return;
+    await installPrompt.prompt();
+    await installPrompt.userChoice;
+    installPrompt = null;
+  }
+</script>
+
+<main class="capture-shell">
+  <section class="hero" aria-label="Quick capture">
+    <div class="hero-top">
+      <div>
+        <p class="eyebrow">Inbox RS</p>
+        <h1>Quick Capture</h1>
+      </div>
+      <a class="main-link" href="/">Full app</a>
+    </div>
+
+    <div class="type-tabs" role="radiogroup" aria-label="Capture type">
+      <button type="button" class:active={type === 'note'} onclick={() => type = 'note'}>Note</button>
+      <button type="button" class:active={type === 'todo'} onclick={() => type = 'todo'}>Todo</button>
+      <button type="button" class:active={type === 'bookmark'} onclick={() => type = 'bookmark'}>Bookmark</button>
+    </div>
+
+    <form class="capture-form" onsubmit={(event) => { event.preventDefault(); void saveCapture(); }}>
+      <textarea
+        bind:value={input}
+        rows="7"
+        placeholder={type === 'bookmark' ? 'https://example.com' : type === 'todo' ? 'What needs doing?' : 'Jot something down...'}
+      ></textarea>
+      <button type="submit" disabled={!input.trim()}>Save</button>
+    </form>
+
+    <p class="status" aria-live="polite">
+      {status}
+      {#if queueCount > 0}
+        <span>{queueCount} queued</span>
+      {/if}
+    </p>
+  </section>
+
+  <section class="panel" aria-label="Connection">
+    {#if connectedAddress}
+      <div>
+        <p class="panel-label">Connected</p>
+        <p class="address">{connectedAddress}</p>
+      </div>
+      <div class="panel-actions">
+        <button type="button" class="secondary" onclick={() => void syncNow()} disabled={syncing}>{syncing ? 'Syncing...' : 'Sync now'}</button>
+        <button type="button" class="ghost" onclick={disconnect}>Disconnect</button>
+      </div>
+    {:else}
+      <p class="panel-label">Connect remoteStorage</p>
+      <form class="connect-form" onsubmit={(event) => { event.preventDefault(); void connect(); }}>
+        <input bind:value={userAddress} type="text" placeholder="user@storage.example" />
+        <button type="submit" class="secondary" disabled={!userAddress.trim()}>Connect</button>
+      </form>
+    {/if}
+  </section>
+
+  <section class="panel install" aria-label="Install">
+    <div>
+      <p class="panel-label">Home screen icon</p>
+      <p>Install this page for the fastest input-only launcher.</p>
+    </div>
+    {#if installPrompt}
+      <button type="button" class="secondary" onclick={() => void install()}>Install</button>
+    {:else if isIos}
+      <p class="hint">Use Share, then Add to Home Screen.</p>
+    {:else}
+      <p class="hint">Use your browser's install option if it is available.</p>
+    {/if}
+  </section>
+</main>

--- a/packages/web/src/capture/main.ts
+++ b/packages/web/src/capture/main.ts
@@ -1,0 +1,8 @@
+import { mount } from 'svelte';
+import App from './App.svelte';
+import './styles.css';
+
+const target = document.getElementById('capture-app');
+if (!target) throw new Error('Mount target #capture-app not found');
+
+mount(App, { target });

--- a/packages/web/src/capture/store.ts
+++ b/packages/web/src/capture/store.ts
@@ -1,0 +1,152 @@
+import type { InboxItem, InboxItemType } from '@inbox-rs/rs-module';
+import {
+  DirectRS,
+  discoverStorage,
+  extractTokenFromRedirect,
+  type RSConfig,
+} from '@inbox-rs/rs-module/runtime';
+
+export type CaptureType = Extract<InboxItemType, 'bookmark' | 'note' | 'todo'>;
+
+export type QueuedCapture = {
+  id: string;
+  item: InboxItem;
+  queuedAt: string;
+  lastError?: string;
+};
+
+const CONFIG_KEY = 'inbox-rs-capture:config';
+const PENDING_AUTH_KEY = 'inbox-rs-capture:pending-auth';
+const QUEUE_KEY = 'inbox-rs-capture:queue';
+
+export function getConfig(): RSConfig | null {
+  return readJson<RSConfig>(CONFIG_KEY);
+}
+
+export function clearConfig(): void {
+  localStorage.removeItem(CONFIG_KEY);
+}
+
+export async function startConnect(userAddress: string): Promise<void> {
+  const discovery = await discoverStorage(userAddress.trim());
+  localStorage.setItem(
+    PENDING_AUTH_KEY,
+    JSON.stringify({ userAddress: userAddress.trim(), discovery }),
+  );
+  const redirectUri = `${window.location.origin}/capture/`;
+  const params = new URLSearchParams({
+    client_id: redirectUri,
+    redirect_uri: redirectUri,
+    response_type: 'token',
+    scope: 'inbox:rw',
+  });
+  window.location.href = `${discovery.authUrl}?${params.toString()}`;
+}
+
+export function finishConnectFromRedirect(): RSConfig | null {
+  if (!window.location.hash.includes('access_token=')) return getConfig();
+  const pending = readJson<{
+    userAddress: string;
+    discovery: { href: string; storageApi?: string };
+  }>(PENDING_AUTH_KEY);
+  if (!pending) return getConfig();
+
+  const config: RSConfig = {
+    userAddress: pending.userAddress,
+    token: extractTokenFromRedirect(window.location.href),
+    href: pending.discovery.href,
+    storageApi: pending.discovery.storageApi,
+  };
+  localStorage.setItem(CONFIG_KEY, JSON.stringify(config));
+  localStorage.removeItem(PENDING_AUTH_KEY);
+  window.history.replaceState(null, '', '/capture/');
+  return config;
+}
+
+export function getQueue(): QueuedCapture[] {
+  return readJson<QueuedCapture[]>(QUEUE_KEY) ?? [];
+}
+
+export function enqueueCapture(
+  type: CaptureType,
+  input: string,
+): QueuedCapture {
+  const item = buildCaptureItem(type, input);
+  const queued: QueuedCapture = {
+    id: item.id,
+    item,
+    queuedAt: new Date().toISOString(),
+  };
+  localStorage.setItem(QUEUE_KEY, JSON.stringify([...getQueue(), queued]));
+  return queued;
+}
+
+export async function flushQueue(config: RSConfig | null = getConfig()) {
+  if (!config?.href || !config.token) return getQueue();
+  const rs = new DirectRS(config);
+  const remaining: QueuedCapture[] = [];
+
+  for (const entry of getQueue()) {
+    try {
+      await rs.store(entry.item);
+    } catch (error) {
+      remaining.push({ ...entry, lastError: errorMessage(error) });
+    }
+  }
+
+  localStorage.setItem(QUEUE_KEY, JSON.stringify(remaining));
+  return remaining;
+}
+
+function buildCaptureItem(type: CaptureType, input: string): InboxItem {
+  const trimmed = input.trim();
+  const id = crypto.randomUUID();
+  const createdAt = new Date().toISOString();
+
+  if (type === 'todo') {
+    return {
+      id,
+      type,
+      title: trimmed,
+      createdAt,
+      completed: false,
+      isTodo: true,
+    };
+  }
+
+  if (type === 'bookmark') {
+    return {
+      id,
+      type,
+      title: trimmed,
+      url: normalizeUrl(trimmed),
+      createdAt,
+    };
+  }
+
+  return {
+    id,
+    type,
+    title: trimmed.slice(0, 50),
+    body: trimmed,
+    createdAt,
+  };
+}
+
+function normalizeUrl(input: string): string {
+  if (/^https?:\/\//i.test(input)) return input;
+  return `https://${input}`;
+}
+
+function readJson<T>(key: string): T | null {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Sync failed';
+}

--- a/packages/web/src/capture/styles.css
+++ b/packages/web/src/capture/styles.css
@@ -1,0 +1,236 @@
+:root {
+  color: #f9fafb;
+  background: #111827;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  font-size: 16px;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 20% 10%,
+      rgba(79, 70, 229, 0.35),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #111827 0%, #0f172a 45%, #020617 100%);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+button {
+  border: 0;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.capture-shell {
+  width: min(100%, 42rem);
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: max(1rem, env(safe-area-inset-top)) 1rem
+    max(1rem, env(safe-area-inset-bottom));
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.hero,
+.panel {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1.5rem;
+  background: rgba(15, 23, 42, 0.78);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(16px);
+}
+
+.hero {
+  padding: 1.1rem;
+}
+
+.hero-top,
+.panel,
+.panel-actions,
+.connect-form,
+.install {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.hero-top,
+.panel,
+.install {
+  justify-content: space-between;
+}
+
+.eyebrow,
+.panel-label {
+  margin: 0;
+  color: #a5b4fc;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0.1rem 0 0;
+  font-size: clamp(1.9rem, 8vw, 3.2rem);
+  letter-spacing: -0.06em;
+}
+
+.main-link {
+  color: #c7d2fe;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.type-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.35rem;
+  margin: 1.1rem 0 0.75rem;
+  padding: 0.3rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.type-tabs button {
+  min-height: 2.4rem;
+  border-radius: 999px;
+  background: transparent;
+  color: #cbd5e1;
+  font-weight: 800;
+}
+
+.type-tabs button.active {
+  background: #f9fafb;
+  color: #111827;
+}
+
+.capture-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+textarea,
+input {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 1rem;
+  background: rgba(2, 6, 23, 0.72);
+  color: #f9fafb;
+  font-size: 1rem;
+  outline: none;
+}
+
+textarea {
+  min-height: 12rem;
+  padding: 1rem;
+  resize: vertical;
+}
+
+input {
+  min-height: 2.75rem;
+  padding: 0 0.85rem;
+}
+
+textarea:focus,
+input:focus {
+  border-color: #818cf8;
+  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.22);
+}
+
+.capture-form button,
+.secondary {
+  min-height: 2.8rem;
+  border-radius: 999px;
+  background: #818cf8;
+  color: #111827;
+  font-weight: 900;
+  padding: 0 1rem;
+}
+
+.ghost {
+  min-height: 2.8rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #e5e7eb;
+  font-weight: 800;
+  padding: 0 1rem;
+}
+
+.status,
+.panel p,
+.hint,
+.address {
+  margin: 0;
+}
+
+.status {
+  min-height: 1.5rem;
+  margin-top: 0.8rem;
+  color: #cbd5e1;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.panel {
+  padding: 1rem;
+}
+
+.panel p,
+.hint {
+  color: #cbd5e1;
+}
+
+.address {
+  margin-top: 0.15rem;
+  color: #f9fafb;
+  font-weight: 800;
+}
+
+.connect-form {
+  flex: 1;
+}
+
+.install {
+  align-items: flex-start;
+}
+
+@media (max-width: 560px) {
+  .capture-shell {
+    justify-content: flex-start;
+  }
+
+  .hero-top,
+  .panel,
+  .install,
+  .connect-form,
+  .panel-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -308,6 +308,17 @@
 
       <div class="divider"></div>
 
+      <div class="section-label">Quick capture</div>
+      <a class="menu-item" role="menuitem" href="/capture/">
+        <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 5v14"></path>
+          <path d="M5 12h14"></path>
+        </svg>
+        Install capture app
+      </a>
+
+      <div class="divider"></div>
+
       <!-- Theme -->
       <div class="section-label">Theme</div>
       <div class="theme-switcher" role="radiogroup" aria-label="Theme">
@@ -697,6 +708,7 @@
     background: none;
     color: var(--text);
     font-size: 0.85rem;
+    text-decoration: none;
     cursor: pointer;
     transition: background 120ms;
   }

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -26,6 +26,10 @@ export default defineConfig({
         'icon-512.png',
       ],
       workbox: {
+        additionalManifestEntries: [
+          { url: '/', revision: version },
+          { url: '/capture/', revision: version },
+        ],
         cleanupOutdatedCaches: true,
         navigateFallback: '/index.html',
         globPatterns: ['**/*.{js,css,html,png,svg,webmanifest}'],
@@ -51,5 +55,11 @@ export default defineConfig({
     // 89 / Firefox 89 / Safari 15 — all 2021 baselines, well below our
     // supported floor.
     target: ['chrome89', 'edge89', 'firefox89', 'safari15'],
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        capture: path.resolve(__dirname, 'capture/index.html'),
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add a tiny `/capture/` PWA entry with its own manifest and install guidance
- support note, todo, and bookmark capture with immediate local queueing
- sync queued captures via the lightweight DirectRS client when connected/online
- add a main app menu link to open/install the capture app
- expose `@inbox-rs/rs-module/runtime` so capture can avoid importing the full rs-module entrypoint

## Dependency
Stacked on #126. Merge #126 first, then retarget this PR to `master` or let GitHub update after #126 lands.

## Performance Notes
- capture app build output is about 8.6 kB minified JS / 3.7 kB gzip, plus about 2.8 kB CSS / 1.2 kB gzip
- `/capture/` is added as a Workbox precache entry so the capture home-screen icon can launch offline after first visit
- capture does not import remotestoragejs, Tiptap, markdown/editor code, transcription code, or the main app data stores

## Verification
- `npm run check`
- `npm run test`
- `npm run build --workspace=packages/web`
