### PR TITLE
fix(ci): unblock release workflow

### DIFF
--- a/Dockerfile.armadietto
+++ b/Dockerfile.armadietto
@@ -1,5 +1,9 @@
 FROM node:20-alpine
-RUN npm install -g armadietto
+RUN npm install -g \
+  armadietto@0.6.5 \
+  @aws-sdk/client-s3@3.525.0 \
+  @aws-sdk/lib-storage@3.525.1 \
+  @smithy/node-http-handler@2.5.0
 COPY armadietto.conf.json /etc/armadietto/config.json
 EXPOSE 8000
 CMD ["armadietto", "-c", "/etc/armadietto/config.json"]

--- a/packages/extension/manifest.firefox.json
+++ b/packages/extension/manifest.firefox.json
@@ -3,15 +3,8 @@
   "name": "Inbox RS",
   "version": "2.2.4",
   "description": "Save links, text, and more to your remoteStorage inbox.",
-  "permissions": [
-    "contextMenus",
-    "activeTab",
-    "storage",
-    "identity"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["contextMenus", "activeTab", "storage", "identity"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Inbox RS",
@@ -22,9 +15,7 @@
     }
   },
   "background": {
-    "scripts": [
-      "service-worker.js"
-    ],
+    "scripts": ["service-worker.js"],
     "type": "module"
   },
   "browser_specific_settings": {
@@ -32,21 +23,15 @@
       "id": "inbox-rs@silverbucket.net",
       "strict_min_version": "126.0",
       "data_collection_permissions": {
-        "required": [
-          "none"
-        ],
+        "required": ["none"],
         "optional": []
       }
     }
   },
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content-metadata.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["content-metadata.js"],
       "run_at": "document_idle"
     }
   ],

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -3,15 +3,8 @@
   "name": "Inbox RS",
   "version": "2.2.4",
   "description": "Save links, text, and more to your remoteStorage inbox.",
-  "permissions": [
-    "contextMenus",
-    "activeTab",
-    "storage",
-    "identity"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["contextMenus", "activeTab", "storage", "identity"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Inbox RS",
@@ -27,12 +20,8 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content-metadata.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["content-metadata.js"],
       "run_at": "document_idle"
     }
   ],

--- a/packages/thunderbird/manifest.json
+++ b/packages/thunderbird/manifest.json
@@ -9,12 +9,7 @@
       "strict_min_version": "128.0"
     }
   },
-  "permissions": [
-    "messagesRead",
-    "storage",
-    "identity",
-    "<all_urls>"
-  ],
+  "permissions": ["messagesRead", "storage", "identity", "<all_urls>"],
   "message_display_action": {
     "default_popup": "src/popup/index.html",
     "default_title": "Save to Inbox RS",
@@ -26,9 +21,7 @@
     }
   },
   "background": {
-    "scripts": [
-      "background.js"
-    ],
+    "scripts": ["background.js"],
     "type": "module"
   },
   "options_ui": {

--- a/scripts/release-bump.mjs
+++ b/scripts/release-bump.mjs
@@ -124,11 +124,18 @@ export function previousTag(gitCwd = rootDir) {
   }
 }
 
-/** Set `version` in a JSON file in-place, preserving the trailing newline. */
+/** Set `version` in a JSON file in-place. Biome formats it afterwards. */
 function setVersionInFile(absPath, version) {
   const json = JSON.parse(readFileSync(absPath, 'utf8'));
   json.version = version;
   writeFileSync(absPath, `${JSON.stringify(json, null, 2)}\n`);
+}
+
+function formatFiles(files) {
+  execFileSync('npx', ['biome', 'format', '--write', ...files], {
+    cwd: rootDir,
+    stdio: 'inherit',
+  });
 }
 
 /** CLI entrypoint. Logs every bump (and every skip) so release logs are readable. */
@@ -187,6 +194,8 @@ export function main(argv = process.argv) {
     setVersionInFile(join(rootDir, file), version);
     console.log(`[release-bump] ${file} → ${version}`);
   }
+
+  formatFiles(plan.map(({ file }) => file));
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {


### PR DESCRIPTION
## Summary
- format the v2.2.4 extension and Thunderbird manifests so CI passes on master
- format release-bump JSON outputs with Biome before committing release bumps
- pin Armadietto and AWS SDK packages in the Docker image to avoid broken latest dependency resolution

## Verification
- npm run check
- npm run test

Note: local Docker image build could not be verified because the Docker daemon socket is unavailable in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Firefox and Thunderbird extension manifests to ensure proper permissions configuration and compatibility
  * Standardized JSON formatting across configuration files
  * Pinned package versions for improved stability
  * Automated code formatting in the release process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->