### PR TITLE
fix(web): keep edited items in their collection

### DIFF
--- a/packages/web/src/lib/build-item.test.ts
+++ b/packages/web/src/lib/build-item.test.ts
@@ -5,6 +5,7 @@ import type {
   DocumentItem,
   EmailItem,
   ImageItem,
+  NoteItem,
   TodoItem,
 } from '@inbox-rs/rs-module';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -123,6 +124,25 @@ describe('buildBookmarkItem', () => {
     expect((result.item as BookmarkItem).body).toBeUndefined();
     expect((result.item as BookmarkItem).filePath).toBeUndefined();
   });
+
+  it('preserves collectionId when editing a bookmark filed in a collection', () => {
+    const editItem: BookmarkItem = {
+      id: 'item-1',
+      type: 'bookmark',
+      title: 'Old',
+      url: 'https://example.com',
+      collectionId: 'col-42',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    };
+
+    const result = buildBookmarkItem(ctx({ id: 'item-1', editItem }), {
+      url: 'https://example.com',
+      title: 'New',
+      description: '',
+    });
+
+    expect((result.item as BookmarkItem).collectionId).toBe('col-42');
+  });
 });
 
 describe('buildNoteItem', () => {
@@ -151,6 +171,39 @@ describe('buildNoteItem', () => {
       body: 'Some body',
       description: undefined,
     });
+  });
+
+  it('preserves collectionId when editing a note filed in a collection', () => {
+    // Regression: editing a note that lives in a collection must keep it
+    // there. Previously the builder created a fresh item without
+    // collectionId, so saving an edit silently moved the note back to the
+    // Inbox.
+    const editItem: NoteItem = {
+      id: 'note-1',
+      type: 'note',
+      title: 'Old title',
+      body: 'Old body',
+      collectionId: 'col-42',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    };
+
+    const result = buildNoteItem(ctx({ id: 'note-1', editItem }), {
+      title: 'New title',
+      body: 'New body',
+      description: '',
+    });
+
+    expect((result.item as NoteItem).collectionId).toBe('col-42');
+  });
+
+  it('leaves collectionId undefined for a brand-new note (stays in Inbox)', () => {
+    const result = buildNoteItem(ctx(), {
+      title: 'Title',
+      body: 'Some body',
+      description: '',
+    });
+
+    expect((result.item as NoteItem).collectionId).toBeUndefined();
   });
 });
 
@@ -209,6 +262,29 @@ describe('buildImageItem', () => {
     );
     expect((result?.item as ImageItem).mimeType).toBe('image/jpeg');
     expect((result?.item as ImageItem).title).toBe('New title');
+  });
+
+  it('preserves collectionId when replacing the bytes of a filed image', async () => {
+    const editItem: ImageItem = {
+      id: 'img-1',
+      type: 'image',
+      title: 'Old',
+      filePath: 'files/img-1.png',
+      mimeType: 'image/png',
+      collectionId: 'col-42',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    };
+    const replacement = new File(['xyz'], 'replacement.jpg', {
+      type: 'image/jpeg',
+    });
+
+    const result = await buildImageItem(ctx({ id: 'img-1', editItem }), {
+      title: 'New title',
+      description: '',
+      file: replacement,
+    });
+
+    expect((result?.item as ImageItem).collectionId).toBe('col-42');
   });
 
   it('returns a metadata-only update when editing without replacing the file', async () => {
@@ -393,6 +469,31 @@ describe('buildAudioItem', () => {
       description: 'desc',
     });
   });
