### PR TITLE
fix(web): render offline-cached files when not connected

### DIFF
--- a/packages/web/src/components/BookmarkCard.svelte
+++ b/packages/web/src/components/BookmarkCard.svelte
@@ -25,12 +25,15 @@
     (item.filePath ? ($blobUrls[item.filePath] || null) : null) || item.ogImage || null
   );
 
-  // Fetch stored file via Authorization header (works on all RS servers).
-  // Pass mimeType so the blob is tagged with the clean type from item metadata
-  // rather than the server's Content-Type (which on 5apps carries the
-  // `; charset=binary` suffix that Chrome won't render as <img>).
+  // Load from the remote when connected, otherwise the local cache, so
+  // offline-captured files still render. Pass mimeType so the blob is tagged
+  // with the clean type from item metadata rather than the server's
+  // Content-Type (which on 5apps carries the `; charset=binary` suffix that
+  // Chrome won't render as <img>). Referencing `$connected` retries over the
+  // network once a connection is established.
   $effect(() => {
-    if ($connected && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
+    void $connected;
+    if (item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
   });
 </script>
 

--- a/packages/web/src/components/ImageCard.svelte
+++ b/packages/web/src/components/ImageCard.svelte
@@ -8,12 +8,15 @@
 
   const imageSrc = $derived($blobUrls[item.filePath] || null);
 
-  // Fetch file via Authorization header when connected (works on all RS servers).
-  // Pass mimeType so the blob is tagged as `image/jpeg` rather than whatever
-  // the server echoes back (e.g. `image/jpeg; charset=binary` on 5apps, which
-  // Chrome refuses to render as an <img> source).
+  // Load the image bytes. loadFileBlobUrl fetches from the remote when
+  // connected and the local cache otherwise, so files captured while offline
+  // still render. Pass mimeType so the blob is tagged as `image/jpeg` rather
+  // than whatever the server echoes back (e.g. `image/jpeg; charset=binary` on
+  // 5apps, which Chrome refuses to render). Referencing `$connected` re-runs
+  // this so we retry over the network once a connection is established.
   $effect(() => {
-    if ($connected && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
+    void $connected;
+    if (item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
   });
 </script>
 

--- a/packages/web/src/components/ImageCard.svelte.test.ts
+++ b/packages/web/src/components/ImageCard.svelte.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Controllable stores + a spy for the loader the component is meant to call.
+// Both the component and this test import from '../lib/stores', so they share
+// these instances.
+vi.mock('../lib/stores', async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    connected: writable(false),
+    blobUrls: writable<Record<string, string>>({}),
+    loadFileBlobUrl: vi.fn(),
+  };
+});
+
+// Lightbox (imported by ImageCard) pulls in ../lib/rs, which constructs a
+// RemoteStorage at import time. Neutralise it.
+vi.mock('../lib/rs', () => ({
+  default: {},
+  fetchFileBlobUrl: vi.fn(),
+  fetchFileWithAuth: vi.fn(),
+}));
+
+import type { ImageItem } from '@inbox-rs/rs-module';
+import { blobUrls, connected, loadFileBlobUrl } from '../lib/stores';
+import ImageCard from './ImageCard.svelte';
+
+const item: ImageItem = {
+  id: 'img1',
+  type: 'image',
+  title: 'Holiday',
+  filePath: 'files/img1.png',
+  mimeType: 'image/png',
+  createdAt: 0,
+};
+
+describe('ImageCard offline display', () => {
+  let host: HTMLElement;
+  let component: ReturnType<typeof mount> | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connected.set(false);
+    blobUrls.set({});
+    host = document.createElement('div');
+    document.body.appendChild(host);
+  });
+
+  afterEach(() => {
+    if (component) unmount(component);
+    host.remove();
+  });
+
+  it('requests the file even when not connected, so cached images render offline', () => {
+    // Regression: file-display cards used to gate loading on `$connected`, so a
+    // file captured while disconnected never loaded from the local cache and
+    // showed a "Not connected" placeholder after reload.
+    component = mount(ImageCard, { target: host, props: { item } });
+    flushSync();
+
+    expect(loadFileBlobUrl).toHaveBeenCalledWith('files/img1.png', 'image/png');
+  });
+
+  it('renders the image (not the placeholder) once a blob URL is present', () => {
+    blobUrls.set({ 'files/img1.png': 'blob:cache/img1' });
+
+    component = mount(ImageCard, { target: host, props: { item } });
+    flushSync();
+
+    expect(host.querySelector('img')?.getAttribute('src')).toBe(
+      'blob:cache/img1',
+    );
+    expect(host.textContent).not.toContain('Not connected');
+  });
+});

