### PR TITLE
feat(web): shared theme system (14 accents × light/dark) + themeable logo

### DIFF
--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -451,7 +451,9 @@
     padding: 0.25rem;
     border: 1px solid var(--border);
     border-radius: 1rem;
-    background: color-mix(in srgb, var(--surface) 88%, black 12%);
+    /* Faint accent tint rather than a flat grey, so the rail harmonises with
+       the active theme instead of clashing with it. */
+    background: color-mix(in srgb, var(--accent) 8%, var(--surface));
     flex-shrink: 0;
   }
 

--- a/packages/web/src/capture/App.svelte
+++ b/packages/web/src/capture/App.svelte
@@ -896,7 +896,7 @@
   }
   .swatches {
     display: grid;
-    grid-template-columns: repeat(8, 1fr);
+    grid-template-columns: repeat(7, 1fr);
     gap: 0.6rem;
   }
   .swatch {

--- a/packages/web/src/capture/styles.css
+++ b/packages/web/src/capture/styles.css
@@ -1,7 +1,10 @@
+@import "../styles/theme-accents.css";
+
 /*
- * Quick-capture theme tokens. Neutrals come from light/dark mode; the accent
- * comes from the chosen theme (data-accent). Tint and shadow are derived from
- * the accent so they adapt to whichever mode is active.
+ * Quick-capture theme tokens. Neutrals come from light/dark mode (data-theme);
+ * the accent comes from the shared accent palette (theme-accents.css, keyed by
+ * data-accent). Tint and shadow are derived from the accent so they adapt to
+ * whichever mode is active.
  */
 
 :root {
@@ -26,7 +29,7 @@
 }
 
 /* dark neutrals — explicit choice */
-:root[data-mode="dark"] {
+:root[data-theme="dark"] {
   --bg: #201f1d;
   --surface: #2a2825;
   --seg: #302d29;
@@ -39,7 +42,7 @@
 
 /* dark neutrals — follow the system when no explicit mode is set */
 @media (prefers-color-scheme: dark) {
-  :root:not([data-mode="light"]):not([data-mode="dark"]) {
+  :root:not([data-theme="light"]):not([data-theme="dark"]) {
     --bg: #201f1d;
     --surface: #2a2825;
     --seg: #302d29;
@@ -49,39 +52,6 @@
     --line: #37342f;
     color-scheme: dark;
   }
-}
-
-:root[data-accent="indigo"] {
-  --accent: #4f46e5;
-  --accent-deep: #3f38c4;
-}
-:root[data-accent="forest"] {
-  --accent: #3f7d54;
-  --accent-deep: #336545;
-}
-:root[data-accent="plum"] {
-  --accent: #8a4a6f;
-  --accent-deep: #743c5e;
-}
-:root[data-accent="teal"] {
-  --accent: #2f8079;
-  --accent-deep: #266860;
-}
-:root[data-accent="slate"] {
-  --accent: #41607f;
-  --accent-deep: #34506c;
-}
-:root[data-accent="rose"] {
-  --accent: #b15775;
-  --accent-deep: #984862;
-}
-:root[data-accent="mustard"] {
-  --accent: #8a6a1f;
-  --accent-deep: #6f551a;
-}
-:root[data-accent="graphite"] {
-  --accent: #5b6b8c;
-  --accent-deep: #4a5876;
 }
 
 * {

--- a/packages/web/src/capture/theme.ts
+++ b/packages/web/src/capture/theme.ts
@@ -1,54 +1,24 @@
 /**
- * Theme configuration for the quick-capture app: a set of accent colours, each
- * rendered in light or dark mode. The palettes themselves live in styles.css,
- * keyed off `data-accent` / `data-mode` attributes on the document root — this
- * module only tracks and applies the user's selection.
+ * Quick-capture theme — a thin wrapper over the shared theme module
+ * (lib/theme), adding the capture app's own persistence keys. This way both the
+ * capture PWA and the main app offer the exact same eight accents × light/dark
+ * from a single source of truth.
  */
+import {
+  ACCENT_LABELS,
+  ACCENT_SWATCHES,
+  ACCENTS,
+  type Accent,
+  applyTheme as applyThemeToDom,
+  isAccent,
+  type Mode,
+} from '../lib/theme';
 
-export const ACCENTS = [
-  'indigo',
-  'forest',
-  'plum',
-  'teal',
-  'slate',
-  'rose',
-  'mustard',
-  'graphite',
-] as const;
-
-export type Accent = (typeof ACCENTS)[number];
-export type Mode = 'light' | 'dark' | 'system';
-
-/** Human labels for the settings UI. */
-export const ACCENT_LABELS: Record<Accent, string> = {
-  indigo: 'Indigo',
-  forest: 'Forest',
-  plum: 'Plum',
-  teal: 'Teal',
-  slate: 'Slate',
-  rose: 'Rose',
-  mustard: 'Mustard',
-  graphite: 'Graphite',
-};
-
-/** Swatch colours for the settings picker (the accent of each theme). */
-export const ACCENT_SWATCHES: Record<Accent, string> = {
-  indigo: '#4f46e5',
-  forest: '#3f7d54',
-  plum: '#8a4a6f',
-  teal: '#2f8079',
-  slate: '#41607f',
-  rose: '#b15775',
-  mustard: '#8a6a1f',
-  graphite: '#5b6b8c',
-};
+export type { Accent, Mode };
+export { ACCENT_LABELS, ACCENT_SWATCHES, ACCENTS };
 
 const ACCENT_KEY = 'inbox-rs-capture:accent';
 const MODE_KEY = 'inbox-rs-capture:mode';
-
-function isAccent(value: string | null): value is Accent {
-  return !!value && (ACCENTS as readonly string[]).includes(value);
-}
 
 export function getAccent(): Accent {
   const stored = localStorage.getItem(ACCENT_KEY);
@@ -60,15 +30,9 @@ export function getMode(): Mode {
   return stored === 'light' || stored === 'dark' ? stored : 'system';
 }
 
-/** Apply a theme to the document root and persist the choice. */
+/** Apply the theme to the document and persist the capture app's choice. */
 export function applyTheme(accent: Accent, mode: Mode): void {
-  const root = document.documentElement;
-  root.dataset.accent = accent;
-  if (mode === 'system') {
-    delete root.dataset.mode;
-  } else {
-    root.dataset.mode = mode;
-  }
+  applyThemeToDom(accent, mode);
   localStorage.setItem(ACCENT_KEY, accent);
   localStorage.setItem(MODE_KEY, mode);
 }

--- a/packages/web/src/components/LogoShield.svelte
+++ b/packages/web/src/components/LogoShield.svelte
@@ -1,47 +1,43 @@
-<script lang="ts">
-  import { onMount } from 'svelte';
-
-  let isLight = $state(false);
-
-  function checkLight() {
-    const dt = document.documentElement.getAttribute('data-theme');
-    if (dt === 'light') { isLight = true; return; }
-    if (dt === 'dark') { isLight = false; return; }
-    // system
-    isLight = window.matchMedia('(prefers-color-scheme: light)').matches;
-  }
-
-  onMount(() => {
-    checkLight();
-    const mq = window.matchMedia('(prefers-color-scheme: light)');
-    const onMq = () => checkLight();
-    mq.addEventListener('change', onMq);
-
-    const observer = new MutationObserver(() => checkLight());
-    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
-
-    return () => {
-      mq.removeEventListener('change', onMq);
-      observer.disconnect();
-    };
-  });
-</script>
-
+<!--
+  Inbox RS logo. Fully theme-aware via CSS variables: the shield follows the
+  active --accent (so it recolours with the chosen theme), the wordmark follows
+  --text (so it adapts to light/dark). No script needed.
+-->
 <svg aria-hidden="true" viewBox="0 0 155 40" xmlns="http://www.w3.org/2000/svg" class="logo-shield">
-  <!-- Icon -->
   <g transform="translate(4, 2) scale(1.15)">
-    <path d="M16 2 L28 7 L28 16 Q28 26 16 30 Q4 26 4 16 L4 7 Z" fill="#6366f1"/>
-    <path d="M8 15 L10.5 23 L13 23 L13 20 Q13 19 14.5 19 L17.5 19 Q19 19 19 20 L19 23 L21.5 23 L24 15 Z" fill="#818cf8"/>
-    <rect x="14.8" y="7" width="2.4" height="7" rx="1.2" fill="#e4e6eb"/>
-    <polygon points="16,16 12,12 13.5,10.8 16,13.5 18.5,10.8 20,12" fill="#e4e6eb"/>
+    <path class="shield" d="M16 2 L28 7 L28 16 Q28 26 16 30 Q4 26 4 16 L4 7 Z" />
+    <path class="tray" d="M8 15 L10.5 23 L13 23 L13 20 Q13 19 14.5 19 L17.5 19 Q19 19 19 20 L19 23 L21.5 23 L24 15 Z" />
+    <rect class="mark" x="14.8" y="7" width="2.4" height="7" rx="1.2" />
+    <polygon class="mark" points="16,16 12,12 13.5,10.8 16,13.5 18.5,10.8 20,12" />
   </g>
-  <!-- Wordmark -->
-  <text x="44" y="27" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-weight="700" font-size="22" letter-spacing="-0.02em"
-    fill={isLight ? '#1a1d27' : '#e4e6eb'}>Inbox <tspan fill={isLight ? '#4f46e5' : '#6366f1'}>RS</tspan></text>
+  <text
+    class="wordmark"
+    x="44"
+    y="27"
+    font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif"
+    font-weight="700"
+    font-size="22"
+    letter-spacing="-0.02em"
+  >Inbox <tspan class="rs">RS</tspan></text>
 </svg>
 
 <style>
   .logo-shield {
     display: block;
+  }
+  .shield {
+    fill: var(--accent);
+  }
+  .tray {
+    fill: color-mix(in srgb, var(--accent) 52%, white);
+  }
+  .mark {
+    fill: #f3f4f8;
+  }
+  .wordmark {
+    fill: var(--text);
+  }
+  .rs {
+    fill: var(--accent);
   }
 </style>

--- a/packages/web/src/components/PluginsPage.svelte
+++ b/packages/web/src/components/PluginsPage.svelte
@@ -542,7 +542,9 @@
     flex-shrink: 0;
     border-radius: 1.15rem;
     border: 1px solid color-mix(in srgb, var(--border) 58%, white 42%);
-    background: color-mix(in srgb, var(--surface) 84%, black 16%);
+    /* A lifted (lighter) surface rather than a darkened one, so the logos sit
+       on a soft tile instead of a heavy dark grey. */
+    background: var(--surface-hover);
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.08),
       0 16px 34px rgba(0, 0, 0, 0.18);

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -856,15 +856,17 @@
   }
 
   .accent-swatches {
-    display: flex;
-    gap: 0.4rem;
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 0.5rem;
     padding: 0.25rem 0.5rem 0.5rem;
+    justify-items: center;
   }
 
   .accent-swatch {
-    flex: 1;
+    width: 100%;
     aspect-ratio: 1;
-    max-width: 1.6rem;
+    max-width: 1.5rem;
     border-radius: 50%;
     background: var(--sw);
     border: 2px solid var(--border);

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -3,6 +3,14 @@
   import { tick } from 'svelte';
   import rs from '../lib/rs';
   import { connected, syncing, userAddress, userSettings, updateUserSettings } from '../lib/stores';
+  import {
+    type Accent,
+    ACCENT_LABELS,
+    ACCENT_SWATCHES,
+    ACCENTS,
+    applyAccent,
+    isAccent,
+  } from '../lib/theme';
 
   type LazyComponent = Component<Record<string, unknown>>;
 
@@ -54,6 +62,16 @@
     // Keep localStorage in sync so it's available as fallback next load
     localStorage.setItem('inbox-rs:theme', theme);
   });
+
+  // Accent — local-only, shared with the quick-capture app's theme set.
+  const storedAccent = localStorage.getItem('inbox-rs:accent');
+  let accent = $state<Accent>(isAccent(storedAccent) ? storedAccent : 'indigo');
+
+  function setAccent(a: Accent) {
+    accent = a;
+    localStorage.setItem('inbox-rs:accent', a);
+    applyAccent(a);
+  }
 
   function toggle() {
     open = !open;
@@ -370,6 +388,24 @@
           </svg>
           Dark
         </button>
+      </div>
+
+      <!-- Accent -->
+      <div class="section-label">Accent</div>
+      <div class="accent-swatches" role="radiogroup" aria-label="Accent colour">
+        {#each ACCENTS as a (a)}
+          <button
+            type="button"
+            class="accent-swatch"
+            class:active={accent === a}
+            style="--sw: {ACCENT_SWATCHES[a]}"
+            role="radio"
+            aria-checked={accent === a}
+            aria-label={ACCENT_LABELS[a]}
+            title={ACCENT_LABELS[a]}
+            onclick={() => setAccent(a)}
+          ></button>
+        {/each}
       </div>
     </div>
   {/if}
@@ -817,6 +853,33 @@
     color: var(--accent);
     border-color: var(--accent);
     background: var(--accent-subtle);
+  }
+
+  .accent-swatches {
+    display: flex;
+    gap: 0.4rem;
+    padding: 0.25rem 0.5rem 0.5rem;
+  }
+
+  .accent-swatch {
+    flex: 1;
+    aspect-ratio: 1;
+    max-width: 1.6rem;
+    border-radius: 50%;
+    background: var(--sw);
+    border: 2px solid var(--border);
+    padding: 0;
+    cursor: pointer;
+    transition: transform 150ms, box-shadow 150ms;
+  }
+
+  .accent-swatch:hover {
+    transform: translateY(-1px);
+  }
+
+  .accent-swatch.active {
+    border-color: var(--text);
+    box-shadow: 0 0 0 2px var(--accent-subtle);
   }
 
   /* ── Mobile ──────────────────────────────── */

--- a/packages/web/src/lib/theme.ts
+++ b/packages/web/src/lib/theme.ts
@@ -9,12 +9,18 @@
 
 export const ACCENTS = [
   'indigo',
-  'forest',
-  'plum',
+  'violet',
+  'blue',
+  'cyan',
   'teal',
-  'slate',
-  'rose',
+  'forest',
   'mustard',
+  'ember',
+  'crimson',
+  'rose',
+  'magenta',
+  'plum',
+  'slate',
   'graphite',
 ] as const;
 
@@ -24,24 +30,36 @@ export type Mode = 'light' | 'dark' | 'system';
 /** Human labels for the settings UI. */
 export const ACCENT_LABELS: Record<Accent, string> = {
   indigo: 'Indigo',
-  forest: 'Forest',
-  plum: 'Plum',
+  violet: 'Violet',
+  blue: 'Blue',
+  cyan: 'Cyan',
   teal: 'Teal',
-  slate: 'Slate',
-  rose: 'Rose',
+  forest: 'Forest',
   mustard: 'Mustard',
+  ember: 'Ember',
+  crimson: 'Crimson',
+  rose: 'Rose',
+  magenta: 'Magenta',
+  plum: 'Plum',
+  slate: 'Slate',
   graphite: 'Graphite',
 };
 
 /** Swatch colours for the picker — kept in sync with the accents in theme-accents.css. */
 export const ACCENT_SWATCHES: Record<Accent, string> = {
   indigo: '#4f46e5',
-  forest: '#3f7d54',
-  plum: '#8a4a6f',
+  violet: '#7c3aed',
+  blue: '#2563eb',
+  cyan: '#0e7490',
   teal: '#2f8079',
-  slate: '#41607f',
-  rose: '#b15775',
+  forest: '#3f7d54',
   mustard: '#8a6a1f',
+  ember: '#c2410c',
+  crimson: '#be123c',
+  rose: '#b15775',
+  magenta: '#a21caf',
+  plum: '#8a4a6f',
+  slate: '#41607f',
   graphite: '#5b6b8c',
 };
 

--- a/packages/web/src/lib/theme.ts
+++ b/packages/web/src/lib/theme.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared theme system for Inbox RS — used by both the main web app and the
+ * quick-capture PWA. A theme is an **accent** (one of {@link ACCENTS}) plus a
+ * light/dark **mode**. The accent palettes live in styles/theme-accents.css,
+ * keyed off the `data-accent` attribute; light/dark neutrals are keyed off
+ * `data-theme`. This module is the single source of truth for the accent list
+ * and the apply helpers — each app layers its own persistence on top.
+ */
+
+export const ACCENTS = [
+  'indigo',
+  'forest',
+  'plum',
+  'teal',
+  'slate',
+  'rose',
+  'mustard',
+  'graphite',
+] as const;
+
+export type Accent = (typeof ACCENTS)[number];
+export type Mode = 'light' | 'dark' | 'system';
+
+/** Human labels for the settings UI. */
+export const ACCENT_LABELS: Record<Accent, string> = {
+  indigo: 'Indigo',
+  forest: 'Forest',
+  plum: 'Plum',
+  teal: 'Teal',
+  slate: 'Slate',
+  rose: 'Rose',
+  mustard: 'Mustard',
+  graphite: 'Graphite',
+};
+
+/** Swatch colours for the picker — kept in sync with the accents in theme-accents.css. */
+export const ACCENT_SWATCHES: Record<Accent, string> = {
+  indigo: '#4f46e5',
+  forest: '#3f7d54',
+  plum: '#8a4a6f',
+  teal: '#2f8079',
+  slate: '#41607f',
+  rose: '#b15775',
+  mustard: '#8a6a1f',
+  graphite: '#5b6b8c',
+};
+
+export function isAccent(value: string | null | undefined): value is Accent {
+  return !!value && (ACCENTS as readonly string[]).includes(value);
+}
+
+/** Set the accent on the document root (palette comes from theme-accents.css). */
+export function applyAccent(accent: Accent): void {
+  document.documentElement.dataset.accent = accent;
+}
+
+/** Set light/dark mode on the document root; 'system' clears the override. */
+export function applyMode(mode: Mode): void {
+  const root = document.documentElement;
+  if (mode === 'system') {
+    root.removeAttribute('data-theme');
+    root.style.colorScheme = '';
+  } else {
+    root.setAttribute('data-theme', mode);
+    root.style.colorScheme = mode;
+  }
+}
+
+export function applyTheme(accent: Accent, mode: Mode): void {
+  applyAccent(accent);
+  applyMode(mode);
+}

--- a/packages/web/src/main.ts
+++ b/packages/web/src/main.ts
@@ -5,9 +5,17 @@ import Root from './Root.svelte';
 // Apply the stored theme (accent + light/dark) before mount to avoid a flash.
 // Mode is reconciled with synced UserSettings once connected (see UserMenu);
 // accent is local-only, mirroring the quick-capture app.
-const storedAccent = localStorage.getItem('inbox-rs:accent');
+// localStorage can throw a SecurityError when storage is blocked (private mode,
+// blocked cookies, sandboxed iframe); fall back to defaults so mount proceeds.
+let storedAccent: string | null = null;
+let storedMode: string | null = null;
+try {
+  storedAccent = localStorage.getItem('inbox-rs:accent');
+  storedMode = localStorage.getItem('inbox-rs:theme');
+} catch {
+  // storage unavailable — keep defaults below
+}
 const accent: Accent = isAccent(storedAccent) ? storedAccent : 'indigo';
-const storedMode = localStorage.getItem('inbox-rs:theme');
 const mode: Mode =
   storedMode === 'light' || storedMode === 'dark' ? storedMode : 'system';
 applyTheme(accent, mode);

--- a/packages/web/src/main.ts
+++ b/packages/web/src/main.ts
@@ -1,5 +1,16 @@
 import { mount } from 'svelte';
+import { type Accent, applyTheme, isAccent, type Mode } from './lib/theme';
 import Root from './Root.svelte';
+
+// Apply the stored theme (accent + light/dark) before mount to avoid a flash.
+// Mode is reconciled with synced UserSettings once connected (see UserMenu);
+// accent is local-only, mirroring the quick-capture app.
+const storedAccent = localStorage.getItem('inbox-rs:accent');
+const accent: Accent = isAccent(storedAccent) ? storedAccent : 'indigo';
+const storedMode = localStorage.getItem('inbox-rs:theme');
+const mode: Mode =
+  storedMode === 'light' || storedMode === 'dark' ? storedMode : 'system';
+applyTheme(accent, mode);
 
 const target = document.getElementById('app');
 if (!target) throw new Error('Mount target #app not found');

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -1,25 +1,36 @@
+@import "./theme-accents.css";
+
 :root {
+  /* Accent comes from data-accent (theme-accents.css); these are fallbacks
+     for the first paint before the stored accent is applied. */
+  --accent: #4f46e5;
+  --accent-deep: #3f38c4;
+
   --bg: #0f1117;
   --surface: #1a1d27;
   --surface-hover: #222632;
   --border: #2a2e3a;
   --text: #e4e6eb;
   --text-muted: #8b8f9a;
-  --accent: #6366f1;
-  --accent-hover: #818cf8;
   --danger: #ef4444;
   --danger-hover: #f87171;
   --radius: 12px;
   --radius-sm: 8px;
   --overlay: rgba(0, 0, 0, 0.6);
   --shadow: rgba(0, 0, 0, 0.3);
-  --accent-subtle: rgba(99, 102, 241, 0.15);
-  --accent-subtler: rgba(99, 102, 241, 0.1);
-  --accent-subtle-strong: rgba(99, 102, 241, 0.25);
   --surface-tint: rgba(255, 255, 255, 0.06);
   --surface-tint-hover: rgba(255, 255, 255, 0.1);
+
+  /* Accent-derived — these track whatever --accent the theme sets. */
+  --accent-hover: color-mix(in srgb, var(--accent) 72%, white);
+  --accent-subtle: color-mix(in srgb, var(--accent) 16%, transparent);
+  --accent-subtler: color-mix(in srgb, var(--accent) 10%, transparent);
+  --accent-subtle-strong: color-mix(in srgb, var(--accent) 26%, transparent);
 }
 
+/* Light neutrals. The accent itself still comes from data-accent; only the
+   hover shade differs (darker on light backgrounds). The --accent-subtle*
+   tokens are accent-mixed-with-transparent in :root, so they hold in both modes. */
 @media (prefers-color-scheme: light) {
   :root:not([data-theme="dark"]) {
     --bg: #f8f9fb;
@@ -28,17 +39,13 @@
     --border: #d8dbe3;
     --text: #1a1d27;
     --text-muted: #6b7084;
-    --accent: #4f46e5;
-    --accent-hover: #4338ca;
     --danger: #dc2626;
     --danger-hover: #b91c1c;
     --overlay: rgba(0, 0, 0, 0.4);
     --shadow: rgba(0, 0, 0, 0.1);
-    --accent-subtle: rgba(79, 70, 229, 0.1);
-    --accent-subtler: rgba(79, 70, 229, 0.06);
-    --accent-subtle-strong: rgba(79, 70, 229, 0.18);
     --surface-tint: rgba(0, 0, 0, 0.04);
     --surface-tint-hover: rgba(0, 0, 0, 0.07);
+    --accent-hover: color-mix(in srgb, var(--accent) 84%, black);
   }
 }
 
@@ -49,17 +56,13 @@
   --border: #d8dbe3;
   --text: #1a1d27;
   --text-muted: #6b7084;
-  --accent: #4f46e5;
-  --accent-hover: #4338ca;
   --danger: #dc2626;
   --danger-hover: #b91c1c;
   --overlay: rgba(0, 0, 0, 0.4);
   --shadow: rgba(0, 0, 0, 0.1);
-  --accent-subtle: rgba(79, 70, 229, 0.1);
-  --accent-subtler: rgba(79, 70, 229, 0.06);
-  --accent-subtle-strong: rgba(79, 70, 229, 0.18);
   --surface-tint: rgba(0, 0, 0, 0.04);
   --surface-tint-hover: rgba(0, 0, 0, 0.07);
+  --accent-hover: color-mix(in srgb, var(--accent) 84%, black);
 }
 
 * {

--- a/packages/web/src/styles/theme-accents.css
+++ b/packages/web/src/styles/theme-accents.css
@@ -1,0 +1,39 @@
+/*
+ * Shared accent palettes for Inbox RS (main app + quick-capture PWA).
+ * Single source of truth for the eight theme accents. Each sets the base
+ * accent + a deeper shade; apps derive softer/hover variants from these.
+ * Keyed off `data-accent` on the document root (see lib/theme.ts).
+ */
+
+:root[data-accent="indigo"] {
+  --accent: #4f46e5;
+  --accent-deep: #3f38c4;
+}
+:root[data-accent="forest"] {
+  --accent: #3f7d54;
+  --accent-deep: #336545;
+}
+:root[data-accent="plum"] {
+  --accent: #8a4a6f;
+  --accent-deep: #743c5e;
+}
+:root[data-accent="teal"] {
+  --accent: #2f8079;
+  --accent-deep: #266860;
+}
+:root[data-accent="slate"] {
+  --accent: #41607f;
+  --accent-deep: #34506c;
+}
+:root[data-accent="rose"] {
+  --accent: #b15775;
+  --accent-deep: #984862;
+}
+:root[data-accent="mustard"] {
+  --accent: #8a6a1f;
+  --accent-deep: #6f551a;
+}
+:root[data-accent="graphite"] {
+  --accent: #5b6b8c;
+  --accent-deep: #4a5876;
+}

--- a/packages/web/src/styles/theme-accents.css
+++ b/packages/web/src/styles/theme-accents.css
@@ -1,7 +1,8 @@
 /*
  * Shared accent palettes for Inbox RS (main app + quick-capture PWA).
- * Single source of truth for the eight theme accents. Each sets the base
- * accent + a deeper shade; apps derive softer/hover variants from these.
+ * Single source of truth for the theme accents. Each sets the base accent + a
+ * deeper shade; apps derive softer/hover variants from these. Every base is
+ * chosen to stay legible with white text on a solid fill (≥4.5:1).
  * Keyed off `data-accent` on the document root (see lib/theme.ts).
  */
 
@@ -9,29 +10,53 @@
   --accent: #4f46e5;
   --accent-deep: #3f38c4;
 }
-:root[data-accent="forest"] {
-  --accent: #3f7d54;
-  --accent-deep: #336545;
+:root[data-accent="violet"] {
+  --accent: #7c3aed;
+  --accent-deep: #6d28d9;
 }
-:root[data-accent="plum"] {
-  --accent: #8a4a6f;
-  --accent-deep: #743c5e;
+:root[data-accent="blue"] {
+  --accent: #2563eb;
+  --accent-deep: #1d4ed8;
+}
+:root[data-accent="cyan"] {
+  --accent: #0e7490;
+  --accent-deep: #0c5e74;
 }
 :root[data-accent="teal"] {
   --accent: #2f8079;
   --accent-deep: #266860;
 }
-:root[data-accent="slate"] {
-  --accent: #41607f;
-  --accent-deep: #34506c;
+:root[data-accent="forest"] {
+  --accent: #3f7d54;
+  --accent-deep: #336545;
+}
+:root[data-accent="mustard"] {
+  --accent: #8a6a1f;
+  --accent-deep: #6f551a;
+}
+:root[data-accent="ember"] {
+  --accent: #c2410c;
+  --accent-deep: #9a3412;
+}
+:root[data-accent="crimson"] {
+  --accent: #be123c;
+  --accent-deep: #9f1239;
 }
 :root[data-accent="rose"] {
   --accent: #b15775;
   --accent-deep: #984862;
 }
-:root[data-accent="mustard"] {
-  --accent: #8a6a1f;
-  --accent-deep: #6f551a;
+:root[data-accent="magenta"] {
+  --accent: #a21caf;
+  --accent-deep: #86198f;
+}
+:root[data-accent="plum"] {
+  --accent: #8a4a6f;
+  --accent-deep: #743c5e;
+}
+:root[data-accent="slate"] {
+  --accent: #41607f;
+  --accent-deep: #34506c;
 }
 :root[data-accent="graphite"] {
   --accent: #5b6b8c;


### PR DESCRIPTION
## Summary

Establishes a single shared theme system used by **both** the main web app and the quick-capture PWA, replacing the duplicated accent definitions that had drifted between them.

- **Shared source of truth** (`lib/theme.ts` + `styles/theme-accents.css`): one accent list, one set of apply helpers. The capture PWA now wraps this module, adding only its own persistence keys.
- **14 accents × light/dark**: indigo, violet, blue, cyan, teal, forest, mustard, ember, crimson, rose, magenta, plum, slate, graphite — each base chosen to stay legible with white text on a solid fill (≥4.5:1). Both pickers render them as a tidy 7×2 grid.
- **Themeable logo** (`LogoShield.svelte`): pure SVG/CSS, no script. The shield follows `--accent` and the wordmark follows `--text`, so it recolours automatically with the chosen accent and light/dark mode.
- **Tokens derived, not duplicated**: subtle/hover accent variants come from `color-mix()` off `--accent`, so the main app's richer token vocabulary survives without per-component changes.

### Polish in this PR

- Primary nav (Inbox/Todos/Collections) now uses a faint accent tint instead of a flat grey that clashed with warmer themes.
- Download logo badges sit on a lighter lifted surface instead of a darkened one.

## Testing

- `biome ci` — clean
- `npm run build` (web) — clean
- `npm test` (web) — 291 passing
- Visually verified the accent picker, nav tint, and download badges across light/dark.

## Notes

This is the shared-theming groundwork. The larger sidebar redesign is a separate follow-up and is **not** in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accent color customization option in the user menu

* **UI & Styling**
  * Updated navigation rail styling with accent-based theming
  * Refined logo shield and plugin tile visual styling
  * User theme preferences (accent color and light/dark mode) now persist across sessions
  * Improved theme application timing to eliminate visual flashes on load

<!-- end of auto-generated comment: release notes by coderabbit.ai -->