+
+  it('preserves collectionId when re-recording a filed audio memo', async () => {
+    const editItem: AudioItem = {
+      id: 'rec-6',
+      type: 'audio',
+      title: 'Old',
+      filePath: 'files/rec-6.webm',
+      mimeType: 'audio/webm',
+      collectionId: 'col-42',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    };
+    const blob = new Blob(['audio'], { type: 'audio/webm' });
+
+    const result = await buildAudioItem(ctx({ id: 'rec-6', editItem }), {
+      title: '',
+      body: '',
+      description: '',
+      file: null,
+      recordedBlob: blob,
+      recordingDuration: 3,
+      transcript: '',
+    });
+
+    expect((result?.item as AudioItem).collectionId).toBe('col-42');
+  });
 });
 
 describe('buildDocumentItem', () => {
@@ -448,6 +549,28 @@ describe('buildDocumentItem', () => {
     });
 
     expect((result?.item as DocumentItem).filePath).toBe('files/doc-1.pdf');
+  });
+
+  it('preserves collectionId when replacing a filed document', async () => {
+    const editItem: DocumentItem = {
+      id: 'doc-1',
+      type: 'document',
+      title: 'Old',
+      filePath: 'files/doc-1.pdf',
+      mimeType: 'application/pdf',
+      collectionId: 'col-42',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    };
+
+    const file = new File(['hi'], 'updated.pdf', { type: 'application/pdf' });
+
+    const result = await buildDocumentItem(ctx({ id: 'doc-1', editItem }), {
+      title: '',
+      description: '',
+      file,
+    });
+
+    expect((result?.item as DocumentItem).collectionId).toBe('col-42');
   });
 });
 
@@ -508,6 +631,26 @@ describe('buildEmailItem', () => {
     });
 
     expect((result.item as EmailItem).messageUrl).toBeUndefined();
+  });
+
+  it('preserves collectionId when editing an email filed in a collection', () => {
+    const editItem: EmailItem = {
+      id: 'mail-1',
+      type: 'email',
+      title: 'Hello',
+      body: 'orig',
+      collectionId: 'col-42',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    };
+
+    const result = buildEmailItem(ctx({ id: 'mail-1', editItem }), {
+      title: 'Hello',
+      body: 'updated',
+      from: '',
+      notes: '',
+    });
+
+    expect((result.item as EmailItem).collectionId).toBe('col-42');
   });
 });
 
@@ -598,5 +741,26 @@ describe('buildTodoItem', () => {
 
     expect((result.item as TodoItem).body).toBeUndefined();
     expect((result.item as TodoItem).description).toBeUndefined();
+  });
+
+  it('preserves collectionId when editing a todo filed in a collection', () => {
+    const editItem: TodoItem = {
+      id: 'todo-1',
+      type: 'todo',
+      title: 'Buy milk',
+      completed: false,
+      isTodo: true,
+      collectionId: 'col-42',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    };
+
+    const result = buildTodoItem(ctx({ id: 'todo-1', editItem }), {
+      title: 'Buy milk and bread',
+      body: '',
+      description: '',
+      completed: false,
+    });
+
+    expect((result.item as TodoItem).collectionId).toBe('col-42');
   });
 });

--- a/packages/web/src/lib/build-item.ts
+++ b/packages/web/src/lib/build-item.ts
@@ -33,6 +33,20 @@ export interface BuildContext {
   editItem?: InboxItem;
 }
 
