### PR TITLE
test(e2e): offline shell tests for service worker PR

### DIFF
--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -196,6 +196,7 @@
     editingItem = undefined;
     preselectedCollectionId = collectionId;
     activeModal = 'todo';
+    void loadAddEntryModal();
   }
 
   function openView(item: InboxItem) {

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -164,9 +164,7 @@
     const file = input.files?.[0];
     if (file) {
       open = false;
-      void loadImportExportModal().then(() => {
-        importExportModal?.promptImport(file);
-      });
+      void withImportExportModal((modal) => modal.promptImport(file));
     }
     input.value = '';
   }

--- a/tests/e2e/desktop/offline-resilience.spec.ts
+++ b/tests/e2e/desktop/offline-resilience.spec.ts
@@ -3,59 +3,77 @@
  *
  * The web app uses remotestoragejs's caching layer (`rs.caching.enable('/inbox/')`)
  * which keeps everything in IndexedDB and replays writes when the network
- * returns. We don't ship a service worker yet, so an offline cold-load is
- * expected to fail — but a *warm* offline load (already-loaded SPA losing
- * network) must keep the cached UI usable.
+ * returns. A Workbox service worker precaches the app shell so reloads work
+ * offline after one online visit.
  */
 
 import { expect, test } from '../helpers/fixtures';
-import { attachConsoleCapture } from '../helpers/pwa';
+import {
+  attachConsoleCapture,
+  waitForServiceWorkerController,
+} from '../helpers/pwa';
 
 test('warm offline still renders shell', async ({
   connectedPage,
   webOrigin,
 }) => {
-  // Load the app, then go offline and reload. With no service worker
-  // today this WILL fail to navigate — that's the documented behaviour
-  // we want to lock in so a future SW addition is an obvious test diff.
-  //
-  // To rephrase: this test is a *characterization test*. When we ship
-  // the PWA service worker, flip the assertion at the bottom and the
-  // suite will tell you the moment offline-first regresses.
   attachConsoleCapture(connectedPage);
   await connectedPage.goto(webOrigin);
   await connectedPage.waitForLoadState('networkidle');
+  await waitForServiceWorkerController(connectedPage);
 
-  // We're in. Capture a sentinel from the live DOM so we can prove a
-  // subsequent offline interaction worked against cached data.
   await expect(
     connectedPage.getByRole('button', { name: 'Inbox' }).first(),
   ).toBeVisible();
 
-  // Drop the network. Existing in-memory app keeps working — RS's
-  // IndexedDB cache satisfies reads, writes queue up.
   await connectedPage.context().setOffline(true);
-  // The hash router doesn't hit the network, so this should still work.
+
   await connectedPage.getByRole('button', { name: 'Collections' }).click();
   await expect(
     connectedPage.getByRole('button', { name: 'Collections' }).first(),
   ).toHaveAttribute('aria-current', 'page');
 
-  // Re-online for cleanup so the context teardown doesn't spam errors.
+  const reload = await connectedPage.reload({
+    waitUntil: 'domcontentloaded',
+    timeout: 15_000,
+  });
+  expect(reload?.ok()).toBeTruthy();
+  await expect(
+    connectedPage.getByRole('button', { name: 'Inbox' }).first(),
+  ).toBeVisible();
+
   await connectedPage.context().setOffline(false);
 });
 
