### PR TITLE
feat(web): distinct per-type inbox cards + voice-memo audio card

### DIFF
--- a/packages/web/src/components/AudioCard.svelte
+++ b/packages/web/src/components/AudioCard.svelte
@@ -3,7 +3,8 @@
   import { blobUrls, connected, loadFileBlobUrl } from '../lib/stores';
 
   let { item }: { item: AudioItem } = $props();
-  let audioError = $state(false);
+  let audioEl = $state<HTMLAudioElement | null>(null);
+  let playing = $state(false);
 
   const audioSrc = $derived($blobUrls[item.filePath] || null);
 
@@ -18,6 +19,29 @@
     if (item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
   });
 
+  // Decorative waveform bars derived deterministically from the item id, so
+  // each memo gets its own stable silhouette (a real PCM analysis would be
+  // overkill for a preview). 28 bars, 5–26px tall.
+  const bars = $derived.by(() => {
+    let h = 2166136261;
+    for (let i = 0; i < item.id.length; i++) {
+      h = Math.imul(h ^ item.id.charCodeAt(i), 16777619) >>> 0;
+    }
+    const out: number[] = [];
+    for (let i = 0; i < 28; i++) {
+      h = (Math.imul(h, 1103515245) + 12345) >>> 0;
+      out.push(5 + (h % 22));
+    }
+    return out;
+  });
+
+  function toggle(e: MouseEvent) {
+    e.stopPropagation();
+    if (!audioEl) return;
+    if (playing) audioEl.pause();
+    else void audioEl.play();
+  }
+
   function formatDuration(seconds?: number): string {
     if (!seconds) return '';
     const m = Math.floor(seconds / 60);
@@ -27,59 +51,123 @@
 </script>
 
 <div class="audio">
-  <h3 class="title">{item.title}</h3>
-  {#if item.duration}
-    <span class="duration">{formatDuration(item.duration)}</span>
-  {/if}
-  <div class="player">
-    {#if audioError}
-      <p class="status">Failed to load audio</p>
-    {:else if audioSrc}
-      <!-- User-recorded audio has no separate captions track; the
-           transcription text (when present) is rendered alongside the player
-           in ViewCardModal. The empty <track> just satisfies the lint rule. -->
-      <audio
-        controls
-        src={audioSrc}
-        preload="metadata"
-        onerror={() => (audioError = true)}
-      >
-        <track kind="captions" />
-      </audio>
-    {:else}
-      <p class="status">Loading audio...</p>
+  <h3 class="title">{item.title || 'Voice memo'}</h3>
+  <div class="voice">
+    <button
+      class="play"
+      class:playing
+      type="button"
+      onclick={toggle}
+      disabled={!audioSrc}
+      aria-label={playing ? 'Pause' : 'Play'}
+    >
+      {#if playing}
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="6" y="5" width="4" height="14" rx="1"/><rect x="14" y="5" width="4" height="14" rx="1"/></svg>
+      {:else}
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>
+      {/if}
+    </button>
+    <div class="wave" aria-hidden="true">
+      {#each bars as h, i (i)}
+        <span style="height:{h}px"></span>
+      {/each}
+    </div>
+    {#if item.duration}
+      <span class="dur">{formatDuration(item.duration)}</span>
     {/if}
   </div>
+  {#if audioSrc}
+    <!-- Hidden player driven by the waveform button. Real playback + transcript
+         live in the view modal; the empty track satisfies the lint rule. -->
+    <audio
+      bind:this={audioEl}
+      src={audioSrc}
+      preload="none"
+      onplay={() => (playing = true)}
+      onpause={() => (playing = false)}
+      onended={() => (playing = false)}
+    >
+      <track kind="captions" />
+    </audio>
+  {/if}
 </div>
 
 <style>
   .title {
     font-size: 0.95rem;
     font-weight: 600;
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.5rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
-  .duration {
-    font-size: 0.8rem;
+  .voice {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.25rem;
+  }
+
+  .play {
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    border: none;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--accent-subtle);
+    color: var(--accent);
+    cursor: pointer;
+    transition: background 150ms ease, transform 120ms ease;
+  }
+
+  .play:hover:not(:disabled) {
+    background: var(--accent-subtle-strong);
+  }
+
+  .play:active:not(:disabled) {
+    transform: scale(0.94);
+  }
+
+  .play:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .play svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  .wave {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    height: 26px;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .wave span {
+    flex: 1;
+    min-width: 2px;
+    max-width: 3px;
+    border-radius: 2px;
+    background: color-mix(in srgb, var(--accent) 32%, var(--border));
+  }
+
+  .play.playing + .wave span {
+    background: color-mix(in srgb, var(--accent) 55%, var(--border));
+  }
+
+  .dur {
+    font-size: 0.75rem;
     color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
   }
-
-  .player {
-    margin-top: 0.5rem;
-  }
-
-  audio {
-    width: 100%;
-    height: 36px;
-  }
-
-  .status {
-    font-size: 0.8rem;
-    color: var(--text-muted);
-  }
-
-
 </style>

--- a/packages/web/src/components/AudioCard.svelte
+++ b/packages/web/src/components/AudioCard.svelte
@@ -8,6 +8,16 @@
 
   const audioSrc = $derived($blobUrls[item.filePath] || null);
 
+  // If the source disappears (store revokes the blob URL), drop the stale
+  // element reference and reset playback so the UI doesn't show a pause icon
+  // on the now-disabled button.
+  $effect(() => {
+    if (!audioSrc) {
+      audioEl = null;
+      playing = false;
+    }
+  });
+
   // Load audio bytes. loadFileBlobUrl fetches from the remote when connected
   // and the local cache otherwise, so files captured via the capture app still
   // play. Pass mimeType so the blob is tagged with the clean type from item

--- a/packages/web/src/components/BookmarkCard.svelte
+++ b/packages/web/src/components/BookmarkCard.svelte
@@ -6,21 +6,6 @@
   let { item }: { item: BookmarkItem } = $props();
   let showLightbox = $state(false);
 
-  function getDomain(url: string): string {
-    try {
-      return new URL(url).hostname.replace(/^www\./, '');
-    } catch {
-      return url;
-    }
-  }
-
-  const faviconSrc = $derived(
-    item.favicon || (() => {
-      try { return new URL('/favicon.ico', new URL(item.url).origin).href; }
-      catch { return ''; }
-    })()
-  );
-
   const imageSrc = $derived(
     (item.filePath ? ($blobUrls[item.filePath] || null) : null) || item.ogImage || null
   );
@@ -53,24 +38,9 @@
   {#if showLightbox && imageSrc}
     <Lightbox src={imageSrc} alt={item.title} onclose={() => showLightbox = false} filePath={item.filePath} mimeType={item.mimeType} filename={item.title || undefined} />
   {/if}
-  <div class="bookmark-body">
-    <div class="bookmark-header">
-      {#if faviconSrc}
-        <img
-          class="favicon"
-          src={faviconSrc}
-          alt=""
-          width="16"
-          height="16"
-          onerror={(e) => (e.currentTarget as HTMLImageElement).style.display = 'none'}
-        />
-      {/if}
-      <span class="domain">{item.siteName || getDomain(item.url)}</span>
-    </div>
-    <h3 class="title">
-      <a href={item.url} target="_blank" rel="noopener noreferrer">{item.title}<svg aria-hidden="true" class="link-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg></a>
-    </h3>
-  </div>
+  <h3 class="title">
+    <a href={item.url} target="_blank" rel="noopener noreferrer">{item.title}<svg aria-hidden="true" class="link-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg></a>
+  </h3>
 </div>
 
 <style>
@@ -79,9 +49,10 @@
     flex-direction: column;
   }
 
+  /* Full-bleed to the card's side/bottom edges; the kind row sits above it. */
   .og-link {
     display: block;
-    margin: -1rem -1rem 0.75rem -1rem;
+    margin: 0 -1.1rem 0.75rem;
     cursor: zoom-in;
   }
 
@@ -92,35 +63,11 @@
     max-height: 180px;
   }
 
-  .bookmark-body {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .bookmark-header {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    margin-bottom: 0.5rem;
-  }
-
-  .favicon {
-    border-radius: 2px;
-    flex-shrink: 0;
-  }
-
-  .domain {
-    font-size: 0.8rem;
-    color: var(--text-muted);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
   .title {
     font-size: 0.95rem;
     font-weight: 600;
     line-height: 1.3;
+    word-break: break-word;
   }
 
   .title a {

--- a/packages/web/src/components/CaptureBar.svelte
+++ b/packages/web/src/components/CaptureBar.svelte
@@ -147,8 +147,11 @@
     display: flex; gap: 0.5rem; align-items: center;
     /* Fixed height reserves the space permanently — the hint fading in on
        focus must not push content below. */
-    min-height: 1.5rem;
-    padding: 0.35rem 0.6rem 0;
+    min-height: 1.4rem;
+    /* Left-align the hint to where the input text starts (past the ⊕ button),
+       so it sits directly under what you're typing rather than at the bar edge.
+       = bar padding-left + plus button width + bar gap. */
+    padding: 0.2rem 0.6rem 0 calc(0.75rem + 30px + 0.6rem);
     font-size: 0.78rem; color: var(--text-muted);
   }
   .hint .sep { opacity: 0.4; }

--- a/packages/web/src/components/InboxCard.svelte
+++ b/packages/web/src/components/InboxCard.svelte
@@ -35,7 +35,9 @@
       return null;
     }
   });
-  const kindLabel = $derived(bookmarkDomain ?? kind.label);
+  // `||` not `??`: a parsed-but-empty hostname ('' for odd/non-host URLs)
+  // should still fall back to the generic label rather than render blank.
+  const kindLabel = $derived(bookmarkDomain || kind.label);
 
   // Preview text — note body or description, shown beneath the title so each
   // card gives a real sense of its content.

--- a/packages/web/src/components/InboxCard.svelte
+++ b/packages/web/src/components/InboxCard.svelte
@@ -6,8 +6,39 @@
   import AudioCard from './AudioCard.svelte';
   import DocumentCard from './DocumentCard.svelte';
   import EmailCard from './EmailCard.svelte';
+
   let { item, onselect }: { item: InboxItem; onselect: (item: InboxItem) => void } = $props();
 
+  // Stable per-type identity colours (independent of the theme accent so types
+  // stay distinguishable under any accent / light or dark mode).
+  const KIND: Record<string, { label: string; color: string }> = {
+    note: { label: 'Note', color: '#c08a2e' },
+    bookmark: { label: 'Bookmark', color: '#3b82f6' },
+    image: { label: 'Image', color: '#3f9d6b' },
+    audio: { label: 'Voice memo', color: '#7c6cf0' },
+    document: { label: 'Document', color: '#c0573a' },
+    email: { label: 'Email', color: '#2f8079' },
+  };
+  const kind = $derived(
+    KIND[item.type] ?? { label: item.type, color: 'var(--text-muted)' },
+  );
+
+  // Bookmarks identify by their source domain rather than the generic label.
+  const bookmarkDomain = $derived.by(() => {
+    if (item.type !== 'bookmark' || !('url' in item)) return null;
+    try {
+      return new URL((item as { url: string }).url).hostname.replace(
+        /^www\./,
+        '',
+      );
+    } catch {
+      return null;
+    }
+  });
+  const kindLabel = $derived(bookmarkDomain ?? kind.label);
+
+  // Preview text — note body or description, shown beneath the title so each
+  // card gives a real sense of its content.
   const cardNotes = $derived(
     ('notes' in item
       ? ((item as { notes?: string | null }).notes ?? null)
@@ -18,7 +49,11 @@
 
   function formatDate(iso: string): string {
     const d = new Date(iso);
-    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+    return d.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
   }
 </script>
 
@@ -32,6 +67,26 @@
     if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onselect(item); }
   }}>
   <div class="card-body">
+    <div class="card-kind">
+      <span class="kind-ic" style="--kc:{kind.color}" aria-hidden="true">
+        {#if item.type === 'note'}
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h10"/></svg>
+        {:else if item.type === 'bookmark'}
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linejoin="round"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+        {:else if item.type === 'image'}
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-5-5L5 21"/></svg>
+        {:else if item.type === 'audio'}
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"><rect x="9" y="3" width="6" height="11" rx="3"/><path d="M5 11a7 7 0 0 0 14 0M12 18v3"/></svg>
+        {:else if item.type === 'document'}
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>
+        {:else if item.type === 'email'}
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg>
+        {/if}
+      </span>
+      <span class="kind-label">{kindLabel}</span>
+      <span class="type-tag">{item.type}</span>
+    </div>
+
     {#if item.type === 'bookmark'}
       <BookmarkCard {item} />
     {:else if item.type === 'note'}
@@ -52,7 +107,6 @@
 
   <footer class="card-footer">
     <time class="date">{formatDate(item.createdAt)}</time>
-    <span class="type-badge">{item.type}</span>
   </footer>
 </article>
 
@@ -73,14 +127,61 @@
   }
 
   .card-body {
-    padding: 1rem;
+    padding: 1rem 1.1rem 1.1rem;
+  }
+
+  /* Per-type identity row: a colour-coded icon chip + source/kind label, so
+     each card type reads distinctly at a glance. */
+  .card-kind {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.7rem;
+  }
+
+  .kind-ic {
+    width: 24px;
+    height: 24px;
+    border-radius: 7px;
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--kc);
+    background: color-mix(in srgb, var(--kc) 15%, var(--surface));
+  }
+
+  .kind-ic svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  .kind-label {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+
+  .type-tag {
+    margin-left: auto;
+    color: var(--text-muted);
+    font-size: 0.6rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    white-space: nowrap;
+    flex-shrink: 0;
   }
 
   .card-footer {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.5rem 1rem;
+    padding: 0.6rem 1.1rem;
     border-top: 1px solid var(--border);
     font-size: 0.75rem;
   }
@@ -89,25 +190,13 @@
     color: var(--text-muted);
   }
 
-  .type-badge {
-    background: var(--accent-subtle);
-    color: var(--accent);
-    padding: 0.15rem 0.5rem;
-    border-radius: 999px;
-    font-size: 0.7rem;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-  }
-
   .card-notes {
     margin-top: 0.5rem;
     font-size: 0.85rem;
-    color: var(--accent);
+    color: var(--text-muted);
     line-height: 1.5;
-    font-style: italic;
     display: -webkit-box;
-    -webkit-line-clamp: 3;
+    -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
     overflow: hidden;
   }

--- a/packages/web/src/components/TodoQuickAdd.svelte
+++ b/packages/web/src/components/TodoQuickAdd.svelte
@@ -400,12 +400,14 @@
 
   .quick-hint {
     display: flex;
-    justify-content: center;
     gap: 0.5rem;
     align-items: center;
     /* Fixed height so the hint appearing on focus never shifts content. */
-    min-height: 1.5rem;
-    margin-top: 0.35rem;
+    min-height: 1.4rem;
+    margin-top: 0.2rem;
+    /* Left-align under the input's text (matches the input's horizontal
+       padding) so the hint sits beneath what you're typing, not centered. */
+    padding-left: 0.9rem;
     font-size: 0.78rem;
     color: var(--text-muted);
   }


### PR DESCRIPTION
## Summary

Phase 2c of the inbox redesign — give each card type a distinct, content-forward identity (no display serif; the earlier Fraunces experiment was reverted per feedback).

- **Per-type identity row** on every inbox card: a colour-coded type icon chip + a source/kind label (the domain for bookmarks), so types read distinctly at a glance. Type colours are fixed (independent of the theme accent) so they stay distinguishable under any accent / light or dark mode.
- **Sans titles** + up to 4 lines of preview text.
- **Voice-memo audio card** — a play/pause button over a per-item deterministic waveform driving the loaded blob (replaces the bare `<audio controls>`).
- **BookmarkCard** simplified — the favicon/domain header moved into the shared identity row; keeps the og-image + linked title.

Cards are shared components, so both the classic layout and the future sidebar inherit this.

## Design docs (groundwork, no runtime impact)

Also includes the design spec + implementation plan for the upcoming **smart capture bar** (`docs/superpowers/specs|plans/...`), so they land in `master` ahead of that work. Docs only — no code.

## Testing

- `npm test` (web) — all passing (incl. existing card/store/route/layout suites unchanged)
- `npm run build` + `biome ci` — clean
- Verified live: per-type chips (amber note, blue bookmark w/ domain), sans titles, waveform render in dark mode; modals open correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio cards now show a waveform-style preview with a play/pause control and optional duration, with cleaner handling when audio is unavailable.
  * Inbox cards display clearer item-type badges and improved bookmark labeling.

* **Bug Fixes**
  * Bookmark cards no longer show extra domain/favorite metadata, keeping the layout cleaner.
  * Updated hint text alignment and spacing in capture and quick-add areas for a more consistent input experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->