### PR TITLE
feat(web): add quick capture PWA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ packages/web/public/ml/
 tests/e2e/playwright-report/
 tests/e2e/test-results/
 tests/e2e/blob-report/
+
+# Local-only design mockups (not part of the app or build)
+mockups/

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ tests/e2e/blob-report/
 
 # Local-only design mockups (not part of the app or build)
 mockups/
+
+# Playwright MCP scratch output
+.playwright-mcp/

--- a/packages/rs-module/package.json
+++ b/packages/rs-module/package.json
@@ -5,6 +5,16 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./runtime": {
+      "types": "./dist/runtime.d.ts",
+      "default": "./dist/runtime.js"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/web/capture/index.html
+++ b/packages/web/capture/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Inbox RS Capture</title>
+    <link rel="icon" href="/src/assets/logos/favicon-shield.svg" type="image/svg+xml" />
+    <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
+    <meta name="theme-color" content="#111827" />
+    <link rel="manifest" href="/capture/manifest.webmanifest" />
+  </head>
+  <body>
+    <div id="capture-app"></div>
+    <script type="module" src="/src/capture/main.ts"></script>
+  </body>
+</html>

--- a/packages/web/capture/index.html
+++ b/packages/web/capture/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/src/assets/logos/favicon-shield.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
-    <meta name="theme-color" content="#111827" />
+    <meta name="theme-color" content="#f2f1ee" />
     <link rel="manifest" href="/capture/manifest.webmanifest" />
   </head>
   <body>

--- a/packages/web/public/capture/manifest.webmanifest
+++ b/packages/web/public/capture/manifest.webmanifest
@@ -5,8 +5,8 @@
   "start_url": "/capture/",
   "scope": "/capture/",
   "display": "standalone",
