### PR TITLE
test(web): cover capture flows + untested lib/store paths

### DIFF
--- a/packages/web/src/lib/clean-for-storage.test.ts
+++ b/packages/web/src/lib/clean-for-storage.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { cleanForStorage } from './clean-for-storage';
+
+describe('cleanForStorage', () => {
+  it('returns a deep clone — mutating the result does not affect the input', () => {
+    const input = { a: { b: 1 } };
+    const result = cleanForStorage(input);
+
+    result.a.b = 99;
+
+    expect(input.a.b).toBe(1);
+  });
+
+  it('result is not the same reference as the input for nested objects', () => {
+    const input = { nested: { x: 1 } };
+    const result = cleanForStorage(input);
+
+    expect(result).not.toBe(input);
+    expect(result.nested).not.toBe(input.nested);
+  });
+
+  it('strips top-level undefined properties', () => {
+    const input = { keep: 'yes', drop: undefined };
+    const result = cleanForStorage(input);
+
+    expect(result).toEqual({ keep: 'yes' });
+    expect('drop' in result).toBe(false);
+  });
+
+  it('strips nested undefined properties', () => {
+    const input = { outer: { keep: 42, drop: undefined } };
+    const result = cleanForStorage(input);
+
+    expect(result).toEqual({ outer: { keep: 42 } });
+    expect('drop' in result.outer).toBe(false);
+  });
+
+  it('strips undefined properties at multiple nesting levels', () => {
+    const input = {
+      a: undefined,
+      b: {
+        c: undefined,
+        d: {
+          e: undefined,
+          f: 'value',
+        },
+      },
+    };
+    const result = cleanForStorage(input);
+
+    expect(result).toEqual({ b: { d: { f: 'value' } } });
+  });
+
+  it('documents JSON.stringify behaviour: undefined array elements become null', () => {
+    // JSON.stringify converts undefined inside arrays to null so that array
+    // indices are preserved. cleanForStorage reflects this behaviour exactly.
+    const input = { arr: [1, undefined, 3] };
+    const result = cleanForStorage(input);
+
+    expect(result.arr).toEqual([1, null, 3]);
+  });
+
+  it('preserves nested objects faithfully', () => {
+    const input = {
+      id: 'item-1',
+      meta: { createdAt: '2026-04-01T00:00:00.000Z', count: 7 },
+    };
+    const result = cleanForStorage(input);
+
+    expect(result).toEqual(input);
+  });
+
+  it('preserves nested arrays faithfully', () => {
+    const input = { tags: ['alpha', 'beta', 'gamma'], counts: [1, 2, 3] };
+    const result = cleanForStorage(input);
+
+    expect(result).toEqual(input);
+  });
+
+  it('preserves primitive values: strings, numbers, booleans, null', () => {
+    const input = {
+      str: 'hello',
+      num: 42,
+      float: 3.14,
+      bool: true,
+      nothing: null,
+    };
+    const result = cleanForStorage(input);
+
+    expect(result).toEqual(input);
+  });
+
+  it('handles an empty object', () => {
+    const result = cleanForStorage({});
+
+    expect(result).toEqual({});
+  });
+
+  it('handles a string primitive passed directly', () => {
+    const result = cleanForStorage('hello');
+
+    expect(result).toBe('hello');
+  });
+
+  it('handles a number primitive passed directly', () => {
+    const result = cleanForStorage(42);
+
+    expect(result).toBe(42);
+  });
+
+  it('handles a boolean primitive passed directly', () => {
+    expect(cleanForStorage(true)).toBe(true);
+    expect(cleanForStorage(false)).toBe(false);
+  });
+
+  it('handles null passed directly', () => {
+    const result = cleanForStorage(null);
+
+    expect(result).toBeNull();
+  });
+
+  it('handles deeply nested arrays of objects, stripping undefined inside each', () => {
+    const input = {
+      items: [
+        { id: '1', label: 'one', extra: undefined },
+        { id: '2', label: 'two', extra: undefined },
+      ],
+    };
+    const result = cleanForStorage(input);
+
+    expect(result).toEqual({
+      items: [
+        { id: '1', label: 'one' },
+        { id: '2', label: 'two' },
+      ],
+    });
+  });
+});