--- a/packages/web/src/components/view-card/AudioView.svelte
+++ b/packages/web/src/components/view-card/AudioView.svelte
@@ -20,7 +20,9 @@
   // Pass mimeType so the blob is tagged with the clean type from item
   // metadata; see BookmarkView for the longer note.
   $effect(() => {
-    if (!$connected) return;
+    // Load from the remote when connected, otherwise the local cache, so
+    // offline-captured files still render; retries on reconnect.
+    void $connected;
     if (item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
   });
 

--- a/packages/web/src/components/view-card/BookmarkView.svelte
+++ b/packages/web/src/components/view-card/BookmarkView.svelte
@@ -29,7 +29,9 @@
   // `; charset=binary` suffix that wireclient adds on upload, and Chrome
   // won't render an <img> whose Blob type carries that suffix.
   $effect(() => {
-    if (!$connected) return;
+    // Load from the remote when connected, otherwise the local cache, so
+    // offline-captured files still render; retries on reconnect.
+    void $connected;
     if (item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
   });
 </script>

--- a/packages/web/src/components/view-card/ImageView.svelte
+++ b/packages/web/src/components/view-card/ImageView.svelte
@@ -16,7 +16,9 @@
   // Pass mimeType so the blob is tagged with the clean type from item
   // metadata; see BookmarkView for the longer note.
   $effect(() => {
-    if (!$connected) return;
+    // Load from the remote when connected, otherwise the local cache, so
+    // offline-captured files still render; retries on reconnect.
+    void $connected;
     if (item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
   });
 </script>

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -18,6 +18,7 @@ const { mockRs, mockInbox } = vi.hoisted(() => {
     onChange: vi.fn(),
     store: vi.fn().mockResolvedValue(undefined),
     remove: vi.fn().mockResolvedValue(undefined),
+    getFile: vi.fn().mockResolvedValue(undefined),
     storeCollection: vi.fn().mockResolvedValue(undefined),
     removeCollection: vi.fn().mockResolvedValue(undefined),
     storeGroup: vi.fn().mockResolvedValue(undefined),
@@ -188,12 +189,38 @@ describe('loadFileBlobUrl', () => {
     expect(mockFetchFileBlobUrl).not.toHaveBeenCalled();
   });
 
-  it('does not fetch if not connected', () => {
+  it('reads from the local cache (not the network) when not connected', async () => {
+    // Regression: a file captured while disconnected is persisted to the local
+    // cache (alongside its metadata) and must still render after a reload,
+    // without hitting the remote.
     connected.set(false);
+    const bytes = new Uint8Array([1, 2, 3]).buffer;
+    mockInbox.getFile.mockResolvedValue({ data: bytes, mimeType: 'image/png' });
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:cache/photo');
 
-    loadFileBlobUrl('files/photo.jpg');
+    loadFileBlobUrl('files/photo.jpg', 'image/png');
 
+    await vi.waitFor(() => {
+      expect(get(blobUrls)['files/photo.jpg']).toBe('blob:cache/photo');
+    });
     expect(mockFetchFileBlobUrl).not.toHaveBeenCalled();
+    expect(mockInbox.getFile).toHaveBeenCalledWith('files/photo.jpg');
+
+    createObjectURL.mockRestore();
+  });
+
+  it('stores no blob URL when the cache has no bytes while disconnected', async () => {
+    connected.set(false);
+    mockInbox.getFile.mockResolvedValue(undefined);
+
+    loadFileBlobUrl('files/missing.jpg');
+
+    await vi.waitFor(() => {
+      expect(mockInbox.getFile).toHaveBeenCalledWith('files/missing.jpg');
+    });
+    expect(get(blobUrls)['files/missing.jpg']).toBeUndefined();
   });
 
   it('does not fetch for empty filePath', () => {

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -663,8 +663,38 @@ const pendingBlobLoads = new Map<string, number>();
 const revokedBlobPaths = new Set<string>();
 
 /**
- * Fetch a file from RS and create a blob URL, stored in blobUrls for reactive display.
+ * Resolve a file's bytes to a blob URL from the best available source.
+ *
+ * When connected we fetch from the remote over authenticated HTTP. Otherwise —
+ * or when the remote 404s because the file was captured offline and hasn't
+ * synced yet — we read it from the local remoteStorage cache, where `store()`
+ * writes the bytes regardless of connection state. Without this fallback, files
+ * captured while disconnected vanish on reload even though their bytes (and
+ * metadata) are sitting in the cache.
+ */
+async function resolveFileBlobUrl(
+  filePath: string,
+  mimeType?: string,
+): Promise<string | null> {
+  if (get(connected)) {
+    const url = await fetchFileBlobUrl(filePath, mimeType);
+    if (url) return url;
+  }
+  const inbox = getInbox();
+  if (!inbox) return null;
+  const cached = await inbox.getFile(filePath);
+  if (!cached?.data) return null;
+  const blob = new Blob([cached.data], {
+    type: cached.mimeType || mimeType || '',
+  });
+  return URL.createObjectURL(blob);
+}
+
+/**
+ * Fetch a file and create a blob URL, stored in blobUrls for reactive display.
  * No-ops if already loaded or in progress. Components should call this on mount.
+ * Reads from the remote when connected, otherwise from the local cache (see
+ * resolveFileBlobUrl) so offline-captured files still render.
  *
  * A generation number is captured at start time. After a disconnect (or other
  * full revocation), the generation is bumped so stale promises cannot
@@ -675,10 +705,9 @@ export function loadFileBlobUrl(filePath: string, mimeType?: string): void {
   // A new explicit load attempt clears any prior delete tombstone for this path.
   revokedBlobPaths.delete(filePath);
   if (get(blobUrls)[filePath] || pendingBlobLoads.has(filePath)) return;
-  if (!get(connected)) return;
   const gen = blobLoadGeneration;
   pendingBlobLoads.set(filePath, gen);
-  fetchFileBlobUrl(filePath, mimeType)
+  resolveFileBlobUrl(filePath, mimeType)
     .then((url) => {
       if (!url) return;
       // Ignore (and revoke) results that are stale due to disconnect, delete, etc.

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -48,6 +48,11 @@ export default defineConfig({
       'onnxruntime-node': 'onnxruntime-web',
       sharp: 'onnxruntime-web',
     },
+    // Under Vitest, resolve Svelte (and deps) to their browser builds so
+    // components can be mounted with the client runtime (mount/flushSync).
+    // Without this they compile for SSR and `lifecycle_function_unavailable`
+    // is thrown. Scoped to test runs so dev/build resolution is unchanged.
+    ...(process.env.VITEST ? { conditions: ['browser'] } : {}),
   },
   build: {
     // Bump above Vite's default `modules` baseline so top-level `await` is


### PR DESCRIPTION
## Problem

Add an image while **not** connected to remoteStorage, refresh: the item record survives but the image is gone — a grey "Not connected" placeholder.

## Root cause (two layers)

Storage is offline-capable, but the display path was network-only — and the gate existed at **two** layers:

1. **Store** (`loadFileBlobUrl` → `fetchFileBlobUrl`) read bytes only over authenticated HTTP and bailed when disconnected (`if (!get(connected)) return;`).
2. **Components** — `ImageCard`, `BookmarkCard`, `ImageView`, `AudioView`, `BookmarkView` only *called* the loader `if ($connected)`, so even a cache-aware loader never ran offline.

Meanwhile `store()` persists both metadata **and** file bytes to the local IndexedDB cache regardless of connection (`rs.caching.enable('/inbox/')`), which is why the record survives a reload while the image doesn't.

## Fix

- **Store:** `loadFileBlobUrl` now resolves bytes from the best source — the remote when connected (with a cache fallback if it 404s for a not-yet-synced file), the local cache via `inbox.getFile()` otherwise.
- **Components:** the five file-display cards now call `loadFileBlobUrl` regardless of connection, referencing `$connected` so they retry over the network on reconnect.

So offline-captured files render after a reload and still sync to the server on the next cycle.

## Testing

- **Store regression tests** (`stores.test.ts`): reads from the local cache (not the network) when disconnected; stores no URL when the cache is empty. Verified they fail without the store fix.
- **New component test** (`ImageCard.svelte.test.ts`) — the project's first Svelte component test: asserts the file is requested while disconnected. **Verified it fails against the unfixed component and passes with the fix.** Also adds the Vitest `conditions: ['browser']` config (test-only) needed to mount components.
- `npm test` (web) — **294 passing**
- `npm run build` + `biome ci` — clean

Independent of the sidebar redesign work (#141/#142); branched from `master`.