### PR TITLE
test(e2e): Quick Capture PWA demo and verification suite

### DIFF
--- a/packages/web/src/capture/store.test.ts
+++ b/packages/web/src/capture/store.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearConfig,
+  enqueueCapture,
+  finishConnectFromRedirect,
+  flushQueue,
+  getConfig,
+  getQueue,
+} from './store';
+
+const CONFIG_KEY = 'inbox-rs-capture:config';
+const PENDING_AUTH_KEY = 'inbox-rs-capture:pending-auth';
+const QUEUE_KEY = 'inbox-rs-capture:queue';
+
+const sampleConfig = {
+  userAddress: 'alice@localhost:8000',
+  token: 'test-token',
+  href: 'http://localhost:8000/storage/alice',
+  storageApi: 'draft-dejong-remotestorage-10',
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.stubGlobal('crypto', {
+    randomUUID: () => '00000000-0000-4000-8000-000000000001',
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('capture store', () => {
+  it('builds note items with title slice and full body', () => {
+    const longText = `${'a'.repeat(60)} extra body text`;
+    enqueueCapture('note', longText);
+    const [entry] = getQueue();
+    expect(entry.item.type).toBe('note');
+    expect(entry.item.title).toBe(longText.slice(0, 50));
+    expect(entry.item.body).toBe(longText);
+  });
+
+  it('builds todo items with isTodo and completed flags', () => {
+    enqueueCapture('todo', 'Buy milk');
+    const [entry] = getQueue();
+    expect(entry.item).toMatchObject({
+      type: 'todo',
+      title: 'Buy milk',
+      isTodo: true,
+      completed: false,
+    });
+  });
+
+  it('normalizes bookmark URLs without a scheme', () => {
+    enqueueCapture('bookmark', 'example.com/page');
+    const [entry] = getQueue();
+    expect(entry.item).toMatchObject({
+      type: 'bookmark',
+      title: 'example.com/page',
+      url: 'https://example.com/page',
+    });
+  });
+
+  it('preserves https bookmark URLs', () => {
+    enqueueCapture('bookmark', 'https://example.com');
+    const [entry] = getQueue();
+    expect(entry.item.url).toBe('https://example.com');
+  });
+
+  it('appends multiple captures to the queue', () => {
+    enqueueCapture('note', 'first');
+    enqueueCapture('todo', 'second');
+    expect(getQueue()).toHaveLength(2);
+  });
+
+  it('persists and clears config', () => {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify(sampleConfig));
+    expect(getConfig()).toEqual(sampleConfig);
+    clearConfig();
+    expect(getConfig()).toBeNull();
+  });
+
+  it('finishes OAuth redirect and stores config', () => {
+    localStorage.setItem(
+      PENDING_AUTH_KEY,
+      JSON.stringify({
+        userAddress: sampleConfig.userAddress,
+        discovery: {
+          href: sampleConfig.href,
+          storageApi: sampleConfig.storageApi,
+        },
+      }),
+    );
+    const hash = '#access_token=abc123&token_type=bearer';
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: `http://localhost:5173/capture/${hash}`,
+        hash,
+        origin: 'http://localhost:5173',
+      },
+      writable: true,
+    });
+    history.replaceState = vi.fn();
+
+    const config = finishConnectFromRedirect();
+    expect(config).toMatchObject({
+      userAddress: sampleConfig.userAddress,
+      token: 'abc123',
+      href: sampleConfig.href,
+    });
+    expect(localStorage.getItem(PENDING_AUTH_KEY)).toBeNull();
+    expect(getConfig()?.token).toBe('abc123');
+  });
+
+  it('flushQueue removes synced entries and keeps failures', async () => {
+    localStorage.setItem(
+      QUEUE_KEY,
+      JSON.stringify([
+        {
+          id: 'a',
+          queuedAt: '2024-01-01T00:00:00.000Z',
+          item: {
+            id: 'a',
+            type: 'note',
+            title: 'ok',
+            body: 'ok',
+            createdAt: '2024-01-01T00:00:00.000Z',
+          },
+        },
+        {
+          id: 'b',
+          queuedAt: '2024-01-01T00:00:00.000Z',
+          item: {
+            id: 'b',
+            type: 'note',
+            title: 'fail',
+            body: 'fail',
+            createdAt: '2024-01-01T00:00:00.000Z',
+          },
+        },
+      ]),
+    );
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: false, status: 503 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const remaining = await flushQueue(sampleConfig);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.id).toBe('b');
+    expect(remaining[0]?.lastError).toContain('503');
+    expect(getQueue()).toHaveLength(1);
+  });
+});

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -20,6 +20,7 @@ schemas.
 | `desktop/offline-resilience.spec.ts` | warm-offline keeps SPA usable; cold-offline characterization (will flip when SW lands) |
 | `desktop/offline-then-connect.spec.ts` | offline → online → connect, both for a brand-new account *and* an existing account with pre-seeded data that must sync down |
 | `desktop/inbox-crud.spec.ts` | add a Note via the modal, see it in the grid (smoke for the change-event path) |