--- a/packages/web/src/lib/item-utils.test.ts
+++ b/packages/web/src/lib/item-utils.test.ts
@@ -1,0 +1,360 @@
+import type { InboxItem, NoteItem, TodoItem } from '@inbox-rs/rs-module';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { storeItem } = vi.hoisted(() => {
+  return {
+    storeItem: vi.fn().mockResolvedValue(undefined),
+  };
+});
+vi.mock('./stores', () => ({ storeItem }));
+
+import {
+  makeReference,
+  makeTodo,
+  TYPE_ICON_PATHS,
+  todoNote,
+  typeBadge,
+  typeIconPath,
+} from './item-utils';
+
+afterEach(() => vi.clearAllMocks());
+
+// ---------------------------------------------------------------------------
+// typeIconPath
+// ---------------------------------------------------------------------------
+
+describe('typeIconPath', () => {
+  it('returns SVG path markup for each known type', () => {
+    const knownTypes = Object.keys(TYPE_ICON_PATHS) as Array<
+      keyof typeof TYPE_ICON_PATHS
+    >;
+    for (const type of knownTypes) {
+      const result = typeIconPath(type);
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe('string');
+      // Sanity: verify it matches the lookup table directly.
+      expect(result).toBe(TYPE_ICON_PATHS[type]);
+    }
+  });
+
+  it('returns todo polyline markup for type "todo"', () => {
+    expect(typeIconPath('todo')).toBe('<polyline points="20 6 9 17 4 12"/>');
+  });
+
+  it('returns empty string for an unknown type', () => {
+    // Cast required because TypeScript's type system prevents passing an
+    // invalid literal, but runtime callers can still pass unknown strings.
+    expect(typeIconPath('unknown' as Parameters<typeof typeIconPath>[0])).toBe(
+      '',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// typeBadge
+// ---------------------------------------------------------------------------
+
+describe('typeBadge', () => {
+  it('returns null for a todo item', () => {
+    const item: TodoItem = {
+      id: 'todo-1',
+      type: 'todo',
+      title: 'Buy milk',
+      completed: false,
+      isTodo: true,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+    expect(typeBadge(item)).toBeNull();
+  });
+
+  it('returns the type string for a bookmark item', () => {
+    const item: InboxItem = {
+      id: 'bm-1',
+      type: 'bookmark',
+      title: 'Example',
+      url: 'https://example.com',
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+    expect(typeBadge(item)).toBe('bookmark');
+  });
+
+  it('returns the type string for a note item', () => {
+    const item: NoteItem = {
+      id: 'note-1',
+      type: 'note',
+      title: 'My note',
+      body: 'content',
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+    expect(typeBadge(item)).toBe('note');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// todoNote
+// ---------------------------------------------------------------------------
+
+describe('todoNote', () => {
+  it('returns null when the item has no notes, description, or body', () => {
+    const item: TodoItem = {
+      id: 'todo-1',
+      type: 'todo',
+      title: 'Simple todo',
+      completed: false,
+      isTodo: true,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+    expect(todoNote(item)).toBeNull();
+  });
+
+  it('returns the first line of description when present', () => {
+    const item: InboxItem = {
+      id: 'bm-1',
+      type: 'bookmark',
+      title: 'Link',
+      url: 'https://example.com',
+      description: 'First line\nSecond line\nThird line',
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+    expect(todoNote(item)).toBe('First line');
+  });
+
+  it('trims whitespace from the first line', () => {
+    const item: InboxItem = {
+      id: 'bm-1',
+      type: 'bookmark',
+      title: 'Link',
+      url: 'https://example.com',
+      description: '   trimmed   \nother line',
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+    expect(todoNote(item)).toBe('trimmed');
+  });
+
+  it('truncates first lines longer than 80 characters with an ellipsis', () => {
+    const longLine = 'x'.repeat(90);
+    const item: InboxItem = {
+      id: 'note-1',
+      type: 'note',
+      title: 'Note',
+      body: longLine,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+    const result = todoNote(item);
+    expect(result).toBe(`${'x'.repeat(80)}...`);
+    expect(result?.length).toBe(83); // 80 chars + '...'
+  });
+
+  it('does not truncate a first line of exactly 80 characters', () => {
+    const eightyChars = 'a'.repeat(80);
+    const item: NoteItem = {
+      id: 'note-1',
+      type: 'note',
+      title: 'Note',
+      body: eightyChars,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+    expect(todoNote(item)).toBe(eightyChars);
+  });
+
+  it('falls back to body when description is absent', () => {
+    const item: NoteItem = {
+      id: 'note-1',
+      type: 'note',
+      title: 'Note',
+      body: 'Body content',
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+    expect(todoNote(item)).toBe('Body content');
+  });
+
+  it('returns null when description is empty string', () => {
+    const item: InboxItem = {
+      id: 'bm-1',
+      type: 'bookmark',
+      title: 'Link',
+      url: 'https://example.com',
+      description: '',
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+    expect(todoNote(item)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// makeTodo
+// ---------------------------------------------------------------------------
+
+describe('makeTodo', () => {
+  it('calls storeItem with isTodo:true and completed:false', async () => {
+    const item: TodoItem = {
+      id: 'todo-1',
+      type: 'todo',
+      title: 'Buy milk',
+      completed: true,
+      completedAt: '2026-04-01T00:00:00.000Z',
+      isTodo: true,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+
+    await makeTodo(item);
+
+    expect(storeItem).toHaveBeenCalledOnce();
+    const stored = storeItem.mock.calls[0][0] as Record<string, unknown>;
+    expect(stored.isTodo).toBe(true);
+    expect(stored.completed).toBe(false);
+  });
+
+  it('drops completedAt from the stored item', async () => {
+    const item: TodoItem = {
+      id: 'todo-1',
+      type: 'todo',
+      title: 'Buy milk',
+      completed: true,
+      completedAt: '2026-04-01T00:00:00.000Z',
+      isTodo: true,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+
+    await makeTodo(item);
+
+    const stored = storeItem.mock.calls[0][0] as Record<string, unknown>;
+    expect('completedAt' in stored).toBe(false);
+  });
+
+  it('preserves other item fields (id, type, title)', async () => {
+    const item: TodoItem = {
+      id: 'todo-42',
+      type: 'todo',
+      title: 'My task',
+      completed: false,
+      isTodo: true,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+
+    await makeTodo(item);
+
+    const stored = storeItem.mock.calls[0][0] as Record<string, unknown>;
+    expect(stored.id).toBe('todo-42');
+    expect(stored.type).toBe('todo');
+    expect(stored.title).toBe('My task');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// makeReference
+// ---------------------------------------------------------------------------
+
+describe('makeReference', () => {
+  it('drops isTodo, completed, and completedAt from a todo item', async () => {
+    const item: TodoItem = {
+      id: 'todo-1',
+      type: 'todo',
+      title: 'A task',
+      completed: true,
+      completedAt: '2026-04-01T00:00:00.000Z',
+      isTodo: true,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+
+    await makeReference(item);
+
+    expect(storeItem).toHaveBeenCalledOnce();
+    const stored = storeItem.mock.calls[0][0] as Record<string, unknown>;
+    expect('isTodo' in stored).toBe(false);
+    expect('completed' in stored).toBe(false);
+    expect('completedAt' in stored).toBe(false);
+  });
+
+  it('rewrites type from "todo" to "note" and moves description→body', async () => {
+    const item: TodoItem = {
+      id: 'todo-1',
+      type: 'todo',
+      title: 'A task',
+      description: 'Some context',
+      completed: false,
+      isTodo: true,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+
+    await makeReference(item);
+
+    const stored = storeItem.mock.calls[0][0] as Record<string, unknown>;
+    expect(stored.type).toBe('note');
+    expect(stored.body).toBe('Some context');
+    expect('description' in stored).toBe(false);
+  });
+
+  it('does not overwrite an existing body when rewiring a todo to a note', async () => {
+    // If body is already set (e.g. from the todo's body field), description
+    // should NOT clobber it.
+    const item = {
+      id: 'todo-1',
+      type: 'todo',
+      title: 'A task',
+      body: 'Original body',
+      description: 'Should not overwrite',
+      completed: false,
+      isTodo: true,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    } as unknown as InboxItem;
+
+    await makeReference(item);
+
+    const stored = storeItem.mock.calls[0][0] as Record<string, unknown>;
+    expect(stored.type).toBe('note');
+    expect(stored.body).toBe('Original body');
+  });
+
+  it('sets body to empty string when todo has no description and no body', async () => {
+    const item: TodoItem = {
+      id: 'todo-1',
+      type: 'todo',
+      title: 'Bare task',
+      completed: false,
+      isTodo: true,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+
+    await makeReference(item);
+
+    const stored = storeItem.mock.calls[0][0] as Record<string, unknown>;
+    expect(stored.type).toBe('note');
+    expect(stored.body).toBe('');
+  });
+
+  it('does not change the type of a non-todo item (e.g. note)', async () => {
+    const item: NoteItem = {
+      id: 'note-1',
+      type: 'note',
+      title: 'Reference note',
+      body: 'Content',
+      isTodo: true,
+      completed: false,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+
+    await makeReference(item);
+
+    const stored = storeItem.mock.calls[0][0] as Record<string, unknown>;
+    expect(stored.type).toBe('note');
+    // body should remain untouched since type was not 'todo'
+    expect(stored.body).toBe('Content');
+  });
+
+  it('preserves unrelated fields like collectionId', async () => {
+    const item: NoteItem = {
+      id: 'note-1',
+      type: 'note',
+      title: 'Reference note',
+      body: 'Content',
+      collectionId: 'col-42',
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+
+    await makeReference(item);
+
+    const stored = storeItem.mock.calls[0][0] as Record<string, unknown>;
+    expect(stored.collectionId).toBe('col-42');
+  });
+});

--- a/packages/web/src/lib/item-utils.test.ts
+++ b/packages/web/src/lib/item-utils.test.ts
@@ -1,4 +1,9 @@
-import type { InboxItem, NoteItem, TodoItem } from '@inbox-rs/rs-module';
+import type {
+  EmailItem,
+  InboxItem,
+  NoteItem,
+  TodoItem,
+} from '@inbox-rs/rs-module';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const { storeItem } = vi.hoisted(() => {
@@ -178,6 +183,46 @@ describe('todoNote', () => {
       createdAt: '2026-04-01T00:00:00.000Z',
     };
     expect(todoNote(item)).toBeNull();
+  });
+
+  it('prefers the notes field over body', () => {
+    // EmailItem carries both `notes` and `body`; the lookup chain is
+    // notes → description → body, so notes must win.
+    const item: EmailItem = {
+      id: 'em-1',
+      type: 'email',
+      title: 'Re: lunch',
+      body: 'Body content',
+      notes: 'Notes content',
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+    expect(todoNote(item)).toBe('Notes content');
+  });
+
+  it('prefers description over body when both are present', () => {
+    const item: NoteItem = {
+      id: 'note-1',
+      type: 'note',
+      title: 'Note',
+      description: 'Description first',
+      body: 'Body second',
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+    expect(todoNote(item)).toBe('Description first');
+  });
+
+  it('returns an empty string when the first line is whitespace-only', () => {
+    // Documents current behavior: the truthiness guard runs on the untrimmed
+    // multi-line value, so a whitespace-only first line trims to '' and is
+    // returned as-is rather than collapsing to null.
+    const item: NoteItem = {
+      id: 'note-1',
+      type: 'note',
+      title: 'Note',
+      body: '   \nsecond line',
+      createdAt: '2026-04-01T00:00:00.000Z',
+    };
+    expect(todoNote(item)).toBe('');
   });
 });
 

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -2045,6 +2045,26 @@ describe('removeItemFromCollection', () => {
     // Should now appear in todoItems (unfiled todos)
     expect(get(todoItems).map((t) => t.id)).toContain('t1');
   });
+
+  it('rolls back the item and collection on persistence error', async () => {
+    const item = makeTodo('t1', { collectionId: 'c1' });
+    const col = { ...makeCollection('c1'), itemIds: ['t1'] };
+
+    items.set({ t1: item });
+    collections.set({ c1: col });
+
+    // The item write succeeds; the follow-up source-collection write fails
+    // mid-flight (delegated through moveItemToCollection).
+    mockInbox.storeCollection.mockRejectedValueOnce(new Error('write failed'));
+
+    await expect(removeItemFromCollection('t1')).rejects.toThrow(
+      'write failed',
+    );
+
+    // Both stores must roll back: the item stays filed in c1 and c1 still lists it.
+    expect(get(items).t1.collectionId).toBe('c1');
+    expect(get(collections).c1.itemIds).toEqual(['t1']);
+  });
 });
 
 describe('reorderCollectionItems', () => {
@@ -2160,5 +2180,16 @@ describe('reorderGroups', () => {
     await reorderGroups(['g2', 'g1']);
 
     expect(get(appConfig).todosGlobalOrder).toEqual(['t1']);
+  });
+
+  it('rolls back groupsOrder on persistence error', async () => {
+    appConfig.set({ groupsOrder: ['g1', 'g2'] });
+    // reorderGroups delegates to updateConfig, which rolls appConfig back
+    // when setConfig rejects.
+    mockInbox.setConfig.mockRejectedValueOnce(new Error('write failed'));
+
+    await expect(reorderGroups(['g2', 'g1'])).rejects.toThrow('write failed');
+
+    expect(get(appConfig).groupsOrder).toEqual(['g1', 'g2']);
   });
 });

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -76,7 +76,10 @@ import {
   openTodos,
   orphanCollections,
   pendingMigrationCount,
+  removeItemFromCollection,
+  reorderCollectionItems,
   reorderGroupCollections,
+  reorderGroups,
   reorderTodosGlobal,
   reorderUnfiledTodos,
   setActiveGroupFilters,
@@ -1977,5 +1980,185 @@ describe('load-time collection/group loading', () => {
     expect(get(groups).g1).toBeDefined();
     expect(mockInbox.storeGroup).not.toHaveBeenCalled();
     expect(mockInbox.storeCollection).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeItemFromCollection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    items.set({});
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+  });
+
+  it('clears collectionId on the item and removes it from the collection itemIds', async () => {
+    const item = makeTodo('t1', { collectionId: 'c1' });
+    const col = { ...makeCollection('c1'), itemIds: ['t1'] };
+
+    items.set({ t1: item });
+    collections.set({ c1: col });
+
+    await removeItemFromCollection('t1');
+
+    expect(get(items).t1.collectionId).toBeUndefined();
+    expect(get(collections).c1.itemIds).toEqual([]);
+    expect(mockInbox.store).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 't1' }),
+    );
+    expect(mockInbox.storeCollection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'c1', itemIds: [] }),
+    );
+  });
+
+  it('is a no-op when the item does not exist in the store', async () => {
+    collections.set({ c1: { ...makeCollection('c1'), itemIds: [] } });
+
+    await removeItemFromCollection('nonexistent');
+
+    expect(mockInbox.store).not.toHaveBeenCalled();
+    expect(mockInbox.storeCollection).not.toHaveBeenCalled();
+  });
+
+  it('works for an unfiled item (no-op on collections)', async () => {
+    // Item has no collectionId — removing from collection is essentially a no-op
+    // on the collections side but should not throw.
+    const item = makeTodo('t1');
+    items.set({ t1: item });
+
+    await removeItemFromCollection('t1');
+
+    // item.collectionId stays absent and no collection write occurs
+    expect(get(items).t1.collectionId).toBeUndefined();
+    expect(mockInbox.storeCollection).not.toHaveBeenCalled();
+  });
+
+  it('leaves the item visible as an unfiled todo after removal', async () => {
+    const item = makeTodo('t1', { collectionId: 'c1' });
+    const col = { ...makeCollection('c1'), itemIds: ['t1'] };
+
+    items.set({ t1: item });
+    collections.set({ c1: col });
+
+    await removeItemFromCollection('t1');
+
+    // Should now appear in todoItems (unfiled todos)
+    expect(get(todoItems).map((t) => t.id)).toContain('t1');
+  });
+});
+
+describe('reorderCollectionItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    items.set({});
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+  });
+
+  it('updates collection itemIds in the store and persists to storage', async () => {
+    const col = { ...makeCollection('c1'), itemIds: ['t1', 't2', 't3'] };
+    collections.set({ c1: col });
+
+    await reorderCollectionItems('c1', ['t3', 't1', 't2']);
+
+    expect(get(collections).c1.itemIds).toEqual(['t3', 't1', 't2']);
+    expect(mockInbox.storeCollection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'c1', itemIds: ['t3', 't1', 't2'] }),
+    );
+  });
+
+  it('is a no-op when the collection does not exist', async () => {
+    collections.set({});
+
+    await reorderCollectionItems('missing', ['t1', 't2']);
+
+    expect(mockInbox.storeCollection).not.toHaveBeenCalled();
+  });
+
+  it('accepts an empty itemIds array', async () => {
+    const col = { ...makeCollection('c1'), itemIds: ['t1', 't2'] };
+    collections.set({ c1: col });
+
+    await reorderCollectionItems('c1', []);
+
+    expect(get(collections).c1.itemIds).toEqual([]);
+    expect(mockInbox.storeCollection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'c1', itemIds: [] }),
+    );
+  });
+
+  it('does not affect other collections', async () => {
+    const c1 = { ...makeCollection('c1'), itemIds: ['t1', 't2'] };
+    const c2 = { ...makeCollection('c2'), itemIds: ['t3', 't4'] };
+    collections.set({ c1, c2 });
+
+    await reorderCollectionItems('c1', ['t2', 't1']);
+
+    expect(get(collections).c1.itemIds).toEqual(['t2', 't1']);
+    expect(get(collections).c2.itemIds).toEqual(['t3', 't4']);
+  });
+
+  it('rolls back store on persistence error', async () => {
+    const col = { ...makeCollection('c1'), itemIds: ['t1', 't2'] };
+    collections.set({ c1: col });
+    mockInbox.storeCollection.mockRejectedValueOnce(new Error('write failed'));
+
+    await expect(reorderCollectionItems('c1', ['t2', 't1'])).rejects.toThrow(
+      'write failed',
+    );
+
+    // Should be rolled back to the original order
+    expect(get(collections).c1.itemIds).toEqual(['t1', 't2']);
+  });
+});
+
+describe('reorderGroups', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    groups.set({});
+    appConfig.set({});
+  });
+
+  it('persists the new group order into appConfig.groupsOrder', async () => {
+    groups.set({
+      g1: makeGroup('g1'),
+      g2: makeGroup('g2'),
+      g3: makeGroup('g3'),
+    });
+
+    await reorderGroups(['g3', 'g1', 'g2']);
+
+    expect(get(appConfig).groupsOrder).toEqual(['g3', 'g1', 'g2']);
+    expect(mockInbox.setConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ groupsOrder: ['g3', 'g1', 'g2'] }),
+    );
+  });
+
+  it('overwrites a previous groupsOrder', async () => {
+    appConfig.set({ groupsOrder: ['g1', 'g2'] });
+
+    await reorderGroups(['g2', 'g1']);
+
+    expect(get(appConfig).groupsOrder).toEqual(['g2', 'g1']);
+  });
+
+  it('accepts an empty order array', async () => {
+    appConfig.set({ groupsOrder: ['g1', 'g2'] });
+
+    await reorderGroups([]);
+
+    expect(get(appConfig).groupsOrder).toEqual([]);
+    expect(mockInbox.setConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ groupsOrder: [] }),
+    );
+  });
+
+  it('does not touch other config keys', async () => {
+    appConfig.set({ todosGlobalOrder: ['t1'], groupsOrder: ['g1'] });
+
+    await reorderGroups(['g2', 'g1']);
+
+    expect(get(appConfig).todosGlobalOrder).toEqual(['t1']);
   });
 });

--- a/tests/e2e/desktop/capture-editor.spec.ts
+++ b/tests/e2e/desktop/capture-editor.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Ctrl/Cmd-Enter in the inbox capture bar opens the full note editor modal
+ * with the typed text pre-filled as the title (the `onopeneditor` path).
+ *
+ * Pressing plain Enter saves instantly; pressing Ctrl/Cmd-Enter instead opens
+ * AddEntryModal with `type="note"` and `prefillTitle` set to the captured
+ * text.  The modal's title input should carry the typed text, and the modal
+ * heading should read "Add Note".
+ */
+
+import { expect, test } from '../helpers/fixtures';
+import { assertNoConsoleErrors, attachConsoleCapture } from '../helpers/pwa';
+
+test('Ctrl+Enter opens the note editor modal pre-filled with the capture bar text', async ({
+  connectedPage,
+  webOrigin,
+}) => {
+  const log = attachConsoleCapture(connectedPage);
+  await connectedPage.goto(webOrigin);
+  await connectedPage.waitForLoadState('networkidle');
+
+  // Navigate to the inbox view where the desktop capture bar is rendered.
+  await connectedPage.getByRole('button', { name: 'Inbox' }).first().click();
+
+  // Dotless sentinel → detected as a note (not a bare-domain bookmark).
+  const sentinel = 'playwright open editor sentinel';
+  const input = connectedPage.getByPlaceholder(
+    'Paste a link, jot a note, or drop a file…',
+  );
+  await input.click();
+  await input.fill(sentinel);
+
+  // Ctrl+Enter triggers `onopeneditor` instead of `oncapture`.
+  await input.press('Control+Enter');
+
+  // The AddEntryModal should appear with role="dialog" and heading "Add Note".
+  const dialog = connectedPage.getByRole('dialog');
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+  await expect(
+    connectedPage.getByRole('heading', { name: 'Add Note' }),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // The typed text should seed the title input inside the modal.
+  const titleInput = connectedPage.getByPlaceholder('Note title');
+  await expect(titleInput).toBeVisible({ timeout: 10_000 });
+  await expect(titleInput).toHaveValue(sentinel);
+
+  assertNoConsoleErrors(log);
+});

--- a/tests/e2e/desktop/capture-file.spec.ts
+++ b/tests/e2e/desktop/capture-file.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * The capture bar's ⊕ ("Attach a file") button lets the user pick a file.
+ * Choosing an image triggers the `onfile` path in App.svelte: `handleFile`
+ * sets `activeModal = 'image'` and passes `prefillFile` to AddEntryModal,
+ * which forwards it to ImageForm.  ImageForm renders the filename in a
+ * `.picked` span and makes the form submittable.
+ *
+ * The native file dialog cannot be driven by Playwright, so we bypass the ⊕
+ * button and call `setInputFiles` directly on the hidden `.file-input` input.
+ * This fires the `change` event that CaptureBar's `onFileChange` listens to,
+ * which calls `onfile(file)` — exactly the path the button would trigger.
+ */
+
+import { expect, test } from '../helpers/fixtures';
+import { assertNoConsoleErrors, attachConsoleCapture } from '../helpers/pwa';
+
+test('attaching an image via the capture bar opens the Add Image modal with the filename pre-filled', async ({
+  connectedPage,
+  webOrigin,
+}) => {
+  const log = attachConsoleCapture(connectedPage);
+  await connectedPage.goto(webOrigin);
+  await connectedPage.waitForLoadState('networkidle');
+
+  // Make sure we're on the inbox view — that's the only page that renders the
+  // desktop CaptureBar (and therefore the hidden .file-input).
+  await connectedPage.getByRole('button', { name: 'Inbox' }).first().click();
+
+  // Build a minimal valid 1×1 PNG in memory so we never need a real file on
+  // disk.  The bytes are the standard 67-byte 1×1 transparent PNG.
+  const pngBuffer = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+    'base64',
+  );
+  const fileName = 'playwright-test-image.png';
+
+  // Set the file directly on the hidden input — this fires the `change` event
+  // that CaptureBar wires to `onFileChange` → `onfile(file)`.  We do NOT click
+  // the ⊕ button because that would open a real OS dialog.
+  const fileInput = connectedPage.locator('.file-input');
+  await fileInput.setInputFiles({
+    name: fileName,
+    mimeType: 'image/png',
+    buffer: pngBuffer,
+  });
+
+  // App.svelte#handleFile detects `image/png` and sets activeModal = 'image',
+  // which causes AddEntryModal to render with role="dialog" and heading "Add Image".
+  const dialog = connectedPage.getByRole('dialog');
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+  await expect(
+    connectedPage.getByRole('heading', { name: 'Add Image' }),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // ImageForm pre-fills the file and renders the filename in a .picked span.
+  const picked = connectedPage.locator('.picked');
+  await expect(picked).toBeVisible({ timeout: 10_000 });
+  await expect(picked).toHaveText(fileName);
+
+  assertNoConsoleErrors(log);
+});


### PR DESCRIPTION
Closes the test-coverage gaps around the capture / quick-add surface (the area under active redesign), following the audit from PR #150's review.

## Unit (vitest) — +50 tests, all green
- **clean-for-storage** (`lib/clean-for-storage.test.ts`) — deep-clone isolation, `undefined` stripping (incl. the JSON quirk where `undefined` array elements become `null`), faithful preservation of nested structures + primitives.
- **item-utils** (`lib/item-utils.test.ts`) — `typeIconPath` / `typeBadge` / `todoNote` (first-line, trim, >80-char truncation, empty→null) and the `makeTodo` / `makeReference` store-mutation shapes (mocked `storeItem`).
- **stores** (appended to `lib/stores.test.ts`) — the previously-untested `removeItemFromCollection`, `reorderCollectionItems`, `reorderGroups`: happy path + persistence, missing-collection no-op, empty-order, isolation from other collections, and **rollback-on-error**, reusing the existing harness helpers.

## E2e (Playwright, desktop) — author-only, run in CI
- **capture-editor** — ⌘/Ctrl-Enter in the capture bar opens the note editor modal pre-filled with the typed text (the `onopeneditor` path).
- **capture-file** — attaching an image via the hidden file input opens the Add Image modal with the filename pre-filled (the `onfile` path).

Local e2e needs the Docker Armadietto + preview server, so these are authored to mirror the existing specs and validated in CI. Every selector/heading they assert (`role=dialog`, `Add Note`/`Add Image` headings, `Note title` placeholder, `.picked` filename span) was verified against the live components before pushing.

## Verification
`npm run build` ✓ · `biome ci` 0 errors · **390/390** web unit tests · e2e `tsc --noEmit` clean.

## Notes
Follow-up to the coverage discussion: this is items #2 (e2e for new capture flows) and #3 (cheap lib/store wins). Component-level tests for TodoQuickAdd + CollectionView already landed with #150.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for storage cleanup, item type handling, collection and group reordering, and desktop capture flows.
  * Verified note creation pre-fills the title, image attachments open the correct dialog with the filename shown, and key item actions remain stable.
  * Expanded checks for nested data cleanup and array handling to better protect saved content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Update after review

Follow-up commit (`109d4e8`, rebased onto current `master` per AGENTS.md — now includes #154) closes the two highest-value gaps:

- **Store rollback parity** — previously only `reorderCollectionItems` had a rollback test. Added rollback-on-error tests for `removeItemFromCollection` (asserts the item *and* its source collection are both restored when the delegated `moveItemToCollection` write fails mid-flight) and `reorderGroups` (asserts `groupsOrder` is restored when the delegated `updateConfig` → `setConfig` write fails). All three reorder/remove paths now have rollback coverage.
- **`todoNote` precedence** — added `notes`-over-`body`, `description`-over-`body`, and a whitespace-only-first-line case.

**Whitespace finding:** the review expected a whitespace-only first line to yield `null`, but the implementation returns `''` — the `if (!notes)` guard runs on the *untrimmed multi-line* value, so `'   \nsecond'` passes the guard and the trimmed-empty first line is returned. The new test documents actual behavior; whether the contract should be `null` is tracked in #155.

### Follow-ups tracked as issues
- #155 — `todoNote` whitespace returns `''` not `null` (decide contract)
- #156 — harden capture e2e selectors (scope to dialog, prefer role/label)
- #157 — mobile capture-sheet e2e coverage
- #158 — extend capture e2e past modal-open (submit/persist + non-image document modal)

### Intentionally not done
- Meta+Enter e2e — `CaptureBar` treats `metaKey`/`ctrlKey` identically, the component test covers `ctrlKey`, and CI is Linux; left to component-level coverage.
- `clean-for-storage` test expansion and a `stores.test.ts` split — noted in review as low-value / out of scope.