-  "background_color": "#111827",
-  "theme_color": "#111827",
+  "background_color": "#f2f1ee",
+  "theme_color": "#f2f1ee",
   "icons": [
     {
       "src": "/favicon-32.png",

--- a/packages/web/public/capture/manifest.webmanifest
+++ b/packages/web/public/capture/manifest.webmanifest
@@ -1,0 +1,29 @@
+{
+  "name": "Inbox RS Quick Capture",
+  "short_name": "Capture",
+  "description": "A fast input-only capture app for Inbox RS.",
+  "start_url": "/capture/",
+  "scope": "/capture/",
+  "display": "standalone",
+  "background_color": "#111827",
+  "theme_color": "#111827",
+  "icons": [
+    {
+      "src": "/favicon-32.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    },
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/packages/web/src/assets/logos/inbox-rs-mobile.svg
+++ b/packages/web/src/assets/logos/inbox-rs-mobile.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <!-- Solid indigo background -->
+  <rect width="128" height="128" rx="22" fill="#6366f1"/>
+  <!-- Shield shape, centered and scaled to fill the space -->
+  <!-- Native shield: x 4-28 (w=24), y 2-30 (h=28), center at (16, 16) -->
+  <!-- Scale 3.4x: 24*3.4=81.6w, 28*3.4=95.2h -->
+  <!-- Translate to center: x = 64 - 16*3.4 = 9.6, y = 64 - 16*3.4 = 9.6 -->
+  <g transform="translate(9.6, 9.6) scale(3.4)">
+    <path d="M16 2 L28 7 L28 16 Q28 26 16 30 Q4 26 4 16 L4 7 Z" fill="#4f46e5"/>
+    <path d="M8 15 L10.5 23 L13 23 L13 20 Q13 19 14.5 19 L17.5 19 Q19 19 19 20 L19 23 L21.5 23 L24 15 Z" fill="#818cf8"/>
+    <rect x="14.8" y="7" width="2.4" height="7" rx="1.2" fill="#e4e6eb"/>
+    <polygon points="16,16 12,12 13.5,10.8 16,13.5 18.5,10.8 20,12" fill="#e4e6eb"/>
+  </g>
+</svg>

--- a/packages/web/src/capture/App.svelte
+++ b/packages/web/src/capture/App.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import {
+    clearConfig,
+    enqueueCapture,
+    finishConnectFromRedirect,
+    flushQueue,
+    getConfig,
+    getQueue,
+    startConnect,
+    type CaptureType,
+  } from './store';
+
+  type BeforeInstallPromptEvent = Event & {
+    prompt: () => Promise<void>;
+    userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+  };
+
+  let type = $state<CaptureType>('note');
+  let input = $state('');
+  let userAddress = $state('');
+  let connectedAddress = $state('');
+  let queueCount = $state(0);
+  let status = $state('Ready');
+  let syncing = $state(false);
+  let installPrompt = $state<BeforeInstallPromptEvent | null>(null);
+  let isIos = $state(false);
+
+  onMount(() => {
+    const config = finishConnectFromRedirect() ?? getConfig();
+    connectedAddress = config?.userAddress ?? '';
+    userAddress = connectedAddress;
+    queueCount = getQueue().length;
+    isIos = /iphone|ipad|ipod/i.test(navigator.userAgent);
+    void syncNow();
+
+    const onOnline = () => void syncNow();
+    const onInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      installPrompt = event as BeforeInstallPromptEvent;
+    };
+    window.addEventListener('online', onOnline);
+    window.addEventListener('beforeinstallprompt', onInstallPrompt);
+    return () => {
+      window.removeEventListener('online', onOnline);
+      window.removeEventListener('beforeinstallprompt', onInstallPrompt);
+    };
+  });
+
+  async function saveCapture() {
+    const value = input.trim();
+    if (!value) return;
+    if (type === 'bookmark' && !value.includes('.')) {
+      status = 'Enter a URL for bookmarks';
+      return;
+    }
+    enqueueCapture(type, value);
+    input = '';
+    queueCount = getQueue().length;
+    status = navigator.onLine ? 'Saved. Syncing...' : 'Saved offline';
+    await syncNow();
+  }
+
+  async function syncNow() {
+    if (syncing) return;
+    const config = getConfig();
+    if (!config?.href || !config.token) {
+      queueCount = getQueue().length;
+      status = queueCount ? 'Saved locally. Connect to sync.' : 'Ready';
+      return;
+    }
+    syncing = true;
+    try {
+      const remaining = await flushQueue(config);
+      queueCount = remaining.length;
+      connectedAddress = config.userAddress;
+      status = queueCount ? `${queueCount} waiting to sync` : 'Synced';
+    } finally {
+      syncing = false;
+    }
+  }
+
+  async function connect() {
+    if (!userAddress.trim()) return;
+    status = 'Opening remoteStorage login...';
+    await startConnect(userAddress);
+  }
+
+  function disconnect() {
+    clearConfig();
+    connectedAddress = '';
+    status = queueCount ? 'Saved locally. Connect to sync.' : 'Disconnected';
+  }
+
+  async function install() {
+    if (!installPrompt) return;
+    await installPrompt.prompt();
+    await installPrompt.userChoice;
+    installPrompt = null;
+  }
+</script>
+
+<main class="capture-shell">
+  <section class="hero" aria-label="Quick capture">
+    <div class="hero-top">
+      <div>
+        <p class="eyebrow">Inbox RS</p>
+        <h1>Quick Capture</h1>
+      </div>
+      <a class="main-link" href="/">Full app</a>
+    </div>
+
+    <div class="type-tabs" role="radiogroup" aria-label="Capture type">
+      <button type="button" class:active={type === 'note'} onclick={() => type = 'note'}>Note</button>
+      <button type="button" class:active={type === 'todo'} onclick={() => type = 'todo'}>Todo</button>
+      <button type="button" class:active={type === 'bookmark'} onclick={() => type = 'bookmark'}>Bookmark</button>
+    </div>
+
+    <form class="capture-form" onsubmit={(event) => { event.preventDefault(); void saveCapture(); }}>
+      <textarea
+        bind:value={input}
+        rows="7"
+        placeholder={type === 'bookmark' ? 'https://example.com' : type === 'todo' ? 'What needs doing?' : 'Jot something down...'}
+      ></textarea>
+      <button type="submit" disabled={!input.trim()}>Save</button>
+    </form>
+
+    <p class="status" aria-live="polite">
+      {status}
+      {#if queueCount > 0}
+        <span>{queueCount} queued</span>
+      {/if}
+    </p>
+  </section>
+
+  <section class="panel" aria-label="Connection">
+    {#if connectedAddress}
+      <div>
+        <p class="panel-label">Connected</p>
+        <p class="address">{connectedAddress}</p>
+      </div>
+      <div class="panel-actions">
+        <button type="button" class="secondary" onclick={() => void syncNow()} disabled={syncing}>{syncing ? 'Syncing...' : 'Sync now'}</button>
+        <button type="button" class="ghost" onclick={disconnect}>Disconnect</button>
+      </div>
+    {:else}
+      <p class="panel-label">Connect remoteStorage</p>
+      <form class="connect-form" onsubmit={(event) => { event.preventDefault(); void connect(); }}>
+        <input bind:value={userAddress} type="text" placeholder="user@storage.example" />
+        <button type="submit" class="secondary" disabled={!userAddress.trim()}>Connect</button>
+      </form>
+    {/if}
+  </section>
+
+  <section class="panel install" aria-label="Install">
+    <div>
+      <p class="panel-label">Home screen icon</p>
+      <p>Install this page for the fastest input-only launcher.</p>
+    </div>
+    {#if installPrompt}
+      <button type="button" class="secondary" onclick={() => void install()}>Install</button>
+    {:else if isIos}
+      <p class="hint">Use Share, then Add to Home Screen.</p>
+    {:else}
+      <p class="hint">Use your browser's install option if it is available.</p>
+    {/if}
+  </section>
+</main>

--- a/packages/web/src/capture/App.svelte
+++ b/packages/web/src/capture/App.svelte
@@ -56,7 +56,6 @@
   // image
   let selectedFile = $state<File | null>(null);
   let imageUrl = $state<string | null>(null);
-  let fileInput = $state<HTMLInputElement>();
 
   // theme + install
   let accent = $state<Accent>('indigo');
@@ -194,9 +193,6 @@
   }
 
   // --- image ---
-  function pickImage() {
-    fileInput?.click();
-  }
   function onFile(event: Event) {
     const input = event.currentTarget as HTMLInputElement;
     const file = input.files?.[0] ?? null;
@@ -382,30 +378,34 @@
         {/if}
       </div>
     {:else}
+      <!--
+        A <label> opening a visually-hidden (not display:none) input is the only
+        approach that reliably triggers the native picker in every browser —
+        Safari/iOS refuse a programmatic .click() on a hidden file input.
+      -->
+      <input
+        id="capture-image-file"
+        class="visually-hidden"
+        type="file"
+        accept="image/*"
+        onchange={onFile}
+      />
       <div class="pad">
         {#if imageUrl}
           <img class="preview-image" src={imageUrl} alt="Selected" />
-          <button class="ghost" type="button" onclick={pickImage}>Choose another</button>
+          <label class="ghost" for="capture-image-file">Choose another</label>
         {:else}
-          <button class="record" type="button" onclick={pickImage} aria-label="Choose a photo">
+          <label class="record" for="capture-image-file" aria-label="Choose a photo">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <title>Photo</title>
               <rect x="3" y="5" width="18" height="14" rx="3" />
               <circle cx="9" cy="11" r="2" />
               <path d="M3 17l5-4 4 3 3-2 6 5" />
             </svg>
-          </button>
+          </label>
           <p class="pad-line">Take or choose a photo</p>
         {/if}
       </div>
-      <input
-        class="hidden-file"
-        bind:this={fileInput}
-        type="file"
-        accept="image/*"
-        capture="environment"
-        onchange={onFile}
-      />
     {/if}
 
     <button class="send" type="button" onclick={send} disabled={!canSend}>
@@ -691,6 +691,7 @@
     align-items: center;
     justify-content: center;
     box-shadow: 0 8px 20px var(--accent-shadow);
+    cursor: pointer;
   }
   .record svg {
     width: 2.4rem;
@@ -717,9 +718,6 @@
   }
   .preview-audio {
     width: 100%;
-  }
-  .hidden-file {
-    display: none;
   }
 
   .send {
@@ -760,6 +758,10 @@
     background: var(--surface);
     color: var(--ink);
     font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
   }
   .ghost.small {
     min-height: 2.4rem;

--- a/packages/web/src/capture/App.svelte
+++ b/packages/web/src/capture/App.svelte
@@ -1,37 +1,89 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import {
+    captureImage,
+    captureNote,
+    captureVoice,
+    type CaptureMode,
+    type CaptureRecord,
     clearConfig,
-    enqueueCapture,
+    type DeliveryStatus,
     finishConnectFromRedirect,
     flushQueue,
+    formatDuration,
     getConfig,
-    getQueue,
+    getHistory,
+    pendingCount,
+    removeRecord,
     startConnect,
-    type CaptureType,
   } from './store';
+  import {
+    type Accent,
+    ACCENT_LABELS,
+    ACCENT_SWATCHES,
+    ACCENTS,
+    applyTheme,
+    initTheme,
+    type Mode,
+  } from './theme';
 
   type BeforeInstallPromptEvent = Event & {
     prompt: () => Promise<void>;
     userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
   };
 
-  let type = $state<CaptureType>('note');
-  let input = $state('');
-  let userAddress = $state('');
-  let connectedAddress = $state('');
-  let queueCount = $state(0);
-  let status = $state('Ready');
+  let mode = $state<CaptureMode>('note');
+  let noteText = $state('');
+  let history = $state<CaptureRecord[]>([]);
+  let status = $state('');
   let syncing = $state(false);
+
+  let connectedAddress = $state('');
+  let userAddress = $state('');
+
+  let showHistory = $state(false);
+  let showSettings = $state(false);
+
+  // voice
+  let recording = $state(false);
+  let recordedBlob = $state<Blob | null>(null);
+  let recordedUrl = $state<string | null>(null);
+  let recordDuration = $state(0);
+  let recordError = $state('');
+  let mediaRecorder: MediaRecorder | null = null;
+  let recordTimer: ReturnType<typeof setInterval> | null = null;
+
+  // image
+  let selectedFile = $state<File | null>(null);
+  let imageUrl = $state<string | null>(null);
+  let fileInput = $state<HTMLInputElement>();
+
+  // theme + install
+  let accent = $state<Accent>('indigo');
+  let themeMode = $state<Mode>('system');
   let installPrompt = $state<BeforeInstallPromptEvent | null>(null);
   let isIos = $state(false);
 
+  const pending = $derived(pendingCount(history));
+  const canSend = $derived(
+    mode === 'note'
+      ? noteText.trim() !== ''
+      : mode === 'voice'
+        ? recordedBlob !== null
+        : selectedFile !== null,
+  );
+
   onMount(() => {
+    const theme = initTheme();
+    accent = theme.accent;
+    themeMode = theme.mode;
+
     const config = finishConnectFromRedirect() ?? getConfig();
     connectedAddress = config?.userAddress ?? '';
     userAddress = connectedAddress;
-    queueCount = getQueue().length;
+    history = getHistory();
     isIos = /iphone|ipad|ipod/i.test(navigator.userAgent);
+    status = idleStatus();
     void syncNow();
 
     const onOnline = () => void syncNow();
@@ -44,20 +96,32 @@
     return () => {
       window.removeEventListener('online', onOnline);
       window.removeEventListener('beforeinstallprompt', onInstallPrompt);
+      if (recordTimer) clearInterval(recordTimer);
+      if (recordedUrl) URL.revokeObjectURL(recordedUrl);
+      if (imageUrl) URL.revokeObjectURL(imageUrl);
     };
   });
 
-  async function saveCapture() {
-    const value = input.trim();
-    if (!value) return;
-    if (type === 'bookmark' && !value.includes('.')) {
-      status = 'Enter a URL for bookmarks';
-      return;
+  function idleStatus(): string {
+    if (!connectedAddress) return 'Not connected';
+    const p = pendingCount();
+    return p ? `${p} waiting to sync` : 'Ready';
+  }
+
+  async function send() {
+    if (!canSend) return;
+    if (mode === 'note') {
+      captureNote(noteText);
+      noteText = '';
+    } else if (mode === 'voice' && recordedBlob) {
+      await captureVoice(recordedBlob, recordDuration);
+      clearVoice();
+    } else if (mode === 'image' && selectedFile) {
+      await captureImage(selectedFile);
+      clearImage();
     }
-    enqueueCapture(type, value);
-    input = '';
-    queueCount = getQueue().length;
-    status = navigator.onLine ? 'Saved. Syncing...' : 'Saved offline';
+    history = getHistory();
+    status = navigator.onLine ? 'Saved ✓' : 'Saved offline';
     await syncNow();
   }
 
@@ -65,36 +129,121 @@
     if (syncing) return;
     const config = getConfig();
     if (!config?.href || !config.token) {
-      queueCount = getQueue().length;
-      status = queueCount ? 'Saved locally. Connect to sync.' : 'Ready';
+      history = getHistory();
+      status = pending ? 'Saved · connect to sync' : idleStatus();
       return;
     }
     syncing = true;
     try {
-      const remaining = await flushQueue(config);
-      queueCount = remaining.length;
+      history = await flushQueue(config);
       connectedAddress = config.userAddress;
-      status = queueCount ? `${queueCount} waiting to sync` : 'Synced';
+      const p = pendingCount(history);
+      status = p ? `${p} waiting to sync` : 'All synced ✓';
     } finally {
       syncing = false;
     }
   }
 
+  // --- voice ---
+  async function startRecording() {
+    recordError = '';
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const chunks: Blob[] = [];
+      mediaRecorder = new MediaRecorder(stream);
+      mediaRecorder.ondataavailable = (e) => {
+        if (e.data.size > 0) chunks.push(e.data);
+      };
+      mediaRecorder.onstop = () => {
+        for (const track of stream.getTracks()) track.stop();
+        const mimeType = mediaRecorder?.mimeType || 'audio/webm';
+        const blob = new Blob(chunks, { type: mimeType });
+        recordedBlob = blob;
+        if (recordedUrl) URL.revokeObjectURL(recordedUrl);
+        recordedUrl = URL.createObjectURL(blob);
+      };
+      mediaRecorder.start();
+      recording = true;
+      recordDuration = 0;
+      recordTimer = setInterval(() => {
+        recordDuration += 1;
+      }, 1000);
+    } catch {
+      recordError = 'Microphone unavailable';
+    }
+  }
+
+  function stopRecording() {
+    if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+      mediaRecorder.stop();
+    }
+    recording = false;
+    if (recordTimer) {
+      clearInterval(recordTimer);
+      recordTimer = null;
+    }
+  }
+
+  function clearVoice() {
+    recordedBlob = null;
+    recordDuration = 0;
+    if (recordedUrl) {
+      URL.revokeObjectURL(recordedUrl);
+      recordedUrl = null;
+    }
+  }
+
+  // --- image ---
+  function pickImage() {
+    fileInput?.click();
+  }
+  function onFile(event: Event) {
+    const input = event.currentTarget as HTMLInputElement;
+    const file = input.files?.[0] ?? null;
+    if (!file) return;
+    selectedFile = file;
+    if (imageUrl) URL.revokeObjectURL(imageUrl);
+    imageUrl = URL.createObjectURL(file);
+  }
+  function clearImage() {
+    selectedFile = null;
+    if (imageUrl) {
+      URL.revokeObjectURL(imageUrl);
+      imageUrl = null;
+    }
+  }
+
+  // --- connection ---
   async function connect() {
     const address = userAddress.trim();
     if (!address) return;
-    status = 'Opening remoteStorage login...';
+    status = 'Opening remoteStorage login…';
     try {
       await startConnect(address);
     } catch (error) {
       status = error instanceof Error ? error.message : 'Could not connect';
     }
   }
-
   function disconnect() {
     clearConfig();
     connectedAddress = '';
-    status = queueCount ? 'Saved locally. Connect to sync.' : 'Disconnected';
+    status = 'Disconnected';
+  }
+
+  // --- theme ---
+  function setAccent(value: Accent) {
+    accent = value;
+    applyTheme(accent, themeMode);
+  }
+  function setMode(value: Mode) {
+    themeMode = value;
+    applyTheme(accent, value);
+  }
+
+  // --- history ---
+  async function remove(id: string) {
+    history = await removeRecord(id);
+    status = idleStatus();
   }
 
   async function install() {
@@ -103,71 +252,673 @@
     await installPrompt.userChoice;
     installPrompt = null;
   }
+
+  // biome-ignore lint/correctness/noUnusedVariables: used as a Svelte action (use:autofocus)
+  function autofocus(node: HTMLTextAreaElement) {
+    node.focus();
+  }
+
+  function onNoteKey(event: KeyboardEvent) {
+    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      void send();
+    }
+  }
+
+  const STATUS_LABEL: Record<DeliveryStatus, string> = {
+    queued: 'Queued',
+    sending: 'Sending…',
+    synced: 'Sent',
+    failed: 'Failed',
+  };
+  function recordTime(iso: string): string {
+    return new Date(iso).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
 </script>
 
-<main class="capture-shell">
-  <section class="hero" aria-label="Quick capture">
-    <div class="hero-top">
-      <div>
-        <p class="eyebrow">Inbox RS</p>
-        <h1>Quick Capture</h1>
-      </div>
-      <a class="main-link" href="/">Full app</a>
+<main class="screen">
+  <header class="topbar">
+    <div class="brand">
+      <span class="name">Quick Capture</span>
+      <span class="status" aria-live="polite">{status}</span>
     </div>
-
-    <div class="type-tabs" role="radiogroup" aria-label="Capture type">
-      <button type="button" class:active={type === 'note'} onclick={() => type = 'note'}>Note</button>
-      <button type="button" class:active={type === 'todo'} onclick={() => type = 'todo'}>Todo</button>
-      <button type="button" class:active={type === 'bookmark'} onclick={() => type = 'bookmark'}>Bookmark</button>
+    <div class="top-actions">
+      <button
+        class="icon-btn"
+        type="button"
+        onclick={() => (showSettings = true)}
+        aria-label="Settings"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <title>Settings</title>
+          <circle cx="12" cy="12" r="3" />
+          <path d="M19.4 15a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-2.7 1.1V21a2 2 0 1 1-4 0v-.2a1.6 1.6 0 0 0-2.7-1.1l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1A1.6 1.6 0 0 0 4.6 15H4.5a2 2 0 1 1 0-4h.2a1.6 1.6 0 0 0 1.1-2.7l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1A1.6 1.6 0 0 0 11 4.6V4.5a2 2 0 1 1 4 0v.2a1.6 1.6 0 0 0 2.7 1.1l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1A1.6 1.6 0 0 0 21 11h.1a2 2 0 1 1 0 4h-.2a1.6 1.6 0 0 0-1.5.9Z" />
+        </svg>
+      </button>
+      <button
+        class="icon-btn"
+        type="button"
+        onclick={() => (showHistory = true)}
+        aria-label="History and delivery status"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <title>History</title>
+          <circle cx="12" cy="12" r="9" />
+          <path d="M12 7v5l3 2" />
+        </svg>
+        {#if pending > 0}<span class="badge">{pending}</span>{/if}
+      </button>
     </div>
+  </header>
 
-    <form class="capture-form" onsubmit={(event) => { event.preventDefault(); void saveCapture(); }}>
+  <div class="modes" role="group" aria-label="Capture mode">
+    <button class="seg" type="button" aria-pressed={mode === 'note'} onclick={() => (mode = 'note')}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <title>Note</title>
+        <path d="M4 6h16M4 12h16M4 18h10" />
+      </svg>
+      Note
+    </button>
+    <button class="seg" type="button" aria-pressed={mode === 'voice'} onclick={() => (mode = 'voice')}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <title>Voice</title>
+        <rect x="9" y="3" width="6" height="11" rx="3" />
+        <path d="M5 11a7 7 0 0 0 14 0M12 18v3" />
+      </svg>
+      Voice
+    </button>
+    <button class="seg" type="button" aria-pressed={mode === 'image'} onclick={() => (mode = 'image')}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <title>Image</title>
+        <rect x="3" y="5" width="18" height="14" rx="3" />
+        <circle cx="9" cy="11" r="2" />
+        <path d="M3 17l5-4 4 3 3-2 6 5" />
+      </svg>
+      Image
+    </button>
+  </div>
+
+  <section class="surface">
+    {#if mode === 'note'}
       <textarea
-        bind:value={input}
-        rows="7"
-        placeholder={type === 'bookmark' ? 'https://example.com' : type === 'todo' ? 'What needs doing?' : 'Jot something down...'}
+        class="field"
+        bind:value={noteText}
+        use:autofocus
+        onkeydown={onNoteKey}
+        placeholder="Jot it down…"
+        aria-label="Note text"
       ></textarea>
-      <button type="submit" disabled={!input.trim()}>Save</button>
-    </form>
-
-    <p class="status" aria-live="polite">
-      {status}
-      {#if queueCount > 0}
-        <span>{queueCount} queued</span>
-      {/if}
-    </p>
-  </section>
-
-  <section class="panel" aria-label="Connection">
-    {#if connectedAddress}
-      <div>
-        <p class="panel-label">Connected</p>
-        <p class="address">{connectedAddress}</p>
-      </div>
-      <div class="panel-actions">
-        <button type="button" class="secondary" onclick={() => void syncNow()} disabled={syncing}>{syncing ? 'Syncing...' : 'Sync now'}</button>
-        <button type="button" class="ghost" onclick={disconnect}>Disconnect</button>
+    {:else if mode === 'voice'}
+      <div class="pad">
+        {#if recording}
+          <button class="record recording" type="button" onclick={stopRecording} aria-label="Stop recording">
+            <span class="rec-dot"></span>
+          </button>
+          <p class="pad-line big">{formatDuration(recordDuration)}</p>
+          <p class="pad-line">Recording… tap to stop</p>
+        {:else if recordedBlob}
+          <p class="pad-line big">Voice memo · {formatDuration(recordDuration)}</p>
+          {#if recordedUrl}
+            <!-- svelte-ignore a11y_media_has_caption -->
+            <!-- biome-ignore lint/a11y/useMediaCaption: user's own voice memo preview, no caption track exists -->
+            <audio class="preview-audio" controls src={recordedUrl}></audio>
+          {/if}
+          <button class="ghost" type="button" onclick={() => { clearVoice(); startRecording(); }}>
+            Re-record
+          </button>
+        {:else}
+          <button class="record" type="button" onclick={startRecording} aria-label="Start recording">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <title>Record</title>
+              <rect x="9" y="3" width="6" height="11" rx="3" />
+              <path d="M5 11a7 7 0 0 0 14 0M12 18v3" />
+            </svg>
+          </button>
+          <p class="pad-line">Tap to record</p>
+          {#if recordError}<p class="pad-line error">{recordError}</p>{/if}
+        {/if}
       </div>
     {:else}
-      <p class="panel-label">Connect remoteStorage</p>
-      <form class="connect-form" onsubmit={(event) => { event.preventDefault(); void connect(); }}>
-        <input bind:value={userAddress} type="text" placeholder="user@storage.example" />
-        <button type="submit" class="secondary" disabled={!userAddress.trim()}>Connect</button>
-      </form>
+      <div class="pad">
+        {#if imageUrl}
+          <img class="preview-image" src={imageUrl} alt="Selected" />
+          <button class="ghost" type="button" onclick={pickImage}>Choose another</button>
+        {:else}
+          <button class="record" type="button" onclick={pickImage} aria-label="Choose a photo">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <title>Photo</title>
+              <rect x="3" y="5" width="18" height="14" rx="3" />
+              <circle cx="9" cy="11" r="2" />
+              <path d="M3 17l5-4 4 3 3-2 6 5" />
+            </svg>
+          </button>
+          <p class="pad-line">Take or choose a photo</p>
+        {/if}
+      </div>
+      <input
+        class="hidden-file"
+        bind:this={fileInput}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        onchange={onFile}
+      />
     {/if}
-  </section>
 
-  <section class="panel install" aria-label="Install">
-    <div>
-      <p class="panel-label">Home screen icon</p>
-      <p>Install this page for the fastest input-only launcher.</p>
-    </div>
-    {#if installPrompt}
-      <button type="button" class="secondary" onclick={() => void install()}>Install</button>
-    {:else if isIos}
-      <p class="hint">Use Share, then Add to Home Screen.</p>
-    {:else}
-      <p class="hint">Use your browser's install option if it is available.</p>
-    {/if}
+    <button class="send" type="button" onclick={send} disabled={!canSend}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+        <title>Send</title>
+        <path d="M5 12h13M13 6l6 6-6 6" />
+      </svg>
+      Send to inbox
+    </button>
   </section>
 </main>
+
+{#if showHistory}
+  <div class="sheet" role="dialog" aria-label="History">
+    <header class="sheet-head">
+      <h2>History</h2>
+      <div class="sheet-head-actions">
+        <button class="ghost small" type="button" onclick={syncNow} disabled={syncing || !connectedAddress}>
+          {syncing ? 'Syncing…' : 'Sync now'}
+        </button>
+        <button class="icon-btn" type="button" onclick={() => (showHistory = false)} aria-label="Close">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><title>Close</title><path d="M6 6l12 12M18 6 6 18" /></svg>
+        </button>
+      </div>
+    </header>
+    {#if history.length === 0}
+      <p class="empty">Nothing captured yet.</p>
+    {:else}
+      <ul class="rec-list">
+        {#each history as rec (rec.id)}
+          <li class="rec rec-{rec.status}">
+            <span class="rec-mode">{rec.mode === 'note' ? 'Note' : rec.mode === 'voice' ? 'Voice' : 'Image'}</span>
+            <div class="rec-main">
+              <p class="rec-preview">{rec.preview}</p>
+              <p class="rec-meta">
+                {recordTime(rec.createdAt)} · <span class="chip chip-{rec.status}">{STATUS_LABEL[rec.status]}</span>
+                {#if rec.lastError}<span class="rec-err"> — {rec.lastError}</span>{/if}
+              </p>
+            </div>
+            <button class="icon-btn tiny" type="button" onclick={() => remove(rec.id)} aria-label="Remove">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><title>Remove</title><path d="M4 7h16M9 7V5h6v2M7 7l1 13h8l1-13" /></svg>
+            </button>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+{/if}
+
+{#if showSettings}
+  <div class="sheet" role="dialog" aria-label="Settings">
+    <header class="sheet-head">
+      <h2>Settings</h2>
+      <button class="icon-btn" type="button" onclick={() => (showSettings = false)} aria-label="Close">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><title>Close</title><path d="M6 6l12 12M18 6 6 18" /></svg>
+      </button>
+    </header>
+
+    <section class="settings-block">
+      <h3>remoteStorage</h3>
+      {#if connectedAddress}
+        <p class="connected">Connected as <strong>{connectedAddress}</strong></p>
+        <button class="ghost" type="button" onclick={disconnect}>Disconnect</button>
+      {:else}
+        <form class="connect-form" onsubmit={(e) => { e.preventDefault(); void connect(); }}>
+          <input bind:value={userAddress} type="text" placeholder="user@storage.example" aria-label="remoteStorage address" />
+          <button class="ghost" type="submit" disabled={!userAddress.trim()}>Connect</button>
+        </form>
+      {/if}
+    </section>
+
+    <section class="settings-block">
+      <h3>Theme</h3>
+      <div class="swatches" role="group" aria-label="Accent colour">
+        {#each ACCENTS as a (a)}
+          <button
+            class="swatch"
+            class:active={accent === a}
+            type="button"
+            style="--sw: {ACCENT_SWATCHES[a]}"
+            onclick={() => setAccent(a)}
+            aria-label={ACCENT_LABELS[a]}
+            aria-pressed={accent === a}
+          ></button>
+        {/each}
+      </div>
+      <div class="mode-toggle" role="group" aria-label="Light or dark">
+        <button class="mode" class:active={themeMode === 'light'} type="button" onclick={() => setMode('light')}>Light</button>
+        <button class="mode" class:active={themeMode === 'dark'} type="button" onclick={() => setMode('dark')}>Dark</button>
+        <button class="mode" class:active={themeMode === 'system'} type="button" onclick={() => setMode('system')}>System</button>
+      </div>
+    </section>
+
+    <section class="settings-block">
+      <h3>Install</h3>
+      {#if installPrompt}
+        <button class="ghost" type="button" onclick={install}>Add to home screen</button>
+      {:else if isIos}
+        <p class="hint">Use Share, then Add to Home Screen.</p>
+      {:else}
+        <p class="hint">Use your browser's install option if available.</p>
+      {/if}
+    </section>
+  </div>
+{/if}
+
+<style>
+  .screen {
+    height: 100%;
+    width: min(100%, 30rem);
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    padding: max(1.5rem, env(safe-area-inset-top)) 1.25rem
+      max(1.5rem, env(safe-area-inset-bottom));
+    gap: 1.25rem;
+  }
+
+  .topbar {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+  .brand {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .name {
+    font-size: 1.05rem;
+    font-weight: 800;
+  }
+  .status {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--ink-faint);
+  }
+  .top-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .icon-btn {
+    position: relative;
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 0.9rem;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--ink-soft);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .icon-btn svg {
+    width: 1.4rem;
+    height: 1.4rem;
+  }
+  .icon-btn.tiny {
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 0.7rem;
+  }
+  .icon-btn:focus-visible {
+    outline: 3px solid var(--accent);
+    outline-offset: 2px;
+  }
+  .badge {
+    position: absolute;
+    top: -0.4rem;
+    right: -0.4rem;
+    min-width: 1.25rem;
+    height: 1.25rem;
+    padding: 0 0.3rem;
+    border-radius: 999px;
+    background: var(--accent);
+    color: var(--on-accent);
+    border: 2px solid var(--bg);
+    font-size: 0.7rem;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .modes {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 0.5rem;
+    background: var(--seg);
+    border: 1px solid var(--line);
+    border-radius: 1.25rem;
+    padding: 0.5rem;
+  }
+  .seg {
+    min-height: 4.25rem;
+    border-radius: 0.9rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    color: var(--ink-soft);
+    font-size: 0.9rem;
+    font-weight: 700;
+  }
+  .seg svg {
+    width: 1.4rem;
+    height: 1.4rem;
+  }
+  .seg:focus-visible {
+    outline: 3px solid var(--accent);
+    outline-offset: 2px;
+  }
+  .seg[aria-pressed='true'] {
+    background: var(--accent);
+    color: var(--on-accent);
+    box-shadow: 0 4px 12px var(--accent-shadow);
+  }
+
+  .surface {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .field {
+    flex: 1;
+    width: 100%;
+    border: 2px solid var(--line);
+    border-radius: 1.5rem;
+    background: var(--surface);
+    padding: 1.25rem;
+    font-size: 1.3rem;
+    font-weight: 500;
+    line-height: 1.45;
+    resize: none;
+    min-height: 0;
+  }
+  .field::placeholder {
+    color: var(--ink-faint);
+  }
+  .field:focus,
+  .field:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 4px var(--accent-tint);
+  }
+
+  .pad {
+    flex: 1;
+    border: 2px solid var(--line);
+    border-radius: 1.5rem;
+    background: var(--surface);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    padding: 1.5rem;
+    min-height: 0;
+  }
+  .pad-line {
+    color: var(--ink-soft);
+    font-weight: 600;
+  }
+  .pad-line.big {
+    font-size: 1.4rem;
+    font-weight: 800;
+    color: var(--ink);
+  }
+  .pad-line.error {
+    color: #b3402f;
+  }
+  .record {
+    width: 6rem;
+    height: 6rem;
+    border-radius: 50%;
+    background: var(--accent);
+    color: var(--on-accent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 8px 20px var(--accent-shadow);
+  }
+  .record svg {
+    width: 2.4rem;
+    height: 2.4rem;
+  }
+  .record:focus-visible {
+    outline: 3px solid var(--accent);
+    outline-offset: 3px;
+  }
+  .record.recording {
+    background: #b3402f;
+  }
+  .rec-dot {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 0.4rem;
+    background: var(--on-accent);
+  }
+  .preview-image {
+    max-width: 100%;
+    max-height: 60%;
+    border-radius: 1rem;
+    object-fit: contain;
+  }
+  .preview-audio {
+    width: 100%;
+  }
+  .hidden-file {
+    display: none;
+  }
+
+  .send {
+    margin-top: 1.1rem;
+    min-height: 4rem;
+    border-radius: 1.25rem;
+    background: var(--accent);
+    color: var(--on-accent);
+    font-size: 1.25rem;
+    font-weight: 800;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    box-shadow: 0 8px 20px var(--accent-shadow);
+  }
+  .send svg {
+    width: 1.4rem;
+    height: 1.4rem;
+  }
+  .send:active {
+    background: var(--accent-deep);
+  }
+  .send:disabled {
+    opacity: 0.45;
+    box-shadow: none;
+  }
+  .send:focus-visible {
+    outline: 3px solid var(--ink);
+    outline-offset: 3px;
+  }
+
+  .ghost {
+    min-height: 2.9rem;
+    padding: 0 1.1rem;
+    border-radius: 999px;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--ink);
+    font-weight: 700;
+  }
+  .ghost.small {
+    min-height: 2.4rem;
+    font-size: 0.85rem;
+  }
+  .ghost:disabled {
+    opacity: 0.5;
+  }
+
+  /* Sheets */
+  .sheet {
+    position: fixed;
+    inset: 0;
+    background: var(--bg);
+    padding: max(1.5rem, env(safe-area-inset-top)) 1.25rem
+      max(1.5rem, env(safe-area-inset-bottom));
+    width: min(100%, 30rem);
+    margin: 0 auto;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+  .sheet-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .sheet-head-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .sheet h2 {
+    font-size: 1.4rem;
+  }
+  .empty {
+    color: var(--ink-faint);
+    padding: 2rem 0;
+    text-align: center;
+  }
+
+  .rec-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .rec {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 0.85rem;
+    border: 1px solid var(--line);
+    border-radius: 1rem;
+    background: var(--surface);
+  }
+  .rec-mode {
+    font-size: 0.7rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--ink-faint);
+    width: 3rem;
+    flex: none;
+  }
+  .rec-main {
+    flex: 1;
+    min-width: 0;
+  }
+  .rec-preview {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .rec-meta {
+    font-size: 0.8rem;
+    color: var(--ink-faint);
+    margin-top: 2px;
+  }
+  .rec-err {
+    color: #b3402f;
+  }
+  .chip {
+    font-weight: 700;
+  }
+  .chip-synced {
+    color: var(--accent);
+  }
+  .chip-failed {
+    color: #b3402f;
+  }
+
+  .settings-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .settings-block h3 {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--ink-faint);
+  }
+  .connected {
+    color: var(--ink-soft);
+  }
+  .connect-form {
+    display: flex;
+    gap: 0.5rem;
+  }
+  .connect-form input {
+    flex: 1;
+    min-height: 2.9rem;
+    padding: 0 0.85rem;
+    border-radius: 0.9rem;
+    border: 1px solid var(--line);
+    background: var(--surface);
+  }
+  .connect-form input:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-tint);
+  }
+  .swatches {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    gap: 0.6rem;
+  }
+  .swatch {
+    aspect-ratio: 1;
+    border-radius: 50%;
+    background: var(--sw);
+    border: 2px solid var(--line);
+  }
+  .swatch.active {
+    border-color: var(--ink);
+    box-shadow: 0 0 0 3px var(--accent-tint);
+  }
+  .mode-toggle {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 0.5rem;
+    background: var(--seg);
+    border-radius: 0.9rem;
+    padding: 0.35rem;
+  }
+  .mode {
+    min-height: 2.6rem;
+    border-radius: 0.6rem;
+    color: var(--ink-soft);
+    font-weight: 700;
+  }
+  .mode.active {
+    background: var(--accent);
+    color: var(--on-accent);
+  }
+  .hint {
+    color: var(--ink-faint);
+  }
+</style>

--- a/packages/web/src/capture/App.svelte
+++ b/packages/web/src/capture/App.svelte
@@ -81,9 +81,14 @@
   }
 
   async function connect() {
-    if (!userAddress.trim()) return;
+    const address = userAddress.trim();
+    if (!address) return;
     status = 'Opening remoteStorage login...';
-    await startConnect(userAddress);
+    try {
+      await startConnect(address);
+    } catch (error) {
+      status = error instanceof Error ? error.message : 'Could not connect';
+    }
   }
 
   function disconnect() {

--- a/packages/web/src/capture/App.svelte
+++ b/packages/web/src/capture/App.svelte
@@ -93,6 +93,10 @@
     window.addEventListener('online', onOnline);
     window.addEventListener('beforeinstallprompt', onInstallPrompt);
     return () => {
+      // Release the mic if we unmount mid-recording.
+      if (recording && mediaRecorder) {
+        for (const track of mediaRecorder.stream.getTracks()) track.stop();
+      }
       window.removeEventListener('online', onOnline);
       window.removeEventListener('beforeinstallprompt', onInstallPrompt);
       if (recordTimer) clearInterval(recordTimer);
@@ -138,6 +142,9 @@
       connectedAddress = config.userAddress;
       const p = pendingCount(history);
       status = p ? `${p} waiting to sync` : 'All synced ✓';
+    } catch (error) {
+      history = getHistory();
+      status = error instanceof Error ? error.message : 'Sync failed';
     } finally {
       syncing = false;
     }

--- a/packages/web/src/capture/main.ts
+++ b/packages/web/src/capture/main.ts
@@ -1,0 +1,8 @@
+import { mount } from 'svelte';
+import App from './App.svelte';
+import './styles.css';
+
+const target = document.getElementById('capture-app');
+if (!target) throw new Error('Mount target #capture-app not found');
+
+mount(App, { target });

--- a/packages/web/src/capture/store.test.ts
+++ b/packages/web/src/capture/store.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { discoverStorageMock } = vi.hoisted(() => ({
+  discoverStorageMock: vi.fn(),
+}));
+
+// Keep extractTokenFromRedirect/DirectRS real (they only parse URLs); only the
+// network-bound discovery step is replaced so we can drive authUrl per test.
+vi.mock('@inbox-rs/rs-module/runtime', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@inbox-rs/rs-module/runtime')>();
+  return { ...actual, discoverStorage: discoverStorageMock };
+});
+
+import { finishConnectFromRedirect, startConnect } from './store';
+
+const PENDING_AUTH_KEY = 'inbox-rs-capture:pending-auth';
+const CONFIG_KEY = 'inbox-rs-capture:config';
+
+function createStorage() {
+  const map = new Map<string, string>();
+  return {
+    getItem: (key: string) => (map.has(key) ? (map.get(key) as string) : null),
+    setItem: (key: string, value: string) => void map.set(key, String(value)),
+    removeItem: (key: string) => void map.delete(key),
+    clear: () => map.clear(),
+  };
+}
+
+let storage: ReturnType<typeof createStorage>;
+let location: { origin: string; href: string; hash: string; search: string };
+let replaceState: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  storage = createStorage();
+  location = {
+    origin: 'https://app.example',
+    href: '',
+    hash: '',
+    search: '',
+  };
+  replaceState = vi.fn();
+  discoverStorageMock.mockReset();
+  vi.stubGlobal('localStorage', storage);
+  vi.stubGlobal('window', { location, history: { replaceState } });
+});
+
+describe('startConnect', () => {
+  it('navigates to a discovered https OAuth endpoint with OAuth params', async () => {
+    discoverStorageMock.mockResolvedValue({
+      href: 'https://storage.example/u',
+      storageApi: 'draft-06',
+      authUrl: 'https://storage.example/oauth',
+    });
+
+    await startConnect(' user@storage.example ');
+
+    const target = new URL(location.href);
+    expect(target.origin + target.pathname).toBe(
+      'https://storage.example/oauth',
+    );
+    expect(target.searchParams.get('redirect_uri')).toBe(
+      'https://app.example/capture/',
+    );
+    expect(target.searchParams.get('response_type')).toBe('token');
+    expect(storage.getItem(PENDING_AUTH_KEY)).not.toBeNull();
+  });
+
+  it('rejects a javascript: OAuth endpoint without navigating', async () => {
+    discoverStorageMock.mockResolvedValue({
+      href: 'https://storage.example/u',
+      authUrl: "javascript:fetch('https://attacker.example')//",
+    });
+
+    await expect(startConnect('user@evil.example')).rejects.toThrow(
+      /insecure OAuth endpoint/,
+    );
+    expect(location.href).toBe('');
+    expect(storage.getItem(PENDING_AUTH_KEY)).toBeNull();
+  });
+
+  it('allows http only for localhost dev', async () => {
+    discoverStorageMock.mockResolvedValue({
+      href: 'http://localhost:8000/u',
+      authUrl: 'http://localhost:8000/oauth',
+    });
+
+    await startConnect('user@localhost');
+
+    expect(new URL(location.href).protocol).toBe('http:');
+  });
+
+  it('rejects plain http on a non-localhost host', async () => {
+    discoverStorageMock.mockResolvedValue({
+      href: 'http://storage.example/u',
+      authUrl: 'http://storage.example/oauth',
+    });
+
+    await expect(startConnect('user@storage.example')).rejects.toThrow(
+      /insecure OAuth endpoint/,
+    );
+    expect(location.href).toBe('');
+  });
+});
+
+describe('finishConnectFromRedirect', () => {
+  function setPending() {
+    storage.setItem(
+      PENDING_AUTH_KEY,
+      JSON.stringify({
+        userAddress: 'user@storage.example',
+        discovery: { href: 'https://storage.example/u', storageApi: 'draft' },
+      }),
+    );
+  }
+
+  it('extracts a token delivered in the query string', () => {
+    setPending();
+    location.search = '?access_token=qtok';
+    location.href = 'https://app.example/capture/?access_token=qtok';
+
+    const config = finishConnectFromRedirect();
+
+    expect(config?.token).toBe('qtok');
+    expect(storage.getItem(PENDING_AUTH_KEY)).toBeNull();
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/capture/');
+  });
+
+  it('extracts a token delivered in the hash fragment', () => {
+    setPending();
+    location.hash = '#access_token=htok';
+    location.href = 'https://app.example/capture/#access_token=htok';
+
+    expect(finishConnectFromRedirect()?.token).toBe('htok');
+    expect(storage.getItem(CONFIG_KEY)).not.toBeNull();
+  });
+
+  it('scrubs pending state and URL on an error redirect', () => {
+    setPending();
+    location.search = '?error=access_denied';
+    location.href = 'https://app.example/capture/?error=access_denied';
+
+    const config = finishConnectFromRedirect();
+
+    expect(config).toBeNull();
+    expect(storage.getItem(PENDING_AUTH_KEY)).toBeNull();
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/capture/');
+  });
+
+  it('returns the stored config untouched when there is no callback', () => {
+    storage.setItem(
+      CONFIG_KEY,
+      JSON.stringify({ userAddress: 'user@storage.example', token: 't' }),
+    );
+
+    expect(finishConnectFromRedirect()).toEqual({
+      userAddress: 'user@storage.example',
+      token: 't',
+    });
+    expect(replaceState).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/capture/store.test.ts
+++ b/packages/web/src/capture/store.test.ts
@@ -12,10 +12,24 @@ vi.mock('@inbox-rs/rs-module/runtime', async (importOriginal) => {
   return { ...actual, discoverStorage: discoverStorageMock };
 });
 
-import { finishConnectFromRedirect, startConnect } from './store';
+import {
+  captureNote,
+  finishConnectFromRedirect,
+  flushQueue,
+  getHistory,
+  pendingCount,
+  removeRecord,
+  startConnect,
+} from './store';
 
 const PENDING_AUTH_KEY = 'inbox-rs-capture:pending-auth';
 const CONFIG_KEY = 'inbox-rs-capture:config';
+
+const SYNCED_CONFIG = JSON.stringify({
+  userAddress: 'alex@5apps.com',
+  token: 'tok',
+  href: 'https://storage.example/u',
+});
 
 function createStorage() {
   const map = new Map<string, string>();
@@ -41,8 +55,10 @@ beforeEach(() => {
   };
   replaceState = vi.fn();
   discoverStorageMock.mockReset();
+  let uuid = 0;
   vi.stubGlobal('localStorage', storage);
   vi.stubGlobal('window', { location, history: { replaceState } });
+  vi.stubGlobal('crypto', { randomUUID: () => `id-${uuid++}` });
 });
 
 describe('startConnect', () => {
@@ -158,5 +174,66 @@ describe('finishConnectFromRedirect', () => {
       token: 't',
     });
     expect(replaceState).not.toHaveBeenCalled();
+  });
+});
+
+describe('capture history + delivery', () => {
+  it('queues a note and counts it as pending', () => {
+    const record = captureNote('  buy milk  ');
+    expect(record.status).toBe('queued');
+    expect(record.item).toMatchObject({
+      type: 'note',
+      title: 'buy milk',
+      body: 'buy milk',
+    });
+    const history = getHistory();
+    expect(history).toHaveLength(1);
+    expect(pendingCount(history)).toBe(1);
+  });
+
+  it('delivers queued notes to remoteStorage and marks them synced (FIFO)', async () => {
+    storage.setItem(CONFIG_KEY, SYNCED_CONFIG);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    captureNote('first');
+    captureNote('second');
+
+    const history = await flushQueue();
+
+    expect(history.every((r) => r.status === 'synced')).toBe(true);
+    expect(pendingCount(history)).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // oldest-first: the first PUT carries the earliest note
+    const firstBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(firstBody.body).toBe('first');
+  });
+
+  it('marks a capture failed (and keeps it pending) when delivery errors', async () => {
+    storage.setItem(CONFIG_KEY, SYNCED_CONFIG);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 500 }),
+    );
+
+    captureNote('oops');
+    const history = await flushQueue();
+
+    expect(history[0].status).toBe('failed');
+    expect(history[0].lastError).toContain('500');
+    expect(pendingCount(history)).toBe(1);
+  });
+
+  it('does nothing when there is no connection', async () => {
+    captureNote('offline note');
+    const history = await flushQueue();
+    expect(history[0].status).toBe('queued');
+    expect(pendingCount(history)).toBe(1);
+  });
+
+  it('removes a record from history', async () => {
+    const record = captureNote('temporary');
+    const history = await removeRecord(record.id);
+    expect(history).toHaveLength(0);
   });
 });

--- a/packages/web/src/capture/store.test.ts
+++ b/packages/web/src/capture/store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { discoverStorageMock } = vi.hoisted(() => ({
   discoverStorageMock: vi.fn(),
@@ -59,6 +59,10 @@ beforeEach(() => {
   vi.stubGlobal('localStorage', storage);
   vi.stubGlobal('window', { location, history: { replaceState } });
   vi.stubGlobal('crypto', { randomUUID: () => `id-${uuid++}` });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe('startConnect', () => {

--- a/packages/web/src/capture/store.ts
+++ b/packages/web/src/capture/store.ts
@@ -28,39 +28,72 @@ export function clearConfig(): void {
 }
 
 export async function startConnect(userAddress: string): Promise<void> {
-  const discovery = await discoverStorage(userAddress.trim());
+  const address = userAddress.trim();
+  const discovery = await discoverStorage(address);
+  // The OAuth endpoint comes straight from the user's WebFinger response, so a
+  // hostile provider could hand back a `javascript:`/`data:` URL that would run
+  // in our origin the moment we navigate to it. Only follow real HTTP(S)
+  // endpoints — and plain HTTP only for localhost, mirroring schemeForHost.
+  const authUrl = parseSafeAuthUrl(discovery.authUrl);
   localStorage.setItem(
     PENDING_AUTH_KEY,
-    JSON.stringify({ userAddress: userAddress.trim(), discovery }),
+    JSON.stringify({ userAddress: address, discovery }),
   );
   const redirectUri = `${window.location.origin}/capture/`;
-  const params = new URLSearchParams({
-    client_id: redirectUri,
-    redirect_uri: redirectUri,
-    response_type: 'token',
-    scope: 'inbox:rw',
-  });
-  window.location.href = `${discovery.authUrl}?${params.toString()}`;
+  authUrl.searchParams.set('client_id', redirectUri);
+  authUrl.searchParams.set('redirect_uri', redirectUri);
+  authUrl.searchParams.set('response_type', 'token');
+  authUrl.searchParams.set('scope', 'inbox:rw');
+  window.location.href = authUrl.toString();
+}
+
+function parseSafeAuthUrl(rawAuthUrl: string): URL {
+  let url: URL;
+  try {
+    url = new URL(rawAuthUrl);
+  } catch {
+    throw new Error('remoteStorage returned an invalid OAuth endpoint');
+  }
+  const isHttps = url.protocol === 'https:';
+  const isLocalhostHttp =
+    url.protocol === 'http:' && url.hostname === 'localhost';
+  if (!isHttps && !isLocalhostHttp) {
+    throw new Error('remoteStorage returned an insecure OAuth endpoint');
+  }
+  return url;
 }
 
 export function finishConnectFromRedirect(): RSConfig | null {
-  if (!window.location.hash.includes('access_token=')) return getConfig();
+  // Tokens (and OAuth errors) can arrive in either the fragment or the query
+  // string, so check both. An `error=` redirect still needs cleanup even though
+  // it yields no token, so the pending state and callback URL are always
+  // scrubbed once we've decided a callback is present.
+  const callback = `${window.location.hash} ${window.location.search}`;
+  if (!callback.includes('access_token=') && !callback.includes('error='))
+    return getConfig();
+
   const pending = readJson<{
     userAddress: string;
     discovery: { href: string; storageApi?: string };
   }>(PENDING_AUTH_KEY);
-  if (!pending) return getConfig();
 
-  const config: RSConfig = {
-    userAddress: pending.userAddress,
-    token: extractTokenFromRedirect(window.location.href),
-    href: pending.discovery.href,
-    storageApi: pending.discovery.storageApi,
-  };
-  localStorage.setItem(CONFIG_KEY, JSON.stringify(config));
-  localStorage.removeItem(PENDING_AUTH_KEY);
-  window.history.replaceState(null, '', '/capture/');
-  return config;
+  try {
+    if (!pending) return getConfig();
+    const config: RSConfig = {
+      userAddress: pending.userAddress,
+      token: extractTokenFromRedirect(window.location.href),
+      href: pending.discovery.href,
+      storageApi: pending.discovery.storageApi,
+    };
+    localStorage.setItem(CONFIG_KEY, JSON.stringify(config));
+    return config;
+  } catch {
+    // extractTokenFromRedirect throws on `error=` responses or a missing token.
+    return getConfig();
+  } finally {
+    localStorage.removeItem(PENDING_AUTH_KEY);
+    window.history.replaceState(null, '', '/capture/');
+  }
 }
 
 export function getQueue(): QueuedCapture[] {

--- a/packages/web/src/capture/store.ts
+++ b/packages/web/src/capture/store.ts
@@ -1,4 +1,9 @@
-import type { InboxItem, InboxItemType } from '@inbox-rs/rs-module';
+import type {
+  AudioItem,
+  ImageItem,
+  InboxItem,
+  NoteItem,
+} from '@inbox-rs/rs-module';
 import {
   DirectRS,
   discoverStorage,
@@ -6,18 +11,35 @@ import {
   type RSConfig,
 } from '@inbox-rs/rs-module/runtime';
 
-export type CaptureType = Extract<InboxItemType, 'bookmark' | 'note' | 'todo'>;
+/** The three ways to capture. Maps to inbox item types note / audio / image. */
+export type CaptureMode = 'note' | 'voice' | 'image';
 
-export type QueuedCapture = {
+/** Delivery state of a captured item, surfaced in the history view. */
+export type DeliveryStatus = 'queued' | 'sending' | 'synced' | 'failed';
+
+/**
+ * A single capture and its delivery state. Persisted as JSON in localStorage;
+ * any binary payload (photo/voice) is held separately in IndexedDB under the
+ * same `id` and referenced via `hasBlob`.
+ */
+export type CaptureRecord = {
   id: string;
-  item: InboxItem;
-  queuedAt: string;
+  mode: CaptureMode;
+  preview: string;
+  createdAt: string;
+  status: DeliveryStatus;
   lastError?: string;
+  item: InboxItem;
+  hasBlob: boolean;
 };
 
 const CONFIG_KEY = 'inbox-rs-capture:config';
 const PENDING_AUTH_KEY = 'inbox-rs-capture:pending-auth';
-const QUEUE_KEY = 'inbox-rs-capture:queue';
+const HISTORY_KEY = 'inbox-rs-capture:history';
+
+// ---------------------------------------------------------------------------
+// remoteStorage connection (unchanged from the original capture flow)
+// ---------------------------------------------------------------------------
 
 export function getConfig(): RSConfig | null {
   return readJson<RSConfig>(CONFIG_KEY);
@@ -96,79 +118,270 @@ export function finishConnectFromRedirect(): RSConfig | null {
   }
 }
 
-export function getQueue(): QueuedCapture[] {
-  return readJson<QueuedCapture[]>(QUEUE_KEY) ?? [];
+// ---------------------------------------------------------------------------
+// Capture history + delivery queue
+// ---------------------------------------------------------------------------
+
+export function getHistory(): CaptureRecord[] {
+  const records = readJson<CaptureRecord[]>(HISTORY_KEY) ?? [];
+  // A 'sending' record means we were interrupted mid-flush (e.g. a reload);
+  // treat it as still queued so it gets retried.
+  return records.map((r) =>
+    r.status === 'sending' ? { ...r, status: 'queued' } : r,
+  );
 }
 
-export function enqueueCapture(
-  type: CaptureType,
-  input: string,
-): QueuedCapture {
-  const item = buildCaptureItem(type, input);
-  const queued: QueuedCapture = {
-    id: item.id,
-    item,
-    queuedAt: new Date().toISOString(),
-  };
-  localStorage.setItem(QUEUE_KEY, JSON.stringify([...getQueue(), queued]));
-  return queued;
+function saveHistory(records: CaptureRecord[]): void {
+  localStorage.setItem(HISTORY_KEY, JSON.stringify(records));
 }
 
-export async function flushQueue(config: RSConfig | null = getConfig()) {
-  if (!config?.href || !config.token) return getQueue();
-  const rs = new DirectRS(config);
-  const remaining: QueuedCapture[] = [];
-
-  for (const entry of getQueue()) {
-    try {
-      await rs.store(entry.item);
-    } catch (error) {
-      remaining.push({ ...entry, lastError: errorMessage(error) });
-    }
-  }
-
-  localStorage.setItem(QUEUE_KEY, JSON.stringify(remaining));
-  return remaining;
+function isPending(record: CaptureRecord): boolean {
+  return record.status !== 'synced';
 }
 
-function buildCaptureItem(type: CaptureType, input: string): InboxItem {
-  const trimmed = input.trim();
-  const id = crypto.randomUUID();
-  const createdAt = new Date().toISOString();
+/** Count of captures not yet delivered (queued, sending, or failed). */
+export function pendingCount(records: CaptureRecord[] = getHistory()): number {
+  return records.filter(isPending).length;
+}
 
-  if (type === 'todo') {
-    return {
-      id,
-      type,
-      title: trimmed,
-      createdAt,
-      completed: false,
-      isTodo: true,
-    };
-  }
-
-  if (type === 'bookmark') {
-    return {
-      id,
-      type,
-      title: trimmed,
-      url: normalizeUrl(trimmed),
-      createdAt,
-    };
-  }
-
+function newRecord(
+  id: string,
+  mode: CaptureMode,
+  preview: string,
+  item: InboxItem,
+  hasBlob: boolean,
+): CaptureRecord {
   return {
     id,
-    type,
-    title: trimmed.slice(0, 50),
-    body: trimmed,
-    createdAt,
+    mode,
+    preview,
+    createdAt: new Date().toISOString(),
+    status: 'queued',
+    item,
+    hasBlob,
   };
 }
 
-function normalizeUrl(input: string): string {
-  if (/^https?:\/\//i.test(input)) return input;
-  return `https://${input}`;
+function prepend(record: CaptureRecord): void {
+  saveHistory([record, ...getHistory()]);
+}
+
+/** Queue a text note for delivery. */
+export function captureNote(text: string): CaptureRecord {
+  const trimmed = text.trim();
+  const id = crypto.randomUUID();
+  const item: NoteItem = {
+    id,
+    type: 'note',
+    title: trimmed.slice(0, 50) || 'Note',
+    body: trimmed,
+    createdAt: new Date().toISOString(),
+  };
+  const record = newRecord(
+    id,
+    'note',
+    trimmed.slice(0, 120) || 'Note',
+    item,
+    false,
+  );
+  prepend(record);
+  return record;
+}
+
+/** Queue a photo for delivery; the binary is held in IndexedDB until synced. */
+export async function captureImage(file: File): Promise<CaptureRecord> {
+  const id = crypto.randomUUID();
+  const ext = extFromName(file.name) || extFromMime(file.type) || '.jpg';
+  const item: ImageItem = {
+    id,
+    type: 'image',
+    title: file.name || 'Photo',
+    filePath: `files/${id}${ext}`,
+    mimeType: file.type || 'image/jpeg',
+    createdAt: new Date().toISOString(),
+  };
+  await putBlob(id, file);
+  const record = newRecord(id, 'image', file.name || 'Photo', item, true);
+  prepend(record);
+  return record;
+}
+
+/** Queue a voice memo for delivery; the binary is held in IndexedDB. */
+export async function captureVoice(
+  blob: Blob,
+  durationSec?: number,
+): Promise<CaptureRecord> {
+  const id = crypto.randomUUID();
+  const ext = blob.type.includes('mp4')
+    ? '.mp4'
+    : blob.type.includes('ogg')
+      ? '.ogg'
+      : '.webm';
+  const item: AudioItem = {
+    id,
+    type: 'audio',
+    title: 'Voice memo',
+    filePath: `files/${id}${ext}`,
+    mimeType: blob.type || 'audio/webm',
+    duration: durationSec,
+    createdAt: new Date().toISOString(),
+  };
+  await putBlob(id, blob);
+  const preview = durationSec
+    ? `Voice memo · ${formatDuration(durationSec)}`
+    : 'Voice memo';
+  const record = newRecord(id, 'voice', preview, item, true);
+  prepend(record);
+  return record;
+}
+
+/**
+ * Deliver every pending capture to remoteStorage, oldest first (FIFO), updating
+ * each record's status as it goes. Safe to call repeatedly — it also retries
+ * anything previously marked failed.
+ */
+export async function flushQueue(
+  config: RSConfig | null = getConfig(),
+): Promise<CaptureRecord[]> {
+  let records = getHistory();
+  if (!config?.href || !config.token) return records;
+
+  const rs = new DirectRS(config);
+  const pending = records.filter(isPending).reverse(); // oldest first
+
+  for (const entry of pending) {
+    records = patch(records, entry.id, {
+      status: 'sending',
+      lastError: undefined,
+    });
+    saveHistory(records);
+    try {
+      const fileData = entry.hasBlob ? await getBlobBytes(entry.id) : undefined;
+      await rs.store(entry.item, fileData);
+      records = patch(records, entry.id, {
+        status: 'synced',
+        lastError: undefined,
+      });
+      if (entry.hasBlob) await deleteBlob(entry.id);
+    } catch (error) {
+      records = patch(records, entry.id, {
+        status: 'failed',
+        lastError: errorMessage(error),
+      });
+    }
+    saveHistory(records);
+  }
+  return records;
+}
+
+/** Remove a capture from history and discard any pending binary. */
+export async function removeRecord(id: string): Promise<CaptureRecord[]> {
+  const records = getHistory().filter((r) => r.id !== id);
+  saveHistory(records);
+  await deleteBlob(id);
+  return records;
+}
+
+function patch(
+  records: CaptureRecord[],
+  id: string,
+  changes: Partial<CaptureRecord>,
+): CaptureRecord[] {
+  return records.map((r) => (r.id === id ? { ...r, ...changes } : r));
+}
+
+// ---------------------------------------------------------------------------
+// Binary blob storage (IndexedDB, with an in-memory fallback for non-DOM envs)
+// ---------------------------------------------------------------------------
+
+const DB_NAME = 'inbox-rs-capture';
+const BLOB_STORE = 'blobs';
+const memoryBlobs = new Map<string, Blob>();
+
+function idbAvailable(): boolean {
+  return typeof indexedDB !== 'undefined';
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(BLOB_STORE)) {
+        request.result.createObjectStore(BLOB_STORE);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function txDone(tx: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+}
+
+async function putBlob(id: string, blob: Blob): Promise<void> {
+  if (!idbAvailable()) {
+    memoryBlobs.set(id, blob);
+    return;
+  }
+  const db = await openDb();
+  const tx = db.transaction(BLOB_STORE, 'readwrite');
+  tx.objectStore(BLOB_STORE).put(blob, id);
+  await txDone(tx);
+  db.close();
+}
+
+async function getBlobBytes(id: string): Promise<ArrayBuffer | undefined> {
+  if (!idbAvailable()) {
+    return memoryBlobs.get(id)?.arrayBuffer();
+  }
+  const db = await openDb();
+  const tx = db.transaction(BLOB_STORE, 'readonly');
+  const blob = await new Promise<Blob | undefined>((resolve, reject) => {
+    const request = tx.objectStore(BLOB_STORE).get(id);
+    request.onsuccess = () => resolve(request.result as Blob | undefined);
+    request.onerror = () => reject(request.error);
+  });
+  db.close();
+  return blob?.arrayBuffer();
+}
+
+async function deleteBlob(id: string): Promise<void> {
+  if (!idbAvailable()) {
+    memoryBlobs.delete(id);
+    return;
+  }
+  const db = await openDb();
+  const tx = db.transaction(BLOB_STORE, 'readwrite');
+  tx.objectStore(BLOB_STORE).delete(id);
+  await txDone(tx);
+  db.close();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extFromName(name: string): string | null {
+  const dot = name.lastIndexOf('.');
+  return dot > 0 ? name.slice(dot).toLowerCase() : null;
+}
+
+function extFromMime(mime: string): string | null {
+  if (!mime) return null;
+  if (mime === 'image/jpeg') return '.jpg';
+  const slash = mime.indexOf('/');
+  return slash > 0 ? `.${mime.slice(slash + 1)}` : null;
+}
+
+export function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
 function readJson<T>(key: string): T | null {

--- a/packages/web/src/capture/store.ts
+++ b/packages/web/src/capture/store.ts
@@ -1,0 +1,152 @@
+import type { InboxItem, InboxItemType } from '@inbox-rs/rs-module';
+import {
+  DirectRS,
+  discoverStorage,
+  extractTokenFromRedirect,
+  type RSConfig,
+} from '@inbox-rs/rs-module/runtime';
+
+export type CaptureType = Extract<InboxItemType, 'bookmark' | 'note' | 'todo'>;
+
+export type QueuedCapture = {
+  id: string;
+  item: InboxItem;
+  queuedAt: string;
+  lastError?: string;
+};
+
+const CONFIG_KEY = 'inbox-rs-capture:config';
+const PENDING_AUTH_KEY = 'inbox-rs-capture:pending-auth';
+const QUEUE_KEY = 'inbox-rs-capture:queue';
+
+export function getConfig(): RSConfig | null {
+  return readJson<RSConfig>(CONFIG_KEY);
+}
+
+export function clearConfig(): void {
+  localStorage.removeItem(CONFIG_KEY);
+}
+
+export async function startConnect(userAddress: string): Promise<void> {
+  const discovery = await discoverStorage(userAddress.trim());
+  localStorage.setItem(
+    PENDING_AUTH_KEY,
+    JSON.stringify({ userAddress: userAddress.trim(), discovery }),
+  );
+  const redirectUri = `${window.location.origin}/capture/`;
+  const params = new URLSearchParams({
+    client_id: redirectUri,
+    redirect_uri: redirectUri,
+    response_type: 'token',
+    scope: 'inbox:rw',
+  });
+  window.location.href = `${discovery.authUrl}?${params.toString()}`;
+}
+
+export function finishConnectFromRedirect(): RSConfig | null {
+  if (!window.location.hash.includes('access_token=')) return getConfig();
+  const pending = readJson<{
+    userAddress: string;
+    discovery: { href: string; storageApi?: string };
+  }>(PENDING_AUTH_KEY);
+  if (!pending) return getConfig();
+
+  const config: RSConfig = {
+    userAddress: pending.userAddress,
+    token: extractTokenFromRedirect(window.location.href),
+    href: pending.discovery.href,
+    storageApi: pending.discovery.storageApi,
+  };
+  localStorage.setItem(CONFIG_KEY, JSON.stringify(config));
+  localStorage.removeItem(PENDING_AUTH_KEY);
+  window.history.replaceState(null, '', '/capture/');
+  return config;
+}
+
+export function getQueue(): QueuedCapture[] {
+  return readJson<QueuedCapture[]>(QUEUE_KEY) ?? [];
+}
+
+export function enqueueCapture(
+  type: CaptureType,
+  input: string,
+): QueuedCapture {
+  const item = buildCaptureItem(type, input);
+  const queued: QueuedCapture = {
+    id: item.id,
+    item,
+    queuedAt: new Date().toISOString(),
+  };
+  localStorage.setItem(QUEUE_KEY, JSON.stringify([...getQueue(), queued]));
+  return queued;
+}
+
+export async function flushQueue(config: RSConfig | null = getConfig()) {
+  if (!config?.href || !config.token) return getQueue();
+  const rs = new DirectRS(config);
+  const remaining: QueuedCapture[] = [];
+
+  for (const entry of getQueue()) {
+    try {
+      await rs.store(entry.item);
+    } catch (error) {
+      remaining.push({ ...entry, lastError: errorMessage(error) });
+    }
+  }
+
+  localStorage.setItem(QUEUE_KEY, JSON.stringify(remaining));
+  return remaining;
+}
+
+function buildCaptureItem(type: CaptureType, input: string): InboxItem {
+  const trimmed = input.trim();
+  const id = crypto.randomUUID();
+  const createdAt = new Date().toISOString();
+
+  if (type === 'todo') {
+    return {
+      id,
+      type,
+      title: trimmed,
+      createdAt,
+      completed: false,
+      isTodo: true,
+    };
+  }
+
+  if (type === 'bookmark') {
+    return {
+      id,
+      type,
+      title: trimmed,
+      url: normalizeUrl(trimmed),
+      createdAt,
+    };
+  }
+
+  return {
+    id,
+    type,
+    title: trimmed.slice(0, 50),
+    body: trimmed,
+    createdAt,
+  };
+}
+
+function normalizeUrl(input: string): string {
+  if (/^https?:\/\//i.test(input)) return input;
+  return `https://${input}`;
+}
+
+function readJson<T>(key: string): T | null {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Sync failed';
+}

--- a/packages/web/src/capture/styles.css
+++ b/packages/web/src/capture/styles.css
@@ -118,6 +118,18 @@ button {
   cursor: pointer;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 #capture-app {
   height: 100%;
 }

--- a/packages/web/src/capture/styles.css
+++ b/packages/web/src/capture/styles.css
@@ -1,0 +1,236 @@
+:root {
+  color: #f9fafb;
+  background: #111827;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  font-size: 16px;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 20% 10%,
+      rgba(79, 70, 229, 0.35),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #111827 0%, #0f172a 45%, #020617 100%);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+button {
+  border: 0;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.capture-shell {
+  width: min(100%, 42rem);
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: max(1rem, env(safe-area-inset-top)) 1rem
+    max(1rem, env(safe-area-inset-bottom));
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.hero,
+.panel {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1.5rem;
+  background: rgba(15, 23, 42, 0.78);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(16px);
+}
+
+.hero {
+  padding: 1.1rem;
+}
+
+.hero-top,
+.panel,
+.panel-actions,
+.connect-form,
+.install {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.hero-top,
+.panel,
+.install {
+  justify-content: space-between;
+}
+
+.eyebrow,
+.panel-label {
+  margin: 0;
+  color: #a5b4fc;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0.1rem 0 0;
+  font-size: clamp(1.9rem, 8vw, 3.2rem);
+  letter-spacing: -0.06em;
+}
+
+.main-link {
+  color: #c7d2fe;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.type-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.35rem;
+  margin: 1.1rem 0 0.75rem;
+  padding: 0.3rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.type-tabs button {
+  min-height: 2.4rem;
+  border-radius: 999px;
+  background: transparent;
+  color: #cbd5e1;
+  font-weight: 800;
+}
+
+.type-tabs button.active {
+  background: #f9fafb;
+  color: #111827;
+}
+
+.capture-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+textarea,
+input {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 1rem;
+  background: rgba(2, 6, 23, 0.72);
+  color: #f9fafb;
+  font-size: 1rem;
+  outline: none;
+}
+
+textarea {
+  min-height: 12rem;
+  padding: 1rem;
+  resize: vertical;
+}
+
+input {
+  min-height: 2.75rem;
+  padding: 0 0.85rem;
+}
+
+textarea:focus,
+input:focus {
+  border-color: #818cf8;
+  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.22);
+}
+
+.capture-form button,
+.secondary {
+  min-height: 2.8rem;
+  border-radius: 999px;
+  background: #818cf8;
+  color: #111827;
+  font-weight: 900;
+  padding: 0 1rem;
+}
+
+.ghost {
+  min-height: 2.8rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #e5e7eb;
+  font-weight: 800;
+  padding: 0 1rem;
+}
+
+.status,
+.panel p,
+.hint,
+.address {
+  margin: 0;
+}
+
+.status {
+  min-height: 1.5rem;
+  margin-top: 0.8rem;
+  color: #cbd5e1;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.panel {
+  padding: 1rem;
+}
+
+.panel p,
+.hint {
+  color: #cbd5e1;
+}
+
+.address {
+  margin-top: 0.15rem;
+  color: #f9fafb;
+  font-weight: 800;
+}
+
+.connect-form {
+  flex: 1;
+}
+
+.install {
+  align-items: flex-start;
+}
+
+@media (max-width: 560px) {
+  .capture-shell {
+    justify-content: flex-start;
+  }
+
+  .hero-top,
+  .panel,
+  .install,
+  .connect-form,
+  .panel-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/packages/web/src/capture/styles.css
+++ b/packages/web/src/capture/styles.css
@@ -1,236 +1,123 @@
+/*
+ * Quick-capture theme tokens. Neutrals come from light/dark mode; the accent
+ * comes from the chosen theme (data-accent). Tint and shadow are derived from
+ * the accent so they adapt to whichever mode is active.
+ */
+
 :root {
-  color: #f9fafb;
-  background: #111827;
-  font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-    "Segoe UI", sans-serif;
-  font-size: 16px;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
+  /* light neutrals (default) */
+  --bg: #f2f1ee;
+  --surface: #fbfaf7;
+  --seg: #e7e4dd;
+  --ink: #2c2a26;
+  --ink-soft: #5f5b53;
+  --ink-faint: #928d83;
+  --line: #dcd8d0;
+  --on-accent: #fdfdfb;
+
+  /* accent (overridden per data-accent below; indigo is the default) */
+  --accent: #4f46e5;
+  --accent-deep: #3f38c4;
+
+  --accent-tint: color-mix(in oklab, var(--accent) 22%, var(--bg));
+  --accent-shadow: color-mix(in oklab, var(--accent) 30%, transparent);
+
+  color-scheme: light;
+}
+
+/* dark neutrals — explicit choice */
+:root[data-mode="dark"] {
+  --bg: #201f1d;
+  --surface: #2a2825;
+  --seg: #302d29;
+  --ink: #ece8e1;
+  --ink-soft: #b4afa5;
+  --ink-faint: #8b867c;
+  --line: #37342f;
+  color-scheme: dark;
+}
+
+/* dark neutrals — follow the system when no explicit mode is set */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-mode="light"]):not([data-mode="dark"]) {
+    --bg: #201f1d;
+    --surface: #2a2825;
+    --seg: #302d29;
+    --ink: #ece8e1;
+    --ink-soft: #b4afa5;
+    --ink-faint: #8b867c;
+    --line: #37342f;
+    color-scheme: dark;
+  }
+}
+
+:root[data-accent="indigo"] {
+  --accent: #4f46e5;
+  --accent-deep: #3f38c4;
+}
+:root[data-accent="forest"] {
+  --accent: #3f7d54;
+  --accent-deep: #336545;
+}
+:root[data-accent="plum"] {
+  --accent: #8a4a6f;
+  --accent-deep: #743c5e;
+}
+:root[data-accent="teal"] {
+  --accent: #2f8079;
+  --accent-deep: #266860;
+}
+:root[data-accent="slate"] {
+  --accent: #41607f;
+  --accent-deep: #34506c;
+}
+:root[data-accent="rose"] {
+  --accent: #b15775;
+  --accent-deep: #984862;
+}
+:root[data-accent="mustard"] {
+  --accent: #8a6a1f;
+  --accent-deep: #6f551a;
+}
+:root[data-accent="graphite"] {
+  --accent: #5b6b8c;
+  --accent-deep: #4a5876;
 }
 
 * {
   box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  height: 100%;
 }
 
 body {
-  min-height: 100vh;
-  margin: 0;
-  background:
-    radial-gradient(
-      circle at 20% 10%,
-      rgba(79, 70, 229, 0.35),
-      transparent 28rem
-    ),
-    linear-gradient(135deg, #111827 0%, #0f172a 45%, #020617 100%);
+  background: var(--bg);
+  color: var(--ink);
+  font-family:
+    system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 button,
 input,
 textarea {
   font: inherit;
+  color: inherit;
 }
 
 button {
   border: 0;
+  background: none;
   cursor: pointer;
 }
 
-button:disabled {
-  cursor: default;
-  opacity: 0.55;
-}
-
-.capture-shell {
-  width: min(100%, 42rem);
-  min-height: 100vh;
-  margin: 0 auto;
-  padding: max(1rem, env(safe-area-inset-top)) 1rem
-    max(1rem, env(safe-area-inset-bottom));
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 1rem;
-}
-
-.hero,
-.panel {
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 1.5rem;
-  background: rgba(15, 23, 42, 0.78);
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
-  backdrop-filter: blur(16px);
-}
-
-.hero {
-  padding: 1.1rem;
-}
-
-.hero-top,
-.panel,
-.panel-actions,
-.connect-form,
-.install {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.hero-top,
-.panel,
-.install {
-  justify-content: space-between;
-}
-
-.eyebrow,
-.panel-label {
-  margin: 0;
-  color: #a5b4fc;
-  font-size: 0.78rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-h1 {
-  margin: 0.1rem 0 0;
-  font-size: clamp(1.9rem, 8vw, 3.2rem);
-  letter-spacing: -0.06em;
-}
-
-.main-link {
-  color: #c7d2fe;
-  font-weight: 800;
-  text-decoration: none;
-}
-
-.type-tabs {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0.35rem;
-  margin: 1.1rem 0 0.75rem;
-  padding: 0.3rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-}
-
-.type-tabs button {
-  min-height: 2.4rem;
-  border-radius: 999px;
-  background: transparent;
-  color: #cbd5e1;
-  font-weight: 800;
-}
-
-.type-tabs button.active {
-  background: #f9fafb;
-  color: #111827;
-}
-
-.capture-form {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-textarea,
-input {
-  width: 100%;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 1rem;
-  background: rgba(2, 6, 23, 0.72);
-  color: #f9fafb;
-  font-size: 1rem;
-  outline: none;
-}
-
-textarea {
-  min-height: 12rem;
-  padding: 1rem;
-  resize: vertical;
-}
-
-input {
-  min-height: 2.75rem;
-  padding: 0 0.85rem;
-}
-
-textarea:focus,
-input:focus {
-  border-color: #818cf8;
-  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.22);
-}
-
-.capture-form button,
-.secondary {
-  min-height: 2.8rem;
-  border-radius: 999px;
-  background: #818cf8;
-  color: #111827;
-  font-weight: 900;
-  padding: 0 1rem;
-}
-
-.ghost {
-  min-height: 2.8rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  color: #e5e7eb;
-  font-weight: 800;
-  padding: 0 1rem;
-}
-
-.status,
-.panel p,
-.hint,
-.address {
-  margin: 0;
-}
-
-.status {
-  min-height: 1.5rem;
-  margin-top: 0.8rem;
-  color: #cbd5e1;
-  display: flex;
-  justify-content: space-between;
-  gap: 0.75rem;
-}
-
-.panel {
-  padding: 1rem;
-}
-
-.panel p,
-.hint {
-  color: #cbd5e1;
-}
-
-.address {
-  margin-top: 0.15rem;
-  color: #f9fafb;
-  font-weight: 800;
-}
-
-.connect-form {
-  flex: 1;
-}
-
-.install {
-  align-items: flex-start;
-}
-
-@media (max-width: 560px) {
-  .capture-shell {
-    justify-content: flex-start;
-  }
-
-  .hero-top,
-  .panel,
-  .install,
-  .connect-form,
-  .panel-actions {
-    align-items: stretch;
-    flex-direction: column;
-  }
+#capture-app {
+  height: 100%;
 }

--- a/packages/web/src/capture/styles.css
+++ b/packages/web/src/capture/styles.css
@@ -125,7 +125,7 @@ button {
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/packages/web/src/capture/theme.ts
+++ b/packages/web/src/capture/theme.ts
@@ -1,0 +1,82 @@
+/**
+ * Theme configuration for the quick-capture app: a set of accent colours, each
+ * rendered in light or dark mode. The palettes themselves live in styles.css,
+ * keyed off `data-accent` / `data-mode` attributes on the document root — this
+ * module only tracks and applies the user's selection.
+ */
+
+export const ACCENTS = [
+  'indigo',
+  'forest',
+  'plum',
+  'teal',
+  'slate',
+  'rose',
+  'mustard',
+  'graphite',
+] as const;
+
+export type Accent = (typeof ACCENTS)[number];
+export type Mode = 'light' | 'dark' | 'system';
+
+/** Human labels for the settings UI. */
+export const ACCENT_LABELS: Record<Accent, string> = {
+  indigo: 'Indigo',
+  forest: 'Forest',
+  plum: 'Plum',
+  teal: 'Teal',
+  slate: 'Slate',
+  rose: 'Rose',
+  mustard: 'Mustard',
+  graphite: 'Graphite',
+};
+
+/** Swatch colours for the settings picker (the accent of each theme). */
+export const ACCENT_SWATCHES: Record<Accent, string> = {
+  indigo: '#4f46e5',
+  forest: '#3f7d54',
+  plum: '#8a4a6f',
+  teal: '#2f8079',
+  slate: '#41607f',
+  rose: '#b8617a',
+  mustard: '#bf8a2e',
+  graphite: '#5b6b8c',
+};
+
+const ACCENT_KEY = 'inbox-rs-capture:accent';
+const MODE_KEY = 'inbox-rs-capture:mode';
+
+function isAccent(value: string | null): value is Accent {
+  return !!value && (ACCENTS as readonly string[]).includes(value);
+}
+
+export function getAccent(): Accent {
+  const stored = localStorage.getItem(ACCENT_KEY);
+  return isAccent(stored) ? stored : 'indigo';
+}
+
+export function getMode(): Mode {
+  const stored = localStorage.getItem(MODE_KEY);
+  return stored === 'light' || stored === 'dark' ? stored : 'system';
+}
+
+/** Apply a theme to the document root and persist the choice. */
+export function applyTheme(accent: Accent, mode: Mode): void {
+  const root = document.documentElement;
+  root.dataset.accent = accent;
+  if (mode === 'system') {
+    delete root.dataset.mode;
+  } else {
+    root.dataset.mode = mode;
+  }
+  localStorage.setItem(ACCENT_KEY, accent);
+  localStorage.setItem(MODE_KEY, mode);
+}
+
+/** Apply the stored (or default) theme — call once on startup. */
+export function initTheme(): { accent: Accent; mode: Mode } {
+  const accent = getAccent();
+  const mode = getMode();
+  applyTheme(accent, mode);
+  return { accent, mode };
+}

--- a/packages/web/src/capture/theme.ts
+++ b/packages/web/src/capture/theme.ts
@@ -38,8 +38,8 @@ export const ACCENT_SWATCHES: Record<Accent, string> = {
   plum: '#8a4a6f',
   teal: '#2f8079',
   slate: '#41607f',
-  rose: '#b8617a',
-  mustard: '#bf8a2e',
+  rose: '#b15775',
+  mustard: '#8a6a1f',
   graphite: '#5b6b8c',
 };
 

--- a/packages/web/src/components/PluginsPage.svelte
+++ b/packages/web/src/components/PluginsPage.svelte
@@ -2,8 +2,8 @@
   import chromeLogo from '../assets/logos/chrome.svg';
   import firefoxLogo from '../assets/logos/firefox.svg';
   import thunderbirdLogo from '../assets/logos/thunderbird.svg';
-  import mobileLogo from '../assets/logos/mobile.svg';
-  import shieldLogo from '../assets/logos/logo-shield.svg';
+  import inboxRsMobileLogo from '../assets/logos/inbox-rs-mobile.svg';
+  import captureLogo from '../assets/logos/favicon-shield.svg';
   import { pluginArtifacts } from '../lib/plugin-downloads.generated';
 
   type DownloadOption = {
@@ -63,11 +63,11 @@
   };
 
   const mobileDownload: MobileDownload = {
-    name: 'Mobile App',
-    compatibility: 'iOS & Android',
+    name: 'Inbox RS Mobile',
+    compatibility: 'Standalone native app · iOS & Android',
     repoUrl: 'https://github.com/silverbucket/inbox-rs-mobile',
     accentClass: 'mobile',
-    logoSrc: mobileLogo,
+    logoSrc: inboxRsMobileLogo,
   };
 
   const thunderbirdDownload: DownloadOption = {
@@ -215,67 +215,35 @@
     <div class="section-header">
       <h2>Mobile</h2>
       <p class="section-lede">
-        Capture to your inbox from your phone two ways. <strong>Quick
-        Capture</strong> is a PWA that installs straight from this site — no
-        app store, no system package — while the native app adds deeper OS
-        integration like the share sheet.
+        Two ways to capture from your phone. <strong>Inbox RS Mobile</strong>
+        is a separate, standalone native app (its own download, built with
+        Flutter). <strong>Quick Capture</strong> is built into Inbox RS — a PWA
+        that opens in your browser and adds to your home screen with no app
+        store and no system install.
       </p>
     </div>
 
     <ul class="feature-list">
       <li>
-        <strong>No install needed</strong> — Quick Capture runs in any modern
-        browser and can be added to your home screen
+        <strong>Inbox RS Mobile</strong> — native iOS &amp; Android, with
+        share-sheet integration to send from any app
       </li>
       <li>
-        <strong>Note, Voice &amp; Image</strong> — type, record, or snap a
-        photo straight to your inbox
+        <strong>Quick Capture</strong> — no install; runs in any modern browser
+        and adds to your home screen
+      </li>
+      <li>
+        <strong>Note, Voice &amp; Image</strong> — both capture notes, voice
+        memos, and photos to your inbox
       </li>
       <li>
         <strong>Offline-first</strong> — captures queue locally and sync once
         you're back online
       </li>
-      <li>
-        <strong>Share Sheet</strong> — the native app adds send-from-any-app
-        integration on iOS &amp; Android
-      </li>
     </ul>
 
     <div class="download-grid">
-      <p class="grid-label">Two ways to capture on mobile</p>
-
-      <article class="download-card capture">
-        <div class="card-topline">
-          <div class="card-heading">
-            <div class="logo-badge capture" aria-hidden="true">
-              <img src={shieldLogo} alt="" />
-            </div>
-            <div class="card-title-group">
-              <h3>Quick Capture</h3>
-              <span class="compatibility">Any modern browser · installable PWA</span>
-            </div>
-          </div>
-          <span class="file-pill">PWA</span>
-        </div>
-
-        <a class="download-button" href="/capture/">
-          Open Quick Capture
-        </a>
-
-        <details class="install-details">
-          <summary>About &amp; install</summary>
-          <p class="install-note">
-            A no-install alternative to the native app: open it in any modern
-            browser and it works immediately, queuing notes, voice memos, and
-            photos offline until they sync to your remoteStorage inbox.
-          </p>
-          <ol class="steps">
-            <li>Open Quick Capture with the button above.</li>
-            <li>In your browser, choose Install or Add to Home Screen.</li>
-            <li>Launch it like any app — capture notes, voice, and photos.</li>
-          </ol>
-        </details>
-      </article>
+      <p class="grid-label">Choose your capture app</p>
 
       <article class={`download-card ${mobileDownload.accentClass}`}>
         <div class="card-topline">
@@ -288,7 +256,7 @@
               <span class="compatibility">{mobileDownload.compatibility}</span>
             </div>
           </div>
-          <span class="file-pill">SOURCE</span>
+          <span class="file-pill">NATIVE</span>
         </div>
 
         <a class="download-button" href={mobileDownload.repoUrl} target="_blank" rel="noopener noreferrer">
@@ -298,15 +266,49 @@
         <details class="install-details">
           <summary>Build instructions</summary>
           <p class="install-note">
-            The native app is built from source with Flutter; pre-built binaries
-            aren't provided. It likely won't be published to the App Store or
-            Play Store for now — the annual developer fees aren't justified at
-            this stage. Use Quick Capture for a no-install option.
+            A standalone app from the inbox-rs-mobile repository, built from
+            source with Flutter; pre-built binaries aren't provided. It likely
+            won't be published to the App Store or Play Store for now — the
+            annual developer fees aren't justified at this stage. Prefer no
+            install? Use Quick Capture instead.
           </p>
           <ol class="steps">
-            <li>Clone the repository from GitHub.</li>
+            <li>Clone the inbox-rs-mobile repository from GitHub.</li>
             <li>Install Flutter and run <code>flutter pub get</code>.</li>
             <li>Build for your target platform, e.g. <code>flutter build apk</code> or <code>flutter build ios</code>.</li>
+          </ol>
+        </details>
+      </article>
+
+      <article class="download-card capture">
+        <div class="card-topline">
+          <div class="card-heading">
+            <div class="logo-badge capture" aria-hidden="true">
+              <img src={captureLogo} alt="" />
+            </div>
+            <div class="card-title-group">
+              <h3>Quick Capture</h3>
+              <span class="compatibility">Built into Inbox RS · installable PWA</span>
+            </div>
+          </div>
+          <span class="file-pill">PWA</span>
+        </div>
+
+        <a class="download-button" href="/capture/">
+          Open Quick Capture
+        </a>
+
+        <details class="install-details">
+          <summary>About &amp; install</summary>
+          <p class="install-note">
+            Part of Inbox RS — no separate download. Open it in any modern
+            browser and it works immediately, queuing notes, voice memos, and
+            photos offline until they sync to your remoteStorage inbox.
+          </p>
+          <ol class="steps">
+            <li>Open Quick Capture with the button above.</li>
+            <li>In your browser, choose Install or Add to Home Screen.</li>
+            <li>Launch it like any app — capture notes, voice, and photos.</li>
           </ol>
         </details>
       </article>
@@ -492,7 +494,7 @@
   }
 
   .download-card.mobile::before {
-    background: linear-gradient(135deg, rgba(80, 200, 120, 0.18), transparent 48%);
+    background: linear-gradient(135deg, rgba(79, 70, 229, 0.18), transparent 48%);
   }
 
   .download-card.capture::before {
@@ -540,7 +542,7 @@
     flex-shrink: 0;
     border-radius: 1.15rem;
     border: 1px solid color-mix(in srgb, var(--border) 58%, white 42%);
-    background: color-mix(in srgb, var(--surface) 58%, black 42%);
+    background: color-mix(in srgb, var(--surface) 84%, black 16%);
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.08),
       0 16px 34px rgba(0, 0, 0, 0.18);
@@ -573,6 +575,12 @@
     display: block;
     object-fit: contain;
     filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.22));
+  }
+
+  /* The bare shield reads smaller than the full app-tile icon — size it up to match. */
+  .logo-badge.capture img {
+    width: 2.85rem;
+    height: 2.85rem;
   }
 
   .logo-badge.chrome {
@@ -619,17 +627,17 @@
   }
 
   .logo-badge.mobile {
-    border-color: rgba(80, 200, 120, 0.42);
+    border-color: rgba(79, 70, 229, 0.42);
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.08),
-      0 18px 34px rgba(80, 200, 120, 0.2);
+      0 18px 34px rgba(79, 70, 229, 0.2);
   }
 
   .logo-badge.mobile::before {
     background:
-      radial-gradient(circle at 40% 28%, rgba(80, 200, 120, 0.6), transparent 32%),
-      radial-gradient(circle at 62% 72%, rgba(34, 197, 94, 0.4), transparent 36%),
-      linear-gradient(180deg, rgba(80, 200, 120, 0.58), rgba(22, 101, 52, 0.38) 60%, rgba(20, 22, 30, 0.18));
+      radial-gradient(circle at 40% 28%, rgba(99, 102, 241, 0.5), transparent 32%),
+      radial-gradient(circle at 64% 74%, rgba(79, 70, 229, 0.4), transparent 36%),
+      linear-gradient(180deg, rgba(79, 70, 229, 0.5), rgba(49, 46, 129, 0.38) 60%, rgba(20, 22, 30, 0.18));
   }
 
   .logo-badge.capture {

--- a/packages/web/src/components/PluginsPage.svelte
+++ b/packages/web/src/components/PluginsPage.svelte
@@ -3,6 +3,7 @@
   import firefoxLogo from '../assets/logos/firefox.svg';
   import thunderbirdLogo from '../assets/logos/thunderbird.svg';
   import mobileLogo from '../assets/logos/mobile.svg';
+  import shieldLogo from '../assets/logos/logo-shield.svg';
   import { pluginArtifacts } from '../lib/plugin-downloads.generated';
 
   type DownloadOption = {
@@ -210,33 +211,72 @@
     </div>
   </section>
 
-  <section class="extension-section compact">
+  <section class="extension-section">
     <div class="section-header">
-      <h2>Mobile App</h2>
+      <h2>Mobile</h2>
       <p class="section-lede">
-        A native capture client for iOS and Android, built with Flutter.
-        Quickly save links, notes, and images to your remoteStorage inbox
-        from your phone — with share-sheet integration so you can send
-        content from any app.
+        Capture to your inbox from your phone two ways. <strong>Quick
+        Capture</strong> is a PWA that installs straight from this site — no
+        app store, no system package — while the native app adds deeper OS
+        integration like the share sheet.
       </p>
     </div>
 
     <ul class="feature-list">
       <li>
-        <strong>Share Sheet</strong> — send links and text from any app
-        directly to your inbox
+        <strong>No install needed</strong> — Quick Capture runs in any modern
+        browser and can be added to your home screen
       </li>
       <li>
-        <strong>Quick Capture</strong> — open the app, type a note, and save
-        in seconds
+        <strong>Note, Voice &amp; Image</strong> — type, record, or snap a
+        photo straight to your inbox
       </li>
       <li>
-        <strong>Cross-Platform</strong> — runs natively on both iOS and
-        Android
+        <strong>Offline-first</strong> — captures queue locally and sync once
+        you're back online
+      </li>
+      <li>
+        <strong>Share Sheet</strong> — the native app adds send-from-any-app
+        integration on iOS &amp; Android
       </li>
     </ul>
 
-    <div class="download-grid single">
+    <div class="download-grid">
+      <p class="grid-label">Two ways to capture on mobile</p>
+
+      <article class="download-card capture">
+        <div class="card-topline">
+          <div class="card-heading">
+            <div class="logo-badge capture" aria-hidden="true">
+              <img src={shieldLogo} alt="" />
+            </div>
+            <div class="card-title-group">
+              <h3>Quick Capture</h3>
+              <span class="compatibility">Any modern browser · installable PWA</span>
+            </div>
+          </div>
+          <span class="file-pill">PWA</span>
+        </div>
+
+        <a class="download-button" href="/capture/">
+          Open Quick Capture
+        </a>
+
+        <details class="install-details">
+          <summary>About &amp; install</summary>
+          <p class="install-note">
+            A no-install alternative to the native app: open it in any modern
+            browser and it works immediately, queuing notes, voice memos, and
+            photos offline until they sync to your remoteStorage inbox.
+          </p>
+          <ol class="steps">
+            <li>Open Quick Capture with the button above.</li>
+            <li>In your browser, choose Install or Add to Home Screen.</li>
+            <li>Launch it like any app — capture notes, voice, and photos.</li>
+          </ol>
+        </details>
+      </article>
+
       <article class={`download-card ${mobileDownload.accentClass}`}>
         <div class="card-topline">
           <div class="card-heading">
@@ -257,7 +297,12 @@
 
         <details class="install-details">
           <summary>Build instructions</summary>
-          <p class="install-note">The mobile app is built from source using Flutter. Pre-built binaries are not yet available.</p>
+          <p class="install-note">
+            The native app is built from source with Flutter; pre-built binaries
+            aren't provided. It likely won't be published to the App Store or
+            Play Store for now — the annual developer fees aren't justified at
+            this stage. Use Quick Capture for a no-install option.
+          </p>
           <ol class="steps">
             <li>Clone the repository from GitHub.</li>
             <li>Install Flutter and run <code>flutter pub get</code>.</li>
@@ -450,6 +495,10 @@
     background: linear-gradient(135deg, rgba(80, 200, 120, 0.18), transparent 48%);
   }
 
+  .download-card.capture::before {
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.18), transparent 48%);
+  }
+
   /* ── Card Internals ── */
 
   .card-topline {
@@ -581,6 +630,20 @@
       radial-gradient(circle at 40% 28%, rgba(80, 200, 120, 0.6), transparent 32%),
       radial-gradient(circle at 62% 72%, rgba(34, 197, 94, 0.4), transparent 36%),
       linear-gradient(180deg, rgba(80, 200, 120, 0.58), rgba(22, 101, 52, 0.38) 60%, rgba(20, 22, 30, 0.18));
+  }
+
+  .logo-badge.capture {
+    border-color: rgba(99, 102, 241, 0.42);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 18px 34px rgba(99, 102, 241, 0.2);
+  }
+
+  .logo-badge.capture::before {
+    background:
+      radial-gradient(circle at 40% 28%, rgba(129, 140, 248, 0.55), transparent 32%),
+      radial-gradient(circle at 64% 74%, rgba(79, 70, 229, 0.4), transparent 36%),
+      linear-gradient(180deg, rgba(99, 102, 241, 0.55), rgba(49, 46, 129, 0.38) 60%, rgba(20, 22, 30, 0.18));
   }
 
   .file-pill {

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -310,6 +310,17 @@
 
       <div class="divider"></div>
 
+      <div class="section-label">Quick capture</div>
+      <a class="menu-item" role="menuitem" href="/capture/">
+        <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 5v14"></path>
+          <path d="M5 12h14"></path>
+        </svg>
+        Install capture app
+      </a>
+
+      <div class="divider"></div>
+
       <!-- Theme -->
       <div class="section-label">Theme</div>
       <div class="theme-switcher" role="radiogroup" aria-label="Theme">
@@ -699,6 +710,7 @@
     background: none;
     color: var(--text);
     font-size: 0.85rem;
+    text-decoration: none;
     cursor: pointer;
     transition: background 120ms;
   }

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -26,6 +26,10 @@ export default defineConfig({
         'icon-512.png',
       ],
       workbox: {
+        additionalManifestEntries: [
+          { url: '/', revision: version },
+          { url: '/capture/', revision: version },
+        ],
         cleanupOutdatedCaches: true,
         navigateFallback: '/index.html',
         globPatterns: ['**/*.{js,css,html,png,svg,webmanifest,wasm}'],
@@ -52,5 +56,11 @@ export default defineConfig({
     // 89 / Firefox 89 / Safari 15 — all 2021 baselines, well below our
     // supported floor.
     target: ['chrome89', 'edge89', 'firefox89', 'safari15'],
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        capture: path.resolve(__dirname, 'capture/index.html'),
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary

Adds the **Quick Capture** PWA — a phone-first, frictionless surface for getting a thought into your remoteStorage inbox in one move — and reshapes it around three capture inputs.

A lightweight `/capture/` entry with its own manifest and install guidance, talking to remoteStorage directly via the `@inbox-rs/rs-module/runtime` `DirectRS` client (no full sync stack).

## Capture model: Note · Voice · Image

The capture surface is a single pre-focused field with one obvious **Send**, a mode switch, and everything else tucked into sheets.

- **Note** — text (default).
- **Voice** — records via `MediaRecorder`.
- **Image** — captures/picks a photo.

Voice and Image are stored as real inbox `audio`/`image` items: the binary is uploaded with `DirectRS.storeFile`, the metadata with `storeObject` — identical to how the main app stores them.

> Removes the previous **todo** and **bookmark** capture paths.

## Offline queue + delivery history

- Captures queue locally and sync **FIFO** when connected/online. Binary payloads are held in **IndexedDB** (text in `localStorage`) so photos/voice survive a reload.
- A unified **history** view shows every capture with its delivery state — `Queued → Sending → Sent`, or `Failed` with the error — plus a pending badge on the toolbar, a "Sync now" retry, and per-item removal.

## Theming

- Eight accent colours × **light / dark / system**, persisted and applied via `data-accent` / `data-mode`; tint and shadow are derived with `color-mix` so they adapt per mode.
- Connection, install and theme controls live in a **Settings** sheet, keeping the capture screen a single focused field.

## Hardening (review fixes)

- The discovered OAuth endpoint is scheme-validated before navigation (rejects `javascript:` / `data:` and non-localhost `http:`), so a hostile WebFinger provider can't run script in our origin.
- Token-or-error callbacks are handled in both the URL fragment and query string, and pending auth state is always scrubbed.
- Connect failures are surfaced in the UI instead of an unhandled rejection.
- The image picker opens from a `<label>` (not a programmatic click on a hidden input), so it works in Safari/iOS.

## Verification

- `npx biome ci` — clean
- `npm run build --workspace=packages/web` — succeeds
- `npm run test --workspace=packages/web` — 283 passing (incl. capture connect/redirect guards and capture → queue → delivery-state coverage)
- Manual browser smoke test: note, image (upload → preview → send → history), theme light/dark + accent switching; voice confirmed recording.

## Replaces

Replaces #127.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Quick Capture, a new progressive web app for rapidly capturing notes, voice recordings, and images
  * Offline-first capture queue with automatic synchronization support
  * Theme customization with multiple accent colors and light/dark/system modes
  * Quick Capture accessible from main app menu and installable as a standalone app

<!-- end of auto-generated comment: release notes by coderabbit.ai -->