+/**
+ * Carry the edit target's collection membership onto a freshly-rebuilt item.
+ * `collectionId` is a type-agnostic placement field the per-type forms never
+ * surface, so without this every edit would drop it and silently move the
+ * item back to the Inbox. Applied unconditionally on edit (including across
+ * type conversions) so an item filed in a collection stays there.
+ */
+function preserveCollection<T extends InboxItem>(ctx: BuildContext, item: T): T {
+  if (ctx.editItem?.collectionId) {
+    item.collectionId = ctx.editItem.collectionId;
+  }
+  return item;
+}
+
 export interface BookmarkFormData {
   url: string;
   title: string;
@@ -63,7 +77,7 @@ export function buildBookmarkItem(
     if (ctx.editItem.filePath) bookmark.filePath = ctx.editItem.filePath;
     if (ctx.editItem.mimeType) bookmark.mimeType = ctx.editItem.mimeType;
   }
-  return { item: bookmark };
+  return { item: preserveCollection(ctx, bookmark) };
 }
 
 export interface NoteFormData {
@@ -84,7 +98,7 @@ export function buildNoteItem(
     description: data.description || undefined,
     createdAt: ctx.createdAt,
   };
-  return { item };
+  return { item: preserveCollection(ctx, item) };
 }
 
 export interface ImageFormData {
@@ -114,7 +128,7 @@ export async function buildImageItem(
       description: data.description || undefined,
       createdAt: ctx.createdAt,
     };
-    return { item, fileData };
+    return { item: preserveCollection(ctx, item), fileData };
   }
   if (ctx.editItem && ctx.editItem.type === 'image') {
     const item: ImageItem = {
@@ -182,7 +196,7 @@ export async function buildAudioItem(
       description: data.description || undefined,
       createdAt: ctx.createdAt,
     };
-    return { item, fileData };
+    return { item: preserveCollection(ctx, item), fileData };
   }
   if (ctx.editItem && ctx.editItem.type === 'audio') {
     const item: AudioItem = {
@@ -223,7 +237,7 @@ export async function buildDocumentItem(
       description: data.description || undefined,
       createdAt: ctx.createdAt,
     };
-    return { item, fileData };
+    return { item: preserveCollection(ctx, item), fileData };
   }
   if (ctx.editItem && ctx.editItem.type === 'document') {
     const item: DocumentItem = {
@@ -261,7 +275,7 @@ export function buildEmailItem(
     messageUrl,
     createdAt: ctx.createdAt,
   };
-  return { item };
+  return { item: preserveCollection(ctx, item) };
 }
 
 export interface TodoFormData {
@@ -303,5 +317,5 @@ export function buildTodoItem(
     createdAt: ctx.createdAt,
     isTodo: true,
   };
-  return { item };
+  return { item: preserveCollection(ctx, item) };
 }

--- a/packages/web/src/lib/build-item.ts
+++ b/packages/web/src/lib/build-item.ts
@@ -40,7 +40,10 @@ export interface BuildContext {
  * item back to the Inbox. Applied unconditionally on edit (including across
  * type conversions) so an item filed in a collection stays there.
  */
-function preserveCollection<T extends InboxItem>(ctx: BuildContext, item: T): T {
+function preserveCollection<T extends InboxItem>(
+  ctx: BuildContext,
+  item: T,
+): T {
   if (ctx.editItem?.collectionId) {
     item.collectionId = ctx.editItem.collectionId;
   }


### PR DESCRIPTION
## Problem

Editing a note (or any item) that lives in a collection moved it back to the **Inbox** on save.

## Root cause

Placement is driven entirely by an item's `collectionId` field:
- Inbox view = items with **no** `collectionId` (`sortedItems`)
- Collection view = items where `collectionId === cid` (`collectionItems`)

The per-type builders in `build-item.ts` rebuild a **fresh** `InboxItem` from the form's fields on save, but the forms never surface `collectionId`. So an edit produced an item with `collectionId` undefined → `storeItem` overwrote the record → the item dropped to the Inbox. The only code that re-attaches a collection (`moveItemToCollection`) is gated to new items (`!isEdit`), and the collection picker is hidden during edits.

This affected `note`, `bookmark`, `email`, `todo`, and the file-replacement paths of `image`/`audio`/`document`. (The no-new-file image/audio/document edits were already safe because they spread `...editItem`.)

## Fix

Added a shared `preserveCollection` helper and applied it in every builder that rebuilds fresh. `collectionId` is a type-agnostic placement field the forms don't own, so it's carried from the edit target unconditionally on edit — an item stays filed even across a type conversion.

## Tests

Added regression coverage in `build-item.test.ts` for note, bookmark, email, todo, and the image/audio/document file-replacement paths, plus a guard that a brand-new note stays in the Inbox. The note test was written first and confirmed failing (`expected undefined to be 'col-42'`) before the fix.

`build-item.test.ts`: **37/37 passing**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression/unit tests to ensure `collectionId` is retained when editing existing items across bookmarks, notes, images, audio, documents, emails, and todos.

* **Bug Fixes**
  * Fixed an issue where saving/editing items could drop their collection association, causing `collectionId` to be lost during the edit/save flow for multiple item types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized save-path fix in item builders with broad unit test coverage; no auth, sync, or storage schema changes.
> 
> **Overview**
> Fixes a bug where **saving an edit** dropped `collectionId` because item builders reconstructed records from form fields that never include collection placement, so filed items silently returned to the Inbox.
> 
> Adds a shared **`preserveCollection`** helper in `build-item.ts` that copies `collectionId` from `ctx.editItem` onto rebuilt items on edit (including type conversions). It is wired into every builder path that creates a **new** object—bookmark, note, email, todo, and file-replacement flows for image, audio, and document. Metadata-only image/audio/document edits still spread `...editItem` and were already safe.
> 
> **Tests** in `build-item.test.ts` lock in `collectionId` retention across those types plus a check that brand-new notes stay inbox-bound (`collectionId` undefined).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf4ae0c3d9af0f82653fa4eda59a1b9f315ba01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->