### PR TITLE
Fix capture audio playback in inbox list (#147)

### DIFF
--- a/packages/web/src/components/AudioCard.svelte
+++ b/packages/web/src/components/AudioCard.svelte
@@ -1,33 +1,22 @@
 <script lang="ts">
   import type { AudioItem } from '@inbox-rs/rs-module';
-  import rs from '../lib/rs';
+  import { blobUrls, connected, loadFileBlobUrl } from '../lib/stores';
+
   let { item }: { item: AudioItem } = $props();
-  let blobUrl = $state<string | null>(null);
-  let loading = $state(true);
-  let error = $state(false);
+  let audioError = $state(false);
 
+  const audioSrc = $derived($blobUrls[item.filePath] || null);
+
+  // Load audio bytes. loadFileBlobUrl fetches from the remote when connected
+  // and the local cache otherwise, so files captured via the capture app still
+  // play. Pass mimeType so the blob is tagged with the clean type from item
+  // metadata rather than whatever the server echoes back (e.g.
+  // `audio/webm; charset=binary` on 5apps). Referencing `$connected` re-runs
+  // this so we retry over the network once a connection is established.
   $effect(() => {
-    loadAudio();
-    return () => {
-      if (blobUrl) URL.revokeObjectURL(blobUrl);
-    };
+    void $connected;
+    if (item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
   });
-
-  async function loadAudio() {
-    try {
-      const file = await rs.inbox.getFile(item.filePath);
-      if (file?.data) {
-        if (blobUrl) URL.revokeObjectURL(blobUrl);
-        blobUrl = URL.createObjectURL(new Blob([file.data], { type: item.mimeType }));
-      } else {
-        error = true;
-      }
-    } catch {
-      error = true;
-    } finally {
-      loading = false;
-    }
-  }
 
   function formatDuration(seconds?: number): string {
     if (!seconds) return '';
@@ -43,17 +32,22 @@
     <span class="duration">{formatDuration(item.duration)}</span>
   {/if}
   <div class="player">
-    {#if loading}
-      <p class="status">Loading audio...</p>
-    {:else if error}
+    {#if audioError}
       <p class="status">Failed to load audio</p>
-    {:else if blobUrl}
+    {:else if audioSrc}
       <!-- User-recorded audio has no separate captions track; the
            transcription text (when present) is rendered alongside the player
            in ViewCardModal. The empty <track> just satisfies the lint rule. -->
-      <audio controls src={blobUrl} preload="metadata">
+      <audio
+        controls
+        src={audioSrc}
+        preload="metadata"
+        onerror={() => (audioError = true)}
+      >
         <track kind="captions" />
       </audio>
+    {:else}
+      <p class="status">Loading audio...</p>
     {/if}
   </div>
 </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #147

## Problem

When saving audio via the capture app, the item appears in the main inbox but the audio player shows "Failed to load audio" and cannot play. Audio saved directly in the main app works fine.

## Root cause

The capture app uploads audio files directly to the remoteStorage server via `DirectRS`, bypassing the main app's local remoteStorage cache. `AudioCard` only loaded audio from that local cache (`rs.inbox.getFile()`), so capture-origin files were never found even though metadata had synced.

Images already had this fixed in `ImageCard` (which uses `loadFileBlobUrl`), and the detail modal's `AudioView` already used the same pattern — only the inbox list card was still on the old path.

## Fix

Update `AudioCard.svelte` to use `loadFileBlobUrl` with the shared `$blobUrls` store and retry on reconnect (via `$connected`), matching `ImageCard` and `AudioView`.

## Testing

- `npm run check` — pass
- `npm run test --workspace=packages/web` — 300 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8b09447-41f4-4f62-8514-07408bd3d325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8b09447-41f4-4f62-8514-07408bd3d325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