-test('cold offline load is blocked without service worker', async ({
+test('cold offline load fails without a prior visit', async ({
   page,
   webOrigin,
 }) => {
-  // Without a service worker, a fully-offline cold load can't reach the
-  // server. Documented here so a regression means somebody added (or
-  // removed) a SW and forgot to update either the docs or the test.
   await page.context().setOffline(true);
 
-  // Playwright surfaces network failures as a navigation error.
   await expect(page.goto(webOrigin, { timeout: 5_000 })).rejects.toThrow(
     /net::ERR_INTERNET_DISCONNECTED|NS_ERROR_OFFLINE|net::ERR_FAILED/i,
   );
+});
+
+test('offline reload serves app shell after service worker install', async ({
+  page,
+  webOrigin,
+}) => {
+  await page.goto(webOrigin);
+  await page.waitForLoadState('networkidle');
+  await waitForServiceWorkerController(page);
+
+  await page.context().setOffline(true);
+
+  const reload = await page.reload({
+    waitUntil: 'domcontentloaded',
+    timeout: 15_000,
+  });
+  expect(reload?.ok()).toBeTruthy();
+  await expect(
+    page.getByRole('button', { name: 'Inbox' }).first(),
+  ).toBeVisible();
+
+  await page.context().setOffline(false);
 });

--- a/tests/e2e/desktop/offline-resilience.spec.ts
+++ b/tests/e2e/desktop/offline-resilience.spec.ts
@@ -8,16 +8,12 @@
  */
 
 import { expect, test } from '../helpers/fixtures';
-import {
-  attachConsoleCapture,
-  waitForServiceWorkerController,
-} from '../helpers/pwa';
+import { waitForServiceWorkerController } from '../helpers/pwa';
 
 test('warm offline still renders shell', async ({
   connectedPage,
   webOrigin,
 }) => {
-  attachConsoleCapture(connectedPage);
   await connectedPage.goto(webOrigin);
   await connectedPage.waitForLoadState('networkidle');
   await waitForServiceWorkerController(connectedPage);

--- a/tests/e2e/desktop/offline-then-connect.spec.ts
+++ b/tests/e2e/desktop/offline-then-connect.spec.ts
@@ -1,9 +1,9 @@
 /**
  * Offline → online → connect transitions.
  *
- * Both scenarios start with the disconnected app shell loaded online (we
- * don't ship a service worker yet, so a *cold* offline load is expected
- * to fail — see `offline-resilience.spec.ts`). The network is then
+ * Both scenarios start with the disconnected app shell loaded online so the
+ * service worker can install (see `offline-resilience.spec.ts` for cold-load
+ * behaviour without a prior visit). The network is then
  * dropped to exercise the "user opened the page on a flaky connection"
  * path, brought back, and the connect flow runs to completion.
  *

--- a/tests/e2e/helpers/pwa.ts
+++ b/tests/e2e/helpers/pwa.ts
@@ -61,6 +61,21 @@ function rsLocalStoragePayload(
  * the web app's `RemoteStorage` constructor runs, the auth state is in
  * place and the connect widget skips straight to the connected UI.
  */
+/**
+ * Wait until the production service worker controls the page.
+ *
+ * Call after the first navigation to the app origin so Workbox has finished
+ * installing and `clients.claim()` has taken effect.
+ */
+export async function waitForServiceWorkerController(
+  page: Page,
+): Promise<void> {
+  await page.waitForFunction(
+    () => navigator.serviceWorker?.controller != null,
+    { timeout: 15_000 },
+  );
+}
+
 export async function seedRsSession(
   context: BrowserContext,
   user: RsUser,

--- a/tests/e2e/helpers/pwa.ts
+++ b/tests/e2e/helpers/pwa.ts
@@ -54,14 +54,6 @@ function rsLocalStoragePayload(
 }
 
 /**
- * Pre-populate the browser context with an authorized RS session.
- *
- * Must be called *before* the page navigates to the app. Internally uses
- * `addInitScript`, which fires before any page script — so by the time
- * the web app's `RemoteStorage` constructor runs, the auth state is in
- * place and the connect widget skips straight to the connected UI.
- */
-/**
  * Wait until the production service worker controls the page.
  *
  * Call after the first navigation to the app origin so Workbox has finished
@@ -76,6 +68,14 @@ export async function waitForServiceWorkerController(
   );
 }
 
+/**
+ * Pre-populate the browser context with an authorized RS session.
+ *
+ * Must be called *before* the page navigates to the app. Internally uses
+ * `addInitScript`, which fires before any page script — so by the time
+ * the web app's `RemoteStorage` constructor runs, the auth state is in
+ * place and the connect widget skips straight to the connected UI.
+ */
 export async function seedRsSession(
   context: BrowserContext,
   user: RsUser,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #126 — updates e2e coverage and fixes a lazy-load race so the offline-first PWA work is testable and merge-ready.

## Changes

- **E2E (`offline-resilience.spec.ts`)**
  - Document Workbox app-shell caching instead of “no service worker”
  - Warm offline test now reloads while offline and expects HTTP 200 + shell
  - Keeps “cold load fails without prior visit” for never-installed SW
  - Adds “offline reload serves shell after SW install”
- **`waitForServiceWorkerController`** helper in `tests/e2e/helpers/pwa.ts`
- **`UserMenu.svelte`**: `withImportExportModal()` awaits chunk load + `tick()` before calling `startExport` / `promptImport`
- **`App.svelte`**: `openAddTodoInCollection` eagerly loads add-entry modal chunk

## Verification

- `npm run check`
- `npm run test`

E2E not run in CI here (requires Docker/Armadietto); should pass in the main e2e workflow once #126 lands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b43e7e43-586e-4686-9131-43693eda3195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b43e7e43-586e-4686-9131-43693eda3195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

