### PR TITLE
fix(ci): harden release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,14 @@ jobs:
       - run: npm ci
       - run: npm install @rollup/rollup-linux-x64-gnu --no-save
 
+      - name: Restore transcription asset cache
+        uses: actions/cache@v4
+        with:
+          path: packages/web/public/ml
+          key: ${{ runner.os }}-transcription-assets-${{ hashFiles('scripts/vendor-transcription-assets.mjs', 'package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-transcription-assets-
+
       - run: npm run build
 
       # Stash the built web app so the e2e job doesn't pay for a second
@@ -64,6 +72,14 @@ jobs:
 
       - run: npm ci
       - run: npm install @rollup/rollup-linux-x64-gnu --no-save
+
+      - name: Restore transcription asset cache
+        uses: actions/cache@v4
+        with:
+          path: packages/web/public/ml
+          key: ${{ runner.os }}-transcription-assets-${{ hashFiles('scripts/vendor-transcription-assets.mjs', 'package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-transcription-assets-
 
       # Other workspaces resolve @inbox-rs/rs-module via its `main:
       # dist/index.js`, so the dist must exist before vitest can import it.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
               --commit "$SHA" \
               --json status,conclusion,headSha,url \
               --jq '[.[] | select(.headSha=="'"$SHA"'")] | first // {status:"",conclusion:"",url:""}' \
-              || echo '{"status":"","conclusion":"","url":""}')
+              || jq -n '{status:"",conclusion:"",url:""}')
 
             STATUS=$(jq -r '.status // ""' <<< "$RUN")
             CONCLUSION=$(jq -r '.conclusion // ""' <<< "$RUN")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,18 +30,35 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ github.sha }}
         run: |
-          STATUS=$(gh run list \
-            --workflow=ci.yml \
-            --branch=master \
-            --commit "$SHA" \
-            --json status,conclusion \
-            --jq '[.[] | select(.status=="completed")] | .[0].conclusion' \
-            || echo "")
-          echo "ci.yml conclusion for $SHA: ${STATUS:-<none>}"
-          if [ "$STATUS" != "success" ]; then
-            echo "::error::Refusing to release: ci.yml has not passed for $SHA. Re-run CI on master and try again."
-            exit 1
-          fi
+          for attempt in {1..60}; do
+            RUN=$(gh run list \
+              --workflow="CI" \
+              --branch=master \
+              --commit "$SHA" \
+              --json status,conclusion,headSha,url \
+              --jq '[.[] | select(.headSha=="'"$SHA"'")] | first // {status:"",conclusion:"",url:""}' \
+              || echo '{"status":"","conclusion":"","url":""}')
+
+            STATUS=$(jq -r '.status // ""' <<< "$RUN")
+            CONCLUSION=$(jq -r '.conclusion // ""' <<< "$RUN")
+            URL=$(jq -r '.url // ""' <<< "$RUN")
+
+            echo "CI status for $SHA: ${STATUS:-<none>} ${CONCLUSION:-}"
+
+            if [ "$STATUS" = "completed" ] && [ "$CONCLUSION" = "success" ]; then
+              exit 0
+            fi
+
+            if [ "$STATUS" = "completed" ]; then
+              echo "::error::CI completed for $SHA but did not succeed (conclusion: $CONCLUSION). $URL"
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          echo "::error::Timed out waiting for CI to complete for $SHA on master."
+          exit 1
 
   release:
     runs-on: ubuntu-latest
@@ -59,6 +76,14 @@ jobs:
 
       - run: npm ci
       - run: npm install @rollup/rollup-linux-x64-gnu --no-save
+
+      - name: Restore transcription asset cache
+        uses: actions/cache@v4
+        with:
+          path: packages/web/public/ml
+          key: ${{ runner.os }}-transcription-assets-${{ hashFiles('scripts/vendor-transcription-assets.mjs', 'package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-transcription-assets-
 
       - name: Configure git
         run: |
@@ -84,6 +109,9 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: node scripts/release-bump.mjs "$VERSION"
 
+      - name: Build web app
+        run: npm run build
+
       - name: Commit version bump and tag
         # This clean commit (no build artifacts) is what gets pushed to origin/master.
         # `git add -u` picks up exactly what release-bump.mjs touched — which
@@ -96,9 +124,6 @@ jobs:
           git commit -m "release v${VERSION}"
           git tag "v${VERSION}"
           git push origin HEAD:master --tags
-
-      - name: Build web app
-        run: npm run build
 
       - name: Setup SSH for 5apps
         env:

--- a/scripts/vendor-transcription-assets.mjs
+++ b/scripts/vendor-transcription-assets.mjs
@@ -86,6 +86,7 @@ const modelBaseUrl = `https://huggingface.co/${MODEL_ID}/resolve/${MODEL_REVISIO
 const forceRefresh =
   process.argv.includes('--refresh') ||
   process.env.FORCE_VENDOR_TRANSCRIPTION_ASSETS === '1';
+const MAX_DOWNLOAD_ATTEMPTS = 5;
 
 async function ensureDir(dir) {
   await mkdir(dir, { recursive: true });
@@ -104,6 +105,64 @@ async function fileMatchesManifest(file, asset) {
   } catch {
     return false;
   }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseRetryAfterMs(header) {
+  if (!header) return null;
+
+  const seconds = Number(header);
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, seconds * 1000);
+  }
+
+  const timestamp = Date.parse(header);
+  if (Number.isNaN(timestamp)) return null;
+  return Math.max(0, timestamp - Date.now());
+}
+
+function isRetryableDownloadStatus(status) {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+async function fetchWithRetry(url) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= MAX_DOWNLOAD_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetch(url);
+      if (
+        response.ok ||
+        !isRetryableDownloadStatus(response.status) ||
+        attempt === MAX_DOWNLOAD_ATTEMPTS
+      ) {
+        return response;
+      }
+
+      const retryAfterMs = parseRetryAfterMs(
+        response.headers.get('retry-after'),
+      );
+      const delayMs = retryAfterMs ?? 1000 * 2 ** (attempt - 1);
+      console.warn(
+        `[vendor-transcription-assets] retrying ${url} after ${response.status} ${response.statusText} (attempt ${attempt}/${MAX_DOWNLOAD_ATTEMPTS})`,
+      );
+      await sleep(delayMs);
+    } catch (error) {
+      lastError = error;
+      if (attempt === MAX_DOWNLOAD_ATTEMPTS) break;
+
+      const delayMs = 1000 * 2 ** (attempt - 1);
+      console.warn(
+        `[vendor-transcription-assets] retrying ${url} after download error (attempt ${attempt}/${MAX_DOWNLOAD_ATTEMPTS})`,
+      );
+      await sleep(delayMs);
+    }
+  }
+
+  throw lastError;
 }
 
 async function copyStaticFile(source, destination, asset) {
@@ -128,7 +187,7 @@ async function downloadStaticFile(url, destination, asset) {
     return;
   }
 
-  const response = await fetch(url);
+  const response = await fetchWithRetry(url);
   if (!response.ok) {
     throw new Error(
       `Failed to download ${url}: ${response.status} ${response.statusText}`,


### PR DESCRIPTION
## Summary
- wait for the exact master CI run in release preflight instead of failing while CI is still queued or running
- build the web app before pushing the release commit and tag, preventing another partial release on build failure
- cache vendored transcription assets in CI and release jobs to reduce external downloads
- retry transient transcription asset downloads, including Hugging Face 429 responses, while preserving checksum validation

## Verification
- npm run check
- npm run test
- git diff --check

## Release note
v2.2.5 already exists from the failed release attempt. The next successful patch release should be v2.2.6 unless the failed tag/commit is manually cleaned up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CI/CD workflow with asset caching to accelerate build times
  * Improved build robustness with automatic retry logic for downloading dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->