### PR TITLE
feat(web): add offline transcription asset storage

### DIFF
--- a/packages/web/src/components/OfflineTranscriptionAssets.svelte
+++ b/packages/web/src/components/OfflineTranscriptionAssets.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import {
+    downloadTranscriptionAssets,
+    formatTranscriptionAssetBytes,
+    getTranscriptionAssetStatus,
+    type TranscriptionAssetStatus,
+  } from '../lib/transcription-assets';
+
+  let status = $state<TranscriptionAssetStatus | null>(null);
+  let downloading = $state(false);
+  let error = $state('');
+
+  const percent = $derived(
+    status && status.totalBytes > 0
+      ? Math.round((status.storedBytes / status.totalBytes) * 100)
+      : 0,
+  );
+
+  onMount(() => {
+    void refreshStatus();
+  });
+
+  async function refreshStatus() {
+    status = await getTranscriptionAssetStatus();
+  }
+
+  async function downloadAssets() {
+    downloading = true;
+    error = '';
+    try {
+      status = await downloadTranscriptionAssets((progress) => {
+        status = progress;
+      });
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Download failed';
+    } finally {
+      downloading = false;
+    }
+  }
+</script>
+
+<div class="offline-transcription">
+  {#if status?.ready}
+    <p>Transcription model saved for offline use.</p>
+  {:else if status}
+    <p>
+      Download transcription model for offline use ({formatTranscriptionAssetBytes(
+        status.totalBytes,
+      )}).
+    </p>
+    <button type="button" onclick={downloadAssets} disabled={downloading}>
+      {downloading ? `Downloading ${percent}%` : 'Download offline transcription'}
+    </button>
+    {#if downloading}
+      <progress max="100" value={percent}>{percent}%</progress>
+    {/if}
+  {/if}
+  {#if error}
+    <p class="error">{error}</p>
+  {/if}
+</div>
+
+<style>
+  .offline-transcription {
+    display: grid;
+    gap: 0.45rem;
+    margin-top: 0.65rem;
+    color: var(--text-muted);
+    font-size: 0.86rem;
+  }
+
+  .offline-transcription p {
+    margin: 0;
+  }
+
+  .offline-transcription button {
+    justify-self: start;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    padding: 0.42rem 0.75rem;
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .offline-transcription button:disabled {
+    cursor: default;
+    opacity: 0.65;
+  }
+
+  .offline-transcription progress {
+    width: min(18rem, 100%);
+  }
+
+  .offline-transcription .error {
+    color: var(--danger);
+  }
+</style>

--- a/packages/web/src/components/add-entry/AudioForm.svelte
+++ b/packages/web/src/components/add-entry/AudioForm.svelte
@@ -8,6 +8,7 @@
   } from '../../lib/add-entry-modal';
   import { buildAudioItem } from '../../lib/build-item';
   import { transcribeAudio } from '../../lib/transcribe';
+  import OfflineTranscriptionAssets from '../OfflineTranscriptionAssets.svelte';
 
   let {
     editItem,
@@ -187,6 +188,7 @@
   {#if transcribing}
     <p class="transcript-status">Transcribing...</p>
   {/if}
+  <OfflineTranscriptionAssets />
   {#if transcript}
     <div class="field">
       <span>Transcript</span>

--- a/packages/web/src/components/view-card/AudioView.svelte
+++ b/packages/web/src/components/view-card/AudioView.svelte
@@ -3,6 +3,7 @@
   import { blobUrls, connected, loadFileBlobUrl, storeItem } from '../../lib/stores';
   import rs from '../../lib/rs';
   import { transcribeAudio } from '../../lib/transcribe';
+  import OfflineTranscriptionAssets from '../OfflineTranscriptionAssets.svelte';
 
   let { item, titleId }: { item: AudioItem; titleId: string } = $props();
 
@@ -92,6 +93,7 @@
       >Transcribe</button
     >
   {/if}
+  <OfflineTranscriptionAssets />
 </div>
 
 {#if item.body}

--- a/packages/web/src/lib/transcribe.test.ts
+++ b/packages/web/src/lib/transcribe.test.ts
@@ -12,6 +12,10 @@ import {
   TRANSCRIPTION_WASM_BASE_PATH,
   TRANSCRIPTION_WASM_FILES,
 } from './transcribe';
+import {
+  formatTranscriptionAssetBytes,
+  TRANSCRIPTION_ASSETS,
+} from './transcription-assets';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../../../..');
@@ -25,10 +29,14 @@ describe('configureTranscriptionEnv', () => {
       allowLocalModels: false,
       allowRemoteModels: true,
       localModelPath: '/',
+      useBrowserCache: true,
+      useCustomCache: false,
+      customCache: null,
       backends: {
         onnx: {
           wasm: {
             wasmPaths: '/cdn/',
+            numThreads: undefined as number | undefined,
           },
         },
       },
@@ -39,7 +47,40 @@ describe('configureTranscriptionEnv', () => {
     expect(env.allowLocalModels).toBe(true);
     expect(env.allowRemoteModels).toBe(false);
     expect(env.localModelPath).toBe(TRANSCRIPTION_MODEL_BASE_PATH);
+    expect(env.useBrowserCache).toBe(true);
+    expect(env.useCustomCache).toBe(false);
+    expect(env.customCache).toBe(null);
     expect(env.backends.onnx.wasm.wasmPaths).toBe(TRANSCRIPTION_WASM_BASE_PATH);
+    expect(env.backends.onnx.wasm.numThreads).toBe(1);
+  });
+
+  it('uses custom cached transcription assets when provided', () => {
+    const customCache = { match: () => undefined, put: () => undefined };
+    const wasmPaths = { 'ort-wasm-simd.wasm': 'blob:test' };
+    const env = {
+      allowLocalModels: false,
+      allowRemoteModels: true,
+      localModelPath: '/',
+      useBrowserCache: true,
+      useCustomCache: false,
+      customCache: null as unknown,
+      backends: {
+        onnx: {
+          wasm: {
+            wasmPaths: '/cdn/' as string | Record<string, string>,
+            numThreads: undefined as number | undefined,
+          },
+        },
+      },
+    };
+
+    configureTranscriptionEnv(env, { assetCache: customCache, wasmPaths });
+
+    expect(env.useBrowserCache).toBe(false);
+    expect(env.useCustomCache).toBe(true);
+    expect(env.customCache).toBe(customCache);
+    expect(env.backends.onnx.wasm.wasmPaths).toBe(wasmPaths);
+    expect(env.backends.onnx.wasm.numThreads).toBe(1);
   });
 });
 
@@ -74,5 +115,27 @@ describe('vendored transcription assets', () => {
         `Missing ONNX Runtime asset: ${path.relative(repoRoot, file)}`,
       ).toBe(true);
     }
+  });
+
+  it('tracks every local transcription file in the offline asset manifest', () => {
+    const expectedUrls = new Set([
+      ...TRANSCRIPTION_MODEL_FILES.map(
+        (file) =>
+          `${TRANSCRIPTION_MODEL_BASE_PATH}${TRANSCRIPTION_MODEL_ID}/${file}`,
+      ),
+      ...TRANSCRIPTION_WASM_FILES.map(
+        (file) => `${TRANSCRIPTION_WASM_BASE_PATH}${file}`,
+      ),
+    ]);
+
+    expect(new Set(TRANSCRIPTION_ASSETS.map((asset) => asset.url))).toEqual(
+      expectedUrls,
+    );
+    expect(TRANSCRIPTION_ASSETS.every((asset) => asset.size > 0)).toBe(true);
+  });
+
+  it('formats offline transcription asset sizes for the UI', () => {
+    expect(formatTranscriptionAssetBytes(1024)).toBe('1 KB');
+    expect(formatTranscriptionAssetBytes(10 * 1024 * 1024)).toBe('10 MB');
   });
 });

--- a/packages/web/src/lib/transcribe.ts
+++ b/packages/web/src/lib/transcribe.ts
@@ -1,3 +1,22 @@
+export {
+  TRANSCRIPTION_MODEL_BASE_PATH,
+  TRANSCRIPTION_MODEL_FILES,
+  TRANSCRIPTION_MODEL_ID,
+  TRANSCRIPTION_MODEL_REVISION,
+  TRANSCRIPTION_WASM_BASE_PATH,
+  TRANSCRIPTION_WASM_FILES,
+} from './transcription-manifest';
+
+import {
+  createStoredWasmPaths,
+  createTranscriptionAssetCache,
+} from './transcription-assets';
+import {
+  TRANSCRIPTION_MODEL_BASE_PATH,
+  TRANSCRIPTION_MODEL_ID,
+  TRANSCRIPTION_WASM_BASE_PATH,
+} from './transcription-manifest';
+
 // The pipeline returned by @xenova/transformers is a callable instance whose
 // own published types are too involved to be useful here — it's effectively a
 // `(input, opts) => Promise<{ text: string }>` for whisper. Treat it as such.
@@ -10,48 +29,48 @@ type TransformersEnv = {
   allowLocalModels: boolean;
   allowRemoteModels: boolean;
   localModelPath: string;
+  useBrowserCache: boolean;
+  useCustomCache: boolean;
+  customCache: unknown;
   backends: {
     onnx: {
       wasm: {
-        wasmPaths: string;
+        wasmPaths: string | Record<string, string>;
+        numThreads?: number;
       };
     };
   };
 };
 
-export const TRANSCRIPTION_MODEL_ID = 'Xenova/whisper-tiny';
-export const TRANSCRIPTION_MODEL_REVISION =
-  '5332fcc35e32a33b86612b9a57a89be7906102b1';
-export const TRANSCRIPTION_MODEL_BASE_PATH = '/ml/models/';
-export const TRANSCRIPTION_WASM_BASE_PATH = '/ml/onnxruntime/';
-export const TRANSCRIPTION_MODEL_FILES = [
-  'config.json',
-  'generation_config.json',
-  'preprocessor_config.json',
-  'tokenizer.json',
-  'tokenizer_config.json',
-  'onnx/encoder_model_quantized.onnx',
-  'onnx/decoder_model_merged_quantized.onnx',
-] as const;
-export const TRANSCRIPTION_WASM_FILES = [
-  'ort-wasm.wasm',
-  'ort-wasm-simd.wasm',
-  'ort-wasm-threaded.wasm',
-  'ort-wasm-threaded.js',
-  'ort-wasm-threaded.worker.js',
-  'ort-wasm-simd-threaded.wasm',
-] as const;
+type TranscriptionEnvOptions = {
+  assetCache?: unknown;
+  wasmPaths?: Record<string, string>;
+};
 
 let transcriber: Transcriber | null = null;
 let loadPromise: Promise<Transcriber> | null = null;
 
-export function configureTranscriptionEnv(env: TransformersEnv) {
+export function configureTranscriptionEnv(
+  env: TransformersEnv,
+  options: TranscriptionEnvOptions = {},
+) {
   // Keep inference entirely same-origin so the runtime does not fall back to
   // remote models or CDN-hosted ONNX assets.
   env.allowLocalModels = true;
   env.allowRemoteModels = false;
   env.localModelPath = TRANSCRIPTION_MODEL_BASE_PATH;
-  env.backends.onnx.wasm.wasmPaths = TRANSCRIPTION_WASM_BASE_PATH;
+  if (options.assetCache) {
+    env.useBrowserCache = false;
+    env.useCustomCache = true;
+    env.customCache = options.assetCache;
+  }
+  env.backends.onnx.wasm.wasmPaths = Object.keys(options.wasmPaths ?? {}).length
+    ? (options.wasmPaths as Record<string, string>)
+    : TRANSCRIPTION_WASM_BASE_PATH;
+  // `wasmPaths` only overrides WASM files, not ONNX Runtime's threaded worker
+  // script. Keep transcription on the non-threaded runtime so cached blob URLs
+  // are enough for offline inference.
+  env.backends.onnx.wasm.numThreads = 1;
 }
 
 async function getTranscriber() {
@@ -60,7 +79,10 @@ async function getTranscriber() {
   loadPromise = (async () => {
     try {
       const { pipeline, env } = await import('@xenova/transformers');
-      configureTranscriptionEnv(env as TransformersEnv);
+      configureTranscriptionEnv(env as TransformersEnv, {
+        assetCache: createTranscriptionAssetCache(),
+        wasmPaths: await createStoredWasmPaths(),
+      });
       transcriber = (await pipeline(
         'automatic-speech-recognition',
         TRANSCRIPTION_MODEL_ID,

--- a/packages/web/src/lib/transcription-assets.ts
+++ b/packages/web/src/lib/transcription-assets.ts
@@ -1,0 +1,303 @@
+import {
+  TRANSCRIPTION_MODEL_BASE_PATH,
+  TRANSCRIPTION_MODEL_FILES,
+  TRANSCRIPTION_MODEL_ID,
+  TRANSCRIPTION_MODEL_REVISION,
+  TRANSCRIPTION_WASM_BASE_PATH,
+  TRANSCRIPTION_WASM_FILES,
+} from './transcription-manifest';
+
+const DB_NAME = 'inbox-rs-transcription-assets';
+const DB_VERSION = 1;
+const STORE_NAME = 'assets';
+const ASSET_VERSION = `whisper-tiny:${TRANSCRIPTION_MODEL_REVISION}:ort-web`;
+const MAX_ASSET_AGE_MS = 1000 * 60 * 60 * 24 * 90;
+
+type StoredAsset = {
+  url: string;
+  version: string;
+  blob: Blob;
+  size: number;
+  storedAt: number;
+  lastAccessedAt: number;
+};
+
+export type TranscriptionAsset = {
+  url: string;
+  size: number;
+  kind: 'model' | 'runtime';
+};
+
+export type TranscriptionAssetStatus = {
+  ready: boolean;
+  storedBytes: number;
+  totalBytes: number;
+  storedAssets: number;
+  totalAssets: number;
+};
+
+export type TranscriptionAssetProgress = TranscriptionAssetStatus & {
+  currentUrl?: string;
+};
+
+const MODEL_ASSET_SIZES = new Map<string, number>([
+  ['config.json', 2248],
+  ['generation_config.json', 3716],
+  ['preprocessor_config.json', 339],
+  ['tokenizer.json', 2480466],
+  ['tokenizer_config.json', 282683],
+  ['onnx/encoder_model_quantized.onnx', 10124910],
+  ['onnx/decoder_model_merged_quantized.onnx', 30727765],
+]);
+
+const WASM_ASSET_SIZES = new Map<string, number>([
+  ['ort-wasm.wasm', 9223228],
+  ['ort-wasm-simd.wasm', 10014674],
+  ['ort-wasm-threaded.wasm', 9149637],
+  ['ort-wasm-threaded.js', 32695],
+  ['ort-wasm-threaded.worker.js', 2366],
+  ['ort-wasm-simd-threaded.wasm', 9960821],
+]);
+
+export const TRANSCRIPTION_ASSETS: TranscriptionAsset[] = [
+  ...TRANSCRIPTION_MODEL_FILES.map((file) => ({
+    url: `${TRANSCRIPTION_MODEL_BASE_PATH}${TRANSCRIPTION_MODEL_ID}/${file}`,
+    size: MODEL_ASSET_SIZES.get(file) ?? 0,
+    kind: 'model' as const,
+  })),
+  ...TRANSCRIPTION_WASM_FILES.map((file) => ({
+    url: `${TRANSCRIPTION_WASM_BASE_PATH}${file}`,
+    size: WASM_ASSET_SIZES.get(file) ?? 0,
+    kind: 'runtime' as const,
+  })),
+];
+
+const assetUrls = new Set(TRANSCRIPTION_ASSETS.map((asset) => asset.url));
+
+function normalizeUrl(input: RequestInfo | URL): string | null {
+  const raw =
+    typeof Request !== 'undefined' && input instanceof Request
+      ? input.url
+      : input.toString();
+  let url: URL;
+  try {
+    url = new URL(raw, window.location.origin);
+  } catch {
+    return null;
+  }
+  return `${url.pathname}${url.search}`;
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE_NAME, { keyPath: 'url' });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function withStore<T>(
+  mode: IDBTransactionMode,
+  fn: (store: IDBObjectStore) => IDBRequest<T> | undefined,
+): Promise<T | undefined> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, mode);
+    const store = tx.objectStore(STORE_NAME);
+    const request = fn(store);
+    let result: T | undefined;
+    if (request) {
+      request.onsuccess = () => {
+        result = request.result;
+      };
+      request.onerror = () => reject(request.error);
+    }
+    tx.oncomplete = () => {
+      db.close();
+      resolve(result);
+    };
+    tx.onerror = () => {
+      db.close();
+      reject(tx.error);
+    };
+  });
+}
+
+async function readAsset(url: string): Promise<StoredAsset | undefined> {
+  const asset = await withStore<StoredAsset>('readonly', (store) =>
+    store.get(url),
+  );
+  if (!asset || asset.version !== ASSET_VERSION) return undefined;
+  return asset;
+}
+
+async function writeAsset(url: string, blob: Blob) {
+  const now = Date.now();
+  const asset: StoredAsset = {
+    url,
+    version: ASSET_VERSION,
+    blob,
+    size: blob.size,
+    storedAt: now,
+    lastAccessedAt: now,
+  };
+  await withStore('readwrite', (store) => store.put(asset));
+}
+
+async function touchAsset(asset: StoredAsset) {
+  await withStore('readwrite', (store) =>
+    store.put({ ...asset, lastAccessedAt: Date.now() }),
+  );
+}
+
+async function deleteAsset(url: string) {
+  await withStore('readwrite', (store) => store.delete(url));
+}
+
+async function getAllAssets(): Promise<StoredAsset[]> {
+  return (
+    (await withStore<StoredAsset[]>('readonly', (store) => store.getAll())) ??
+    []
+  );
+}
+
+export function formatTranscriptionAssetBytes(bytes: number): string {
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${Math.round((bytes / (1024 * 1024)) * 10) / 10} MB`;
+}
+
+export async function cleanupExpiredTranscriptionAssets() {
+  if (typeof indexedDB === 'undefined') return;
+  const now = Date.now();
+  for (const asset of await getAllAssets()) {
+    if (
+      !assetUrls.has(asset.url) ||
+      asset.version !== ASSET_VERSION ||
+      now - asset.lastAccessedAt > MAX_ASSET_AGE_MS
+    ) {
+      await deleteAsset(asset.url);
+    }
+  }
+}
+
+export async function getTranscriptionAssetStatus(): Promise<TranscriptionAssetStatus> {
+  if (typeof indexedDB === 'undefined') {
+    const totalBytes = TRANSCRIPTION_ASSETS.reduce(
+      (sum, asset) => sum + asset.size,
+      0,
+    );
+    return {
+      ready: false,
+      storedBytes: 0,
+      totalBytes,
+      storedAssets: 0,
+      totalAssets: TRANSCRIPTION_ASSETS.length,
+    };
+  }
+
+  await cleanupExpiredTranscriptionAssets();
+  let storedBytes = 0;
+  let storedAssets = 0;
+  for (const asset of TRANSCRIPTION_ASSETS) {
+    const stored = await readAsset(asset.url);
+    if (stored) {
+      storedBytes += stored.size;
+      storedAssets++;
+    }
+  }
+  const totalBytes = TRANSCRIPTION_ASSETS.reduce(
+    (sum, asset) => sum + asset.size,
+    0,
+  );
+  return {
+    ready: storedAssets === TRANSCRIPTION_ASSETS.length,
+    storedBytes,
+    totalBytes,
+    storedAssets,
+    totalAssets: TRANSCRIPTION_ASSETS.length,
+  };
+}
+
+async function assertEnoughStorage(remainingBytes: number) {
+  if (!navigator.storage?.estimate) return;
+  const { quota, usage } = await navigator.storage.estimate();
+  if (quota === undefined || usage === undefined) return;
+  const available = quota - usage;
+  if (available < remainingBytes) {
+    throw new Error(
+      `Not enough browser storage for offline transcription assets. Need ${formatTranscriptionAssetBytes(remainingBytes)}, have ${formatTranscriptionAssetBytes(available)} available.`,
+    );
+  }
+}
+
+export async function downloadTranscriptionAssets(
+  onProgress?: (progress: TranscriptionAssetProgress) => void,
+): Promise<TranscriptionAssetStatus> {
+  if (typeof indexedDB === 'undefined') {
+    throw new Error('Offline transcription storage is not available here.');
+  }
+  await cleanupExpiredTranscriptionAssets();
+  const status = await getTranscriptionAssetStatus();
+  await assertEnoughStorage(status.totalBytes - status.storedBytes);
+
+  for (const asset of TRANSCRIPTION_ASSETS) {
+    if (await readAsset(asset.url)) continue;
+    onProgress?.({
+      ...(await getTranscriptionAssetStatus()),
+      currentUrl: asset.url,
+    });
+    const response = await fetch(asset.url, { cache: 'no-cache' });
+    if (!response.ok) {
+      throw new Error(`Failed to download ${asset.url}: ${response.status}`);
+    }
+    await writeAsset(asset.url, await response.blob());
+  }
+
+  const finalStatus = await getTranscriptionAssetStatus();
+  onProgress?.(finalStatus);
+  return finalStatus;
+}
+
+export async function deleteTranscriptionAssets() {
+  if (typeof indexedDB === 'undefined') return;
+  for (const asset of TRANSCRIPTION_ASSETS) {
+    await deleteAsset(asset.url);
+  }
+}
+
+export function createTranscriptionAssetCache() {
+  return {
+    async match(input: RequestInfo | URL): Promise<Response | undefined> {
+      if (typeof indexedDB === 'undefined') return undefined;
+      const url = normalizeUrl(input);
+      if (!url || !assetUrls.has(url)) return undefined;
+      const asset = await readAsset(url);
+      if (!asset) return undefined;
+      await touchAsset(asset);
+      return new Response(asset.blob);
+    },
+    async put(input: RequestInfo | URL, response: Response): Promise<void> {
+      if (typeof indexedDB === 'undefined') return;
+      const url = normalizeUrl(input);
+      if (!url || !assetUrls.has(url) || !response.ok) return;
+      await writeAsset(url, await response.clone().blob());
+    },
+  };
+}
+
+export async function createStoredWasmPaths(): Promise<Record<string, string>> {
+  if (typeof indexedDB === 'undefined') return {};
+  const paths: Record<string, string> = {};
+  for (const file of TRANSCRIPTION_WASM_FILES) {
+    const url = `${TRANSCRIPTION_WASM_BASE_PATH}${file}`;
+    const asset = await readAsset(url);
+    if (asset) {
+      await touchAsset(asset);
+      paths[file] = URL.createObjectURL(asset.blob);
+    }
+  }
+  return paths;
+}

--- a/packages/web/src/lib/transcription-manifest.ts
+++ b/packages/web/src/lib/transcription-manifest.ts
@@ -1,0 +1,22 @@
+export const TRANSCRIPTION_MODEL_ID = 'Xenova/whisper-tiny';
+export const TRANSCRIPTION_MODEL_REVISION =
+  '5332fcc35e32a33b86612b9a57a89be7906102b1';
+export const TRANSCRIPTION_MODEL_BASE_PATH = '/ml/models/';
+export const TRANSCRIPTION_WASM_BASE_PATH = '/ml/onnxruntime/';
+export const TRANSCRIPTION_MODEL_FILES = [
+  'config.json',
+  'generation_config.json',
+  'preprocessor_config.json',
+  'tokenizer.json',
+  'tokenizer_config.json',
+  'onnx/encoder_model_quantized.onnx',
+  'onnx/decoder_model_merged_quantized.onnx',
+] as const;
+export const TRANSCRIPTION_WASM_FILES = [
+  'ort-wasm.wasm',
+  'ort-wasm-simd.wasm',
+  'ort-wasm-threaded.wasm',
+  'ort-wasm-threaded.js',
+  'ort-wasm-threaded.worker.js',
+  'ort-wasm-simd-threaded.wasm',
+] as const;


### PR DESCRIPTION
## Summary

Replaces #130 with a clean PR targeting `master` directly. The original PR included stale offline-app-shell merge history that is now already on `master`.

## Changes

- Add an IndexedDB-backed transcription asset store for local Whisper and ONNX Runtime files.
- Add UI to download offline transcription assets before relying on them offline.
- Configure Transformers/ONNX to prefer stored assets and disable threaded WASM so blob-backed offline runtime paths are sufficient.

## Verification

- `npx @sveltejs/mcp svelte-autofixer ./packages/web/src/components/OfflineTranscriptionAssets.svelte --svelte-version 5`
- `npm run check`
- `npm run test`

## Replaces

Replaces #130.