+| `desktop/quick-capture.spec.ts` | Quick Capture PWA at `/capture/`: manifest, OAuth connect, note/todo/bookmark sync, offline queue, cross-app visibility in main inbox |
 | `mobile/mobile-layout.spec.ts` | 768 px breakpoint promotes header to grid, logo shrinks, touch targets sized |
 | `mobile/touch-interactions.spec.ts` | `tap()` (touch dispatch) opens menus and navigates |
 | `mobile/modal-scroll-lock.spec.ts` | iOS body-scroll-lock fixed on open, restored on close |

--- a/tests/e2e/demo/quick-capture-video.spec.ts
+++ b/tests/e2e/demo/quick-capture-video.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Recorded walkthrough of the Quick Capture PWA for demo / review.
+ *
+ * Run:
+ *   npm test -w @inbox-rs/e2e -- demo/quick-capture-video.spec.ts \
+ *     --config=playwright.demo.config.ts
+ */
+
+import { expect, test } from '../helpers/fixtures';
+
+const WEB_ORIGIN = process.env.WEB_ORIGIN ?? 'http://localhost:4173';
+const captureUrl = `${WEB_ORIGIN}/capture/`;
+
+async function pause(page: import('@playwright/test').Page, ms = 1200) {
+  await page.waitForTimeout(ms);
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test('Quick Capture video demo', async ({ page, freshRsUser }) => {
+  test.setTimeout(120_000);
+
+  // 1. Open the capture shell
+  await page.goto(captureUrl);
+  await page.waitForLoadState('networkidle');
+  await pause(page, 1500);
+
+  // 2. Connect remoteStorage via OAuth
+  await page.getByPlaceholder('user@storage.example').fill(freshRsUser.address);
+  await pause(page, 600);
+  await page.getByRole('button', { name: 'Connect', exact: true }).click();
+
+  await page.waitForURL(/^http:\/\/localhost:8000\/oauth\//, {
+    timeout: 15_000,
+  });
+  await pause(page, 800);
+  await page.locator('input[name="password"]').fill(freshRsUser.password);
+  await pause(page, 400);
+  await page.locator('button[name="allow"]').click();
+
+  await page.waitForURL(`${WEB_ORIGIN}/capture/**`, { timeout: 15_000 });
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByText('Connected')).toBeVisible();
+  await pause(page, 1500);
+
+  // 3. Capture a note
+  await page.getByRole('button', { name: 'Note' }).click();
+  await page
+    .getByPlaceholder('Jot something down...')
+    .fill('Quick idea: ship the capture app as a home-screen PWA');
+  await pause(page, 800);
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByText('Synced')).toBeVisible({ timeout: 15_000 });
+  await pause(page, 1200);
+
+  // 4. Capture a todo
+  await page.getByRole('button', { name: 'Todo' }).click();
+  await page
+    .getByPlaceholder('What needs doing?')
+    .fill('Review Quick Capture PR');
+  await pause(page, 800);
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByText('Synced')).toBeVisible({ timeout: 15_000 });
+  await pause(page, 1200);
+
+  // 5. Capture a bookmark
+  await page.getByRole('button', { name: 'Bookmark' }).click();
+  await page
+    .getByPlaceholder('https://example.com')
+    .fill('github.com/silverbucket/inbox-rs');
+  await pause(page, 800);
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByText('Synced')).toBeVisible({ timeout: 15_000 });
+  await pause(page, 1500);
+
+  // 6. Open the main app and connect the same account
+  await page.getByRole('link', { name: 'Full app' }).click();
+  await page.waitForLoadState('networkidle');
+  await pause(page, 1200);
+
+  await page.getByRole('button', { name: 'User menu — disconnected' }).click();
+  await pause(page, 500);
+  await page.getByPlaceholder('user@storage.example').fill(freshRsUser.address);
+  await page.getByRole('button', { name: 'Connect', exact: true }).click();
+
+  await page.waitForURL(/^http:\/\/localhost:8000\/oauth\//, {
+    timeout: 15_000,
+  });
+  await page.locator('input[name="password"]').fill(freshRsUser.password);
+  await page.locator('button[name="allow"]').click();
+
+  await page.waitForURL(`${WEB_ORIGIN}/**`, { timeout: 15_000 });
+  await page.waitForLoadState('networkidle');
+  await expect(
+    page.getByRole('button', { name: 'User menu — connected' }),
+  ).toBeVisible({ timeout: 15_000 });
+  await pause(page, 2000);
+
+  // 7. Show captured items synced into the inbox
+  await expect(page.getByText('Quick idea: ship the capture app')).toBeVisible({
+    timeout: 20_000,
+  });
+  await pause(page, 2500);
+});

