### PR TITLE
test(e2e): offline shell tests for service worker

### DIFF
--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -196,6 +196,7 @@
     editingItem = undefined;
     preselectedCollectionId = collectionId;
     activeModal = 'todo';
+    void loadAddEntryModal();
   }
 
   function openView(item: InboxItem) {

--- a/tests/e2e/desktop/offline-resilience.spec.ts
+++ b/tests/e2e/desktop/offline-resilience.spec.ts
@@ -8,15 +8,15 @@
  */
 
 import { expect, test } from '../helpers/fixtures';
-import { attachConsoleCapture } from '../helpers/pwa';
+import { waitForServiceWorkerController } from '../helpers/pwa';
 
 test('warm offline still renders shell', async ({
   connectedPage,
   webOrigin,
 }) => {
-  attachConsoleCapture(connectedPage);
   await connectedPage.goto(webOrigin);
   await connectedPage.waitForLoadState('networkidle');
+  await waitForServiceWorkerController(connectedPage);
 
   // We're in. Capture a sentinel from the live DOM so we can prove a
   // subsequent offline interaction worked against cached data.
@@ -24,16 +24,14 @@ test('warm offline still renders shell', async ({
     connectedPage.getByRole('button', { name: 'Inbox' }).first(),
   ).toBeVisible();
 
-  // Drop the network. Existing in-memory app keeps working — RS's
-  // IndexedDB cache satisfies reads, writes queue up.
+  // Drop the network. Existing in-memory app keeps working: RS's IndexedDB
+  // cache satisfies reads, writes queue up, and the hash router stays local.
   await connectedPage.context().setOffline(true);
-  // The hash router doesn't hit the network, so this should still work.
   await connectedPage.getByRole('button', { name: 'Collections' }).click();
   await expect(
     connectedPage.getByRole('button', { name: 'Collections' }).first(),
   ).toHaveAttribute('aria-current', 'page');
 
-  // Re-online for cleanup so the context teardown doesn't spam errors.
   await connectedPage.context().setOffline(false);
 });
 
@@ -83,4 +81,26 @@ test('first-ever offline load still requires one online visit', async ({
   } finally {
     await context.close();
   }
+});
+
+test('offline reload serves app shell after service worker install', async ({
+  page,
+  webOrigin,
+}) => {
+  await page.goto(webOrigin);
+  await page.waitForLoadState('networkidle');
+  await waitForServiceWorkerController(page);
+
+  await page.context().setOffline(true);
+
+  const reload = await page.reload({
+    waitUntil: 'domcontentloaded',
+    timeout: 15_000,
+  });
+  expect(reload?.ok()).toBeTruthy();
+  await expect(
+    page.getByRole('button', { name: 'Inbox' }).first(),
+  ).toBeVisible();
+
+  await page.context().setOffline(false);
 });

--- a/tests/e2e/desktop/offline-then-connect.spec.ts
+++ b/tests/e2e/desktop/offline-then-connect.spec.ts
@@ -1,9 +1,9 @@
 /**
  * Offline → online → connect transitions.
  *
- * Both scenarios start with the disconnected app shell loaded online (we
- * don't ship a service worker yet, so a *cold* offline load is expected
- * to fail — see `offline-resilience.spec.ts`). The network is then
+ * Both scenarios start with the disconnected app shell loaded online so the
+ * service worker can install (see `offline-resilience.spec.ts` for cold-load
+ * behaviour without a prior visit). The network is then
  * dropped to exercise the "user opened the page on a flaky connection"
  * path, brought back, and the connect flow runs to completion.
  *

--- a/tests/e2e/helpers/pwa.ts
+++ b/tests/e2e/helpers/pwa.ts
@@ -61,6 +61,21 @@ function rsLocalStoragePayload(
  * the web app's `RemoteStorage` constructor runs, the auth state is in
  * place and the connect widget skips straight to the connected UI.
  */
+/**
+ * Wait until the production service worker controls the page.
+ *
+ * Call after the first navigation to the app origin so Workbox has finished
+ * installing and `clients.claim()` has taken effect.
+ */
+export async function waitForServiceWorkerController(
+  page: Page,
+): Promise<void> {
+  await page.waitForFunction(
+    () => navigator.serviceWorker?.controller != null,
+    { timeout: 15_000 },
+  );
+}
+
 export async function seedRsSession(
   context: BrowserContext,
   user: RsUser,

--- a/tests/e2e/helpers/pwa.ts
+++ b/tests/e2e/helpers/pwa.ts
@@ -54,14 +54,6 @@ function rsLocalStoragePayload(
 }
 
 /**
- * Pre-populate the browser context with an authorized RS session.
- *
- * Must be called *before* the page navigates to the app. Internally uses
- * `addInitScript`, which fires before any page script — so by the time
- * the web app's `RemoteStorage` constructor runs, the auth state is in
- * place and the connect widget skips straight to the connected UI.
- */
-/**
  * Wait until the production service worker controls the page.
  *
  * Call after the first navigation to the app origin so Workbox has finished
@@ -76,6 +68,14 @@ export async function waitForServiceWorkerController(
   );
 }
 
+/**
+ * Pre-populate the browser context with an authorized RS session.
+ *
+ * Must be called *before* the page navigates to the app. Internally uses
+ * `addInitScript`, which fires before any page script — so by the time
+ * the web app's `RemoteStorage` constructor runs, the auth state is in
+ * place and the connect widget skips straight to the connected UI.
+ */
 export async function seedRsSession(
   context: BrowserContext,
   user: RsUser,


### PR DESCRIPTION
## Summary

Recreates #129 against master. The original PR targeted `pwa-full-app-offline-performance`, but its dependency (#126) has since landed on master.

## Changes

- Add `waitForServiceWorkerController` helper for deterministic service-worker e2e tests.
- Update offline resilience coverage for installed app-shell offline loads and offline reloads after SW control.
- Clarify the offline-then-connect test description around the required first online visit.
- Eagerly start loading the add-entry modal chunk for collection-specific add-todo flows.

## Verification

- `npx @sveltejs/mcp svelte-autofixer ./packages/web/src/App.svelte --svelte-version 5`
- `npm run check`
- `npm run test`

## Dependencies

No remaining dependency PRs. #126 is already included in master as `4a07403 perf(web): make full app offline-first`.