--- a/tests/e2e/desktop/quick-capture.spec.ts
+++ b/tests/e2e/desktop/quick-capture.spec.ts
@@ -1,0 +1,291 @@
+/**
+ * Quick Capture PWA — end-to-end demo of the `/capture/` entry point.
+ */
+
+import { listInboxItems, oauthTokenForCapture } from '../helpers/armadietto';
+import { clearCaptureStorage, seedCaptureSession } from '../helpers/capture';
+import { expect, test } from '../helpers/fixtures';
+import {
+  assertNoConsoleErrors,
+  attachConsoleCapture,
+  seedRsSession,
+} from '../helpers/pwa';
+
+const captureUrl = (origin: string) => `${origin}/capture/`;
+
+test.describe('Quick Capture PWA', () => {
+  test('capture manifest is served and scoped to /capture/', async ({
+    webOrigin,
+    request,
+  }) => {
+    const resp = await request.get(`${webOrigin}/capture/manifest.webmanifest`);
+    expect(resp.status()).toBe(200);
+
+    const manifest = (await resp.json()) as {
+      name?: string;
+      start_url?: string;
+      scope?: string;
+      display?: string;
+      icons?: Array<{ src: string; sizes?: string }>;
+    };
+    expect(manifest.name).toContain('Quick Capture');
+    expect(manifest.start_url).toBe('/capture/');
+    expect(manifest.scope).toBe('/capture/');
+    expect(['standalone', 'fullscreen', 'minimal-ui']).toContain(
+      manifest.display,
+    );
+
+    const bigIcons = (manifest.icons ?? []).filter((i) =>
+      (i.sizes ?? '')
+        .split(/\s+/)
+        .some((s) => parseInt(s.split('x')[0] ?? '0', 10) >= 192),
+    );
+    expect(bigIcons.length).toBeGreaterThan(0);
+  });
+
+  test('capture page renders the input shell', async ({ page, webOrigin }) => {
+    await page.goto(captureUrl(webOrigin));
+    await page.waitForLoadState('networkidle');
+
+    await expect(
+      page.getByRole('heading', { name: 'Quick Capture' }),
+    ).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Full app' })).toHaveAttribute(
+      'href',
+      '/',
+    );
+    await expect(page.getByRole('button', { name: 'Note' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Todo' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Bookmark' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  test('full connect round-trip via OAuth on capture page', async ({
+    page,
+    webOrigin,
+    freshRsUser,
+  }) => {
+    const log = attachConsoleCapture(page);
+    await page.goto(captureUrl(webOrigin));
+    await page.waitForLoadState('networkidle');
+
+    await page
+      .getByPlaceholder('user@storage.example')
+      .fill(freshRsUser.address);
+    await page.getByRole('button', { name: 'Connect', exact: true }).click();
+
+    await page.waitForURL(/^http:\/\/localhost:8000\/oauth\//, {
+      timeout: 10_000,
+    });
+    await page.locator('input[name="password"]').fill(freshRsUser.password);
+    await page.locator('button[name="allow"]').click();
+
+    await page.waitForURL(`${webOrigin}/capture/**`, { timeout: 10_000 });
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Connected')).toBeVisible();
+    await expect(page.getByText(freshRsUser.address)).toBeVisible();
+    assertNoConsoleErrors(log);
+  });
+
+  test('captures a note and syncs it to remoteStorage', async ({
+    context,
+    freshRsUser,
+    webOrigin,
+  }) => {
+    const captureToken = await oauthTokenForCapture(freshRsUser, {
+      clientOrigin: webOrigin,
+    });
+    await clearCaptureStorage(context);
+    await seedCaptureSession(context, freshRsUser, captureToken, {
+      clientOrigin: webOrigin,
+    });
+
+    const page = await context.newPage();
+    const log = attachConsoleCapture(page);
+    await page.goto(captureUrl(webOrigin));
+    await page.waitForLoadState('networkidle');
+
+    const sentinel = 'capture-e2e-note-α';
+    await page.getByRole('button', { name: 'Note' }).click();
+    await page
+      .getByPlaceholder('Jot something down...')
+      .fill(`Title line\n${sentinel}`);
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByText('Synced')).toBeVisible({ timeout: 15_000 });
+
+    const queueRaw = await page.evaluate(() =>
+      localStorage.getItem('inbox-rs-capture:queue'),
+    );
+    expect(JSON.parse(queueRaw ?? '[]')).toEqual([]);
+
+    const itemsOnServer = await listInboxItems(freshRsUser, captureToken);
+    expect(
+      itemsOnServer.some(
+        (item) => item.type === 'note' && item.body?.includes(sentinel),
+      ),
+    ).toBe(true);
+    assertNoConsoleErrors(log);
+    await page.close();
+  });
+
+  test('captures todo and bookmark types with correct shape', async ({
+    context,
+    freshRsUser,
+    webOrigin,
+  }) => {
+    const captureToken = await oauthTokenForCapture(freshRsUser, {
+      clientOrigin: webOrigin,
+    });
+    await clearCaptureStorage(context);
+    await seedCaptureSession(context, freshRsUser, captureToken, {
+      clientOrigin: webOrigin,
+    });
+
+    const page = await context.newPage();
+    await page.goto(captureUrl(webOrigin));
+    await page.waitForLoadState('networkidle');
+
+    const todoText = 'capture-e2e-todo-β';
+    await page.getByRole('button', { name: 'Todo' }).click();
+    await page.getByPlaceholder('What needs doing?').fill(todoText);
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText('Synced')).toBeVisible({ timeout: 15_000 });
+
+    const bookmarkUrl = 'example.com/capture-e2e';
+    await page.getByRole('button', { name: 'Bookmark' }).click();
+    await page.getByPlaceholder('https://example.com').fill(bookmarkUrl);
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText('Synced')).toBeVisible({ timeout: 15_000 });
+
+    const serverItems = await listInboxItems(freshRsUser, captureToken);
+
+    const todo = serverItems.find((item) => item.type === 'todo');
+    expect(todo?.type === 'todo' && todo.title).toBe(todoText);
+    if (todo?.type === 'todo') {
+      expect(todo.isTodo).toBe(true);
+      expect(todo.completed).toBe(false);
+    }
+
+    const bookmark = serverItems.find((item) => item.type === 'bookmark');
+    expect(bookmark?.type === 'bookmark' && bookmark.url).toBe(
+      `https://${bookmarkUrl}`,
+    );
+
+    await page.close();
+  });
+
+  test('queues captures offline then syncs when back online', async ({
+    context,
+    freshRsUser,
+    webOrigin,
+  }) => {
+    const captureToken = await oauthTokenForCapture(freshRsUser, {
+      clientOrigin: webOrigin,
+    });
+
+    const page = await context.newPage();
+    await page.goto(captureUrl(webOrigin));
+    await page.waitForLoadState('networkidle');
+
+    await context.setOffline(true);
+    const offlineNote = 'capture-e2e-offline-γ';
+    await page.getByPlaceholder('Jot something down...').fill(offlineNote);
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(
+      page.getByText('Saved locally. Connect to sync.'),
+    ).toBeVisible();
+    await expect(page.getByText('1 queued')).toBeVisible();
+
+    const queueLen = await page.evaluate(() => {
+      const raw = localStorage.getItem('inbox-rs-capture:queue');
+      return raw ? (JSON.parse(raw) as unknown[]).length : 0;
+    });
+    expect(queueLen).toBe(1);
+
+    await context.setOffline(false);
+    await seedCaptureSession(context, freshRsUser, captureToken, {
+      clientOrigin: webOrigin,
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Synced')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('queued')).toHaveCount(0);
+
+    const itemsAfterSync = await listInboxItems(freshRsUser, captureToken);
+    expect(
+      itemsAfterSync.some(
+        (item) =>
+          item.type === 'note' &&
+          (item.body?.includes(offlineNote) ||
+            item.title?.includes(offlineNote)),
+      ),
+    ).toBe(true);
+
+    await page.close();
+  });
+
+  test('captured items surface in the main inbox app', async ({
+    context,
+    freshRsUser,
+    freshRsToken,
+    webOrigin,
+  }) => {
+    const captureToken = await oauthTokenForCapture(freshRsUser, {
+      clientOrigin: webOrigin,
+    });
+    await clearCaptureStorage(context);
+    await seedCaptureSession(context, freshRsUser, captureToken, {
+      clientOrigin: webOrigin,
+    });
+
+    const capturePage = await context.newPage();
+    await capturePage.goto(captureUrl(webOrigin));
+    await capturePage.waitForLoadState('networkidle');
+
+    const crossAppSentinel = 'capture-e2e-cross-app-δ';
+    await capturePage
+      .getByPlaceholder('Jot something down...')
+      .fill(crossAppSentinel);
+    await capturePage.getByRole('button', { name: 'Save' }).click();
+    await expect(capturePage.getByText('Synced')).toBeVisible({
+      timeout: 15_000,
+    });
+    await capturePage.close();
+
+    await seedRsSession(context, freshRsUser, freshRsToken, {
+      clientOrigin: webOrigin,
+    });
+
+    const mainPage = await context.newPage();
+    await mainPage.goto(webOrigin);
+    await mainPage.waitForLoadState('networkidle');
+
+    await expect(
+      mainPage.getByRole('button', { name: 'User menu — connected' }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(mainPage.getByText(crossAppSentinel)).toBeVisible({
+      timeout: 15_000,
+    });
+    await mainPage.close();
+  });
+
+  test('main app user menu links to Quick Capture', async ({
+    page,
+    webOrigin,
+  }) => {
+    await page.goto(webOrigin);
+    await page.waitForLoadState('networkidle');
+
+    await page
+      .getByRole('button', { name: 'User menu — disconnected' })
+      .click();
+    const captureLink = page.getByRole('menuitem', {
+      name: 'Install capture app',
+    });
+    await expect(captureLink).toHaveAttribute('href', '/capture/');
+  });
+});

--- a/tests/e2e/helpers/armadietto.ts
+++ b/tests/e2e/helpers/armadietto.ts
@@ -151,6 +151,36 @@ export async function oauthToken(
 }
 
 /**
+ * List all inbox items for a user by walking the RS folder index.
+ */
+export async function listInboxItems(
+  user: RsUser,
+  token: string,
+): Promise<InboxItem[]> {
+  const indexUrl = `${ARMADIETTO_ORIGIN}/storage/${user.username}/inbox/items/`;
+  const indexResp = await fetch(indexUrl, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  });
+  if (indexResp.status !== 200) {
+    const text = await indexResp.text().catch(() => '');
+    throw new Error(
+      `GET /inbox/items/ for ${user.username} failed: HTTP ${indexResp.status} — ${text.slice(0, 200)}`,
+    );
+  }
+  const index = (await indexResp.json()) as {
+    items?: Record<string, unknown>;
+  };
+  const ids = Object.keys(index.items ?? {});
+  const items: InboxItem[] = [];
+  for (const id of ids) {
+    const item = await getInboxItem(user, token, id);
+    if (item) items.push(item);
+  }
+  return items;
+}
+
+/**
  * Write a single inbox item directly to RS, bypassing the web app.
  *
  * Targets `PUT /storage/<user>/inbox/items/<id>`, which is the same path
@@ -188,4 +218,71 @@ export async function putInboxItem(
       `PUT /inbox/items/${item.id} for ${user.username} failed: HTTP ${r.status} — ${text.slice(0, 200)}`,
     );
   }
+}
+
+/**
+ * Read a single inbox item directly from RS, bypassing the web app.
+ *
+ * Returns `null` when the item does not exist (HTTP 404).
+ */
+export async function getInboxItem(
+  user: RsUser,
+  token: string,
+  itemId: string,
+): Promise<InboxItem | null> {
+  const r = await fetch(
+    `${ARMADIETTO_ORIGIN}/storage/${user.username}/inbox/items/${itemId}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+    },
+  );
+  if (r.status === 404) return null;
+  if (r.status !== 200) {
+    const text = await r.text().catch(() => '');
+    throw new Error(
+      `GET /inbox/items/${itemId} for ${user.username} failed: HTTP ${r.status} — ${text.slice(0, 200)}`,
+    );
+  }
+  return (await r.json()) as InboxItem;
+}
+
+/**
+ * OAuth token for the Quick Capture PWA at `/capture/`.
+ */
+export async function oauthTokenForCapture(
+  user: RsUser,
+  options: { clientOrigin: string; scopes?: string },
+): Promise<string> {
+  const { clientOrigin, scopes = 'inbox:rw' } = options;
+  const redirectUri = `${clientOrigin}/capture/`;
+  const body = new URLSearchParams({
+    client_id: redirectUri,
+    redirect_uri: redirectUri,
+    response_type: 'token',
+    scope: scopes,
+    state: '',
+    username: user.username,
+    password: user.password,
+    allow: 'Allow',
+  });
+  const r = await fetch(`${ARMADIETTO_ORIGIN}/oauth`, {
+    method: 'POST',
+    body,
+    redirect: 'manual',
+    signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  });
+  if (r.status !== 302) {
+    const text = await r.text().catch(() => '');
+    throw new Error(
+      `OAuth Allow for ${user.username} (capture) returned HTTP ${r.status}, expected 302. Body: ${text.slice(0, 200)}`,
+    );
+  }
+  const location = r.headers.get('Location') ?? '';
+  const fragment = location.split('#')[1] ?? '';
+  for (const kv of fragment.split('&')) {
+    const [k, v = ''] = kv.split('=');
+    if (k === 'access_token') return decodeURIComponent(v);
+  }
+  throw new Error(`OAuth redirect missing access_token: ${location}`);
 }

--- a/tests/e2e/helpers/capture.ts
+++ b/tests/e2e/helpers/capture.ts
@@ -1,0 +1,52 @@
+/**
+ * Helpers for the Quick Capture PWA at `/capture/`.
+ */
+
+import type { BrowserContext } from '@playwright/test';
+
+import { ARMADIETTO_ORIGIN, type RsUser } from './armadietto';
+
+function captureConfigPayload(
+  user: RsUser,
+  token: string,
+): Record<string, string> {
+  const storageHref = `${ARMADIETTO_ORIGIN}/storage/${user.username}`;
+  return {
+    'inbox-rs-capture:config': JSON.stringify({
+      userAddress: user.address,
+      href: storageHref,
+      storageApi: 'draft-dejong-remotestorage-10',
+      token,
+    }),
+  };
+}
+
+export async function seedCaptureSession(
+  context: BrowserContext,
+  user: RsUser,
+  token: string,
+  _options: { clientOrigin: string },
+): Promise<void> {
+  const payload = captureConfigPayload(user, token);
+  await context.addInitScript((entries) => {
+    for (const [k, v] of Object.entries(entries)) {
+      try {
+        localStorage.setItem(k, v as string);
+      } catch {
+        // Storage quota or disabled.
+      }
+    }
+  }, payload);
+}
+
+export async function clearCaptureStorage(
+  context: BrowserContext,
+): Promise<void> {
+  await context.addInitScript(() => {
+    for (const key of Object.keys(localStorage)) {
+      if (key.startsWith('inbox-rs-capture:')) {
+        localStorage.removeItem(key);
+      }
+    }
+  });
+}

--- a/tests/e2e/playwright.demo.config.ts
+++ b/tests/e2e/playwright.demo.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const WEB_ORIGIN = process.env.WEB_ORIGIN ?? 'http://localhost:4173';
+
+/** Playwright config for recording demo videos (no webServer — reuse running servers). */
+export default defineConfig({
+  testDir: '.',
+  testMatch: ['demo/*.spec.ts'],
+  workers: 1,
+  retries: 0,
+  timeout: 120_000,
+  reporter: 'list',
+  outputDir: '/opt/cursor/artifacts/demo/playwright-output',
+  use: {
+    baseURL: WEB_ORIGIN,
+    ...devices['Desktop Chrome'],
+    viewport: { width: 1280, height: 720 },
+    video: 'on',
+    launchOptions: { slowMo: 250 },
+    trace: 'off',
+    screenshot: 'off',
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a full automated demo proving the Quick Capture PWA (`/capture/`) works end-to-end against a live Armadietto remoteStorage server.

## Video demo

[quick-capture-demo.mp4](https://cursor.com/agents/bc-3a509be5-2f76-4c08-85e9-93bec39ba08a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo%2Fquick-capture-demo.mp4)

The walkthrough shows:
1. Opening `/capture/` — the standalone Quick Capture shell
2. Connecting to remoteStorage via OAuth
3. Saving a note, todo, and bookmark (each syncing immediately)
4. Opening the main app and connecting the same account
5. Captured items appearing in the inbox grid

## What was verified (8 Playwright tests, all passing)

| Test | Proves |
|------|--------|
| Capture manifest | `/capture/manifest.webmanifest` is valid, scoped to `/capture/`, installable |
| Input shell | Note/Todo/Bookmark tabs, textarea, Save button render correctly |
| OAuth connect | Full remoteStorage login round-trip from the capture page |
| Note sync | Captured note reaches remoteStorage and queue clears |
| Todo + bookmark | Correct item shapes (`isTodo`, normalized bookmark URL) sync to RS |
| Offline queue | Disconnected offline save queues locally, then flushes after connect |
| Cross-app sync | Item captured in `/capture/` appears in the main inbox app |
| User menu link | Main app links to `/capture/` via "Install capture app" |

## Supporting changes

- **`tests/e2e/helpers/capture.ts`** — seed/clear capture localStorage session
- **`tests/e2e/helpers/armadietto.ts`** — `oauthTokenForCapture`, `getInboxItem`, `listInboxItems` helpers
- **`packages/web/src/capture/store.test.ts`** — 8 unit tests for queue, config, and flush logic
- **`tests/e2e/demo/quick-capture-video.spec.ts`** — slow-motion recording script for the video above

## How to run the demo locally

```bash
npm ci
npm run test:e2e:install
npm run build -w packages/web
npm run test:e2e -- --grep "Quick Capture"
```

To re-record the video (requires Armadietto on :8000 and preview on :4173 already running):

```bash
npm test -w @inbox-rs/e2e -- demo/quick-capture-video.spec.ts --config=playwright.demo.config.ts
```

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a509be5-2f76-4c08-85e9-93bec39ba08a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a509be5-2f76-4c08-85e9-93bec39ba08a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

