### PR TITLE
fix(web): keep quick-add todos from vanishing into hidden groups

### DIFF
--- a/packages/web/src/components/TodoQuickAdd.svelte
+++ b/packages/web/src/components/TodoQuickAdd.svelte
@@ -181,7 +181,13 @@
       label: 'Show',
       // Guard against a double-toggle if the group was revealed meanwhile.
       run: () => {
-        if (!get(activeGroupIds).has(gid)) void toggleGroupFilter(gid);
+        if (get(activeGroupIds).has(gid)) return;
+        // A failed config write would otherwise be an unhandled rejection;
+        // tell the user the reveal didn't take so they can retry.
+        void toggleGroupFilter(gid).catch((error) => {
+          console.error('Failed to reveal hidden group', error);
+          showToast('Could not show the group. Please try again.');
+        });
       },
     });
   }

--- a/packages/web/src/components/TodoQuickAdd.svelte
+++ b/packages/web/src/components/TodoQuickAdd.svelte
@@ -10,15 +10,19 @@
    * pick a destination, persisted per-device.
    */
   import { tick } from 'svelte';
+  import { get } from 'svelte/store';
   import { canCaptureTodo, makeUnfiledTodo } from '../lib/add-entry-modal';
   import { autofocusIf } from '../lib/actions';
   import { modLabel } from '../lib/platform';
+  import { showToast } from '../lib/toast';
   import {
+    activeGroupIds,
     collections,
     groupCollections,
     moveItemToCollection,
     sortedGroups,
     storeItem,
+    toggleGroupFilter,
   } from '../lib/stores';
 
   let {
@@ -76,12 +80,39 @@
     }
   }
   let storedQuickAddId = $state<string | undefined>(readStoredQuickAddId());
-  const quickAddCollectionId = $derived.by(() => {
-    const id = storedQuickAddId;
-    return id && collectionMap[id] ? id : undefined;
-  });
+  // Whether the user has actively chosen a destination in this composer
+  // instance. Distinguishes a deliberate in-session pick (honored verbatim,
+  // even into a hidden group) from the passively-restored default (guarded
+  // below). Resets on remount, so a stale hidden default never silently
+  // reapplies across reloads.
+  let userPicked = $state(false);
+
+  /** True when the collection exists, belongs to a known group, and that group
+   *  is currently filtered out of view — i.e. filing here makes the todo
+   *  vanish from the list. Ungrouped/orphan collections are never hidden. */
+  function isOutOfView(id: string | undefined): boolean {
+    const gid = id ? collectionMap[id]?.groupId : undefined;
+    return !!gid && !!groupMap()[gid] && !$activeGroupIds.has(gid);
+  }
+
+  // The remembered preference, if it still resolves to a real collection.
+  const pickedId = $derived(
+    storedQuickAddId && collectionMap[storedQuickAddId]
+      ? storedQuickAddId
+      : undefined,
+  );
+  // The passive default never targets a hidden group: a plain-Enter add would
+  // file the todo where it can't be seen. Falls back to Unfiled instead.
+  const defaultCollectionId = $derived(
+    pickedId && isOutOfView(pickedId) ? undefined : pickedId,
+  );
+  // Live select value: an explicit in-session pick wins (you may deliberately
+  // file into a hidden group — addQuickTodo surfaces a "Show" toast for that);
+  // otherwise use the guarded default.
+  const quickAddCollectionId = $derived(userPicked ? pickedId : defaultCollectionId);
   function setQuickAddCollection(id: string | undefined) {
     storedQuickAddId = id;
+    userPicked = true;
     try {
       if (id) localStorage.setItem(QUICK_ADD_KEY, id);
       else localStorage.removeItem(QUICK_ADD_KEY);
@@ -91,6 +122,18 @@
   }
 
   const targetCollectionId = $derived(fixedCollectionId ?? quickAddCollectionId);
+
+  // Where plain Enter will file the todo, shown in the hint while composing so
+  // the destination is predictable before submitting. Flags an out-of-view
+  // target so an explicit hidden pick isn't a surprise.
+  const destinationLabel = $derived.by(() => {
+    const id = targetCollectionId;
+    const col = id ? collectionMap[id] : undefined;
+    if (!col) return 'Unfiled';
+    const group = col.groupId ? groupMap()[col.groupId] : undefined;
+    const base = group ? `${group.name} › ${col.name}` : col.name;
+    return isOutOfView(id) ? `${base} (hidden)` : base;
+  });
 
   async function addQuickTodo() {
     if (!canCaptureTodo(quickTitle) || quickSaving) return;
@@ -108,6 +151,7 @@
       // Separate step keeps collection.itemIds in sync, matching AddEntryModal.
       if (targetCollectionId) {
         await moveItemToCollection(todo.id, targetCollectionId);
+        notifyIfOutOfView(targetCollectionId);
       }
     } catch (error) {
       console.error('Failed to add todo', error);
@@ -123,6 +167,23 @@
       await tick();
       quickInputEl?.focus();
     }
+  }
+
+  // After filing into a collection whose group is filtered out of view, the
+  // todo is intact but invisible here. Confirm where it went and offer a
+  // one-tap reveal so it never feels like it vanished — no after-the-fact edit.
+  function notifyIfOutOfView(collectionId: string) {
+    if (!isOutOfView(collectionId)) return;
+    const col = collectionMap[collectionId];
+    const gid = col?.groupId;
+    if (!gid) return;
+    showToast(`Added to ${col.name} — hidden from this view`, {
+      label: 'Show',
+      // Guard against a double-toggle if the group was revealed meanwhile.
+      run: () => {
+        if (!get(activeGroupIds).has(gid)) void toggleGroupFilter(gid);
+      },
+    });
   }
 
   // Clear a stale error once the user edits the input. Driven by the input's
@@ -208,7 +269,7 @@
 <!-- Always rendered with a fixed height so the hint never shifts content. -->
 <div class="quick-hint">
   {#if quickFocused && quickTitle.trim()}
-    <span>↵ Add todo</span>
+    <span>↵ {fixedCollectionId ? 'Add todo' : `Add to ${destinationLabel}`}</span>
     <span class="sep">·</span>
     <span>{mod}↵ Open editor</span>
   {/if}

--- a/packages/web/src/components/TodoQuickAdd.svelte.test.ts
+++ b/packages/web/src/components/TodoQuickAdd.svelte.test.ts
@@ -337,6 +337,31 @@ describe('TodoQuickAdd', () => {
     expect(toggleGroupFilter).toHaveBeenCalledWith('g-hidden');
   });
 
+  it('surfaces an error toast when the Show action fails to reveal the group', async () => {
+    toggleGroupFilter.mockRejectedValueOnce(new Error('config write failed'));
+    seedHiddenGroupDefault({ visible: false });
+    render();
+    pickCollection('col-h');
+    type('buy milk');
+    submit();
+    await vi.waitFor(() => {
+      flushSync();
+      expect(showToast).toHaveBeenCalledOnce();
+    });
+    const [, action] = showToast.mock.calls[0] as [
+      string,
+      { label: string; run: () => void },
+    ];
+    action.run();
+    expect(toggleGroupFilter).toHaveBeenCalledWith('g-hidden');
+    // The rejected reveal is caught and reported instead of going unhandled.
+    await vi.waitFor(() => {
+      expect(showToast).toHaveBeenLastCalledWith(
+        'Could not show the group. Please try again.',
+      );
+    });
+  });
+
   it('does not toast when filing into a currently visible group', async () => {
     seedHiddenGroupDefault({ visible: true });
     render();

--- a/packages/web/src/components/TodoQuickAdd.svelte.test.ts
+++ b/packages/web/src/components/TodoQuickAdd.svelte.test.ts
@@ -2,25 +2,41 @@
 import { flushSync, mount, unmount } from 'svelte';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { storeItem, moveItemToCollection } = vi.hoisted(() => ({
-  storeItem: vi.fn().mockResolvedValue(undefined),
-  moveItemToCollection: vi.fn().mockResolvedValue(undefined),
-}));
+const { storeItem, moveItemToCollection, toggleGroupFilter, showToast } =
+  vi.hoisted(() => ({
+    storeItem: vi.fn().mockResolvedValue(undefined),
+    moveItemToCollection: vi.fn().mockResolvedValue(undefined),
+    toggleGroupFilter: vi.fn().mockResolvedValue(undefined),
+    showToast: vi.fn(),
+  }));
 
-// Mock the data layer. The three stores the component subscribes to are real
-// writables so `$`-auto-subscription works; the two CRUD calls are spies.
+// Mock the data layer. The stores the component subscribes to are real
+// writables so `$`-auto-subscription works; the CRUD/toggle calls are spies.
 vi.mock('../lib/stores', async () => {
   const { writable } = await import('svelte/store');
   return {
     storeItem,
     moveItemToCollection,
+    toggleGroupFilter,
     collections: writable({}),
     groupCollections: writable({}),
     sortedGroups: writable([]),
+    activeGroupIds: writable(new Set<string>()),
   };
 });
+vi.mock('../lib/toast', () => ({ showToast }));
 
+import type { Writable } from 'svelte/store';
+import {
+  activeGroupIds,
+  collections,
+  groupCollections,
+  sortedGroups,
+} from '../lib/stores';
 import TodoQuickAdd from './TodoQuickAdd.svelte';
+
+// The mocked stores are plain writables; the real types are derived (no .set).
+const w = <T>(store: unknown) => store as Writable<T>;
 
 describe('TodoQuickAdd', () => {
   let host: HTMLElement;
@@ -32,6 +48,10 @@ describe('TodoQuickAdd', () => {
     storeItem.mockResolvedValue(undefined);
     moveItemToCollection.mockResolvedValue(undefined);
     localStorage.clear();
+    w<Record<string, unknown>>(collections).set({});
+    w<unknown[]>(sortedGroups).set([]);
+    w<Record<string, unknown>>(groupCollections).set({});
+    w<Set<string>>(activeGroupIds).set(new Set());
     onopenmodal = vi.fn();
     host = document.createElement('div');
     document.body.appendChild(host);
@@ -56,6 +76,25 @@ describe('TodoQuickAdd', () => {
     host.querySelector('button[type="submit"]') as HTMLButtonElement;
   const errorText = () =>
     host.querySelector('.quick-error')?.textContent?.trim() ?? '';
+  const hintText = () =>
+    host
+      .querySelector('.quick-hint')
+      ?.textContent?.replace(/\s+/g, ' ')
+      .trim() ?? '';
+
+  // The destination echo only renders while the input is focused with text.
+  function focus() {
+    input().dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+    flushSync();
+  }
+
+  // Drive the native select the way a user picking a destination would.
+  function pickCollection(value: string) {
+    const sel = collectionSelect();
+    sel.value = value;
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+    flushSync();
+  }
 
   function type(value: string) {
     const el = input();
@@ -154,6 +193,160 @@ describe('TodoQuickAdd', () => {
     // Nothing was created, so the title is preserved for an easy retry.
     expect(moveItemToCollection).not.toHaveBeenCalled();
     expect(input().value).toBe('store fail');
+  });
+
+  // Seed a persisted quick-add default pointing at `col-h`, which lives in
+  // group `g-hidden`. The caller decides whether that group is visible.
+  function seedHiddenGroupDefault({ visible }: { visible: boolean }) {
+    localStorage.setItem('inbox-rs:quickAddCollectionId', 'col-h');
+    const col = {
+      id: 'col-h',
+      name: 'Hidden Col',
+      itemIds: [],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      groupId: 'g-hidden',
+    };
+    w<Record<string, unknown>>(collections).set({ 'col-h': col });
+    w<unknown[]>(sortedGroups).set([
+      {
+        id: 'g-hidden',
+        name: 'Hidden',
+        collectionIds: ['col-h'],
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+    w<Record<string, unknown>>(groupCollections).set({ 'g-hidden': [col] });
+    w<Set<string>>(activeGroupIds).set(
+      visible ? new Set(['g-hidden']) : new Set(),
+    );
+  }
+
+  const collectionSelect = () =>
+    host.querySelector('.quick-add__collection') as HTMLSelectElement;
+
+  it('ignores a persisted default whose group is filtered out of view', async () => {
+    seedHiddenGroupDefault({ visible: false });
+    render();
+    // The default resolves to Unfiled so the just-added todo stays visible.
+    expect(collectionSelect().value).toBe('');
+    type('buy milk');
+    submit();
+    await vi.waitFor(() => {
+      flushSync();
+      expect(storeItem).toHaveBeenCalledOnce();
+    });
+    expect(moveItemToCollection).not.toHaveBeenCalled();
+  });
+
+  it('honors a persisted default whose group is currently visible', async () => {
+    seedHiddenGroupDefault({ visible: true });
+    render();
+    expect(collectionSelect().value).toBe('col-h');
+    type('buy milk');
+    submit();
+    await vi.waitFor(() => {
+      flushSync();
+      expect(moveItemToCollection).toHaveBeenCalledOnce();
+    });
+    const todoId = (storeItem.mock.calls[0][0] as { id: string }).id;
+    expect(moveItemToCollection).toHaveBeenCalledWith(todoId, 'col-h');
+  });
+
+  // Seed one visible group `g-work` with collection `col-road`.
+  function seedVisibleGroup() {
+    const col = {
+      id: 'col-road',
+      name: 'Roadmap',
+      itemIds: [],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      groupId: 'g-work',
+    };
+    w<Record<string, unknown>>(collections).set({ 'col-road': col });
+    w<unknown[]>(sortedGroups).set([
+      {
+        id: 'g-work',
+        name: 'Work',
+        collectionIds: ['col-road'],
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+    w<Record<string, unknown>>(groupCollections).set({ 'g-work': [col] });
+    w<Set<string>>(activeGroupIds).set(new Set(['g-work']));
+  }
+
+  // --- Win 1: destination echo in the hint line ---
+
+  it('echoes "Unfiled" as the destination when nothing is selected', () => {
+    render();
+    focus();
+    type('buy milk');
+    expect(hintText()).toContain('Add to Unfiled');
+  });
+
+  it('echoes the group › collection destination of a visible default', () => {
+    seedVisibleGroup();
+    localStorage.setItem('inbox-rs:quickAddCollectionId', 'col-road');
+    render();
+    focus();
+    type('buy milk');
+    expect(hintText()).toContain('Add to Work › Roadmap');
+  });
+
+  it('flags the destination as hidden in the echo when its group is filtered out', () => {
+    seedHiddenGroupDefault({ visible: false });
+    render();
+    // The default is guarded to Unfiled, so explicitly pick the hidden one.
+    pickCollection('col-h');
+    focus();
+    type('buy milk');
+    expect(hintText()).toContain('Add to Hidden › Hidden Col (hidden)');
+  });
+
+  // --- Win 2: filing into a hidden group is allowed, with a Show toast ---
+
+  it('honors an explicit pick into a hidden group instead of bouncing to Unfiled', () => {
+    seedHiddenGroupDefault({ visible: false });
+    render();
+    expect(collectionSelect().value).toBe('');
+    pickCollection('col-h');
+    // The explicit choice sticks — it does NOT revert to Unfiled.
+    expect(collectionSelect().value).toBe('col-h');
+  });
+
+  it('files into the hidden group and shows a Show toast that reveals it', async () => {
+    seedHiddenGroupDefault({ visible: false });
+    render();
+    pickCollection('col-h');
+    type('buy milk');
+    submit();
+    await vi.waitFor(() => {
+      flushSync();
+      expect(moveItemToCollection).toHaveBeenCalledOnce();
+    });
+    const todoId = (storeItem.mock.calls[0][0] as { id: string }).id;
+    expect(moveItemToCollection).toHaveBeenCalledWith(todoId, 'col-h');
+    // A toast names the hidden destination and offers a Show action.
+    expect(showToast).toHaveBeenCalledOnce();
+    const [message, action] = showToast.mock.calls[0] as [
+      string,
+      { label: string; run: () => void },
+    ];
+    expect(message).toContain('Hidden Col');
+    expect(action.label).toBe('Show');
+    action.run();
+    expect(toggleGroupFilter).toHaveBeenCalledWith('g-hidden');
+  });
+
+  it('does not toast when filing into a currently visible group', async () => {
+    seedHiddenGroupDefault({ visible: true });
+    render();
+    type('buy milk');
+    submit();
+    await vi.waitFor(() => {
+      flushSync();
+      expect(moveItemToCollection).toHaveBeenCalledOnce();
+    });
+    expect(showToast).not.toHaveBeenCalled();
   });
 
   it('disables the Add button until there is a title', () => {


### PR DESCRIPTION
## Problem

The quick-add todo composer's default destination was validated only for **existence**, never against **group visibility**. If your persisted default pointed at a collection whose group was toggled out of view, a plain-Enter add silently filed the todo into that hidden group — and it **disappeared** from the list. The flow felt unpredictable and forced after-the-fact hunting/editing.

## Changes

**Fix — guarded default**
- The default destination now falls back to **Unfiled** when the persisted default lives in a group that's currently filtered out of view, so a plain-Enter add always lands somewhere visible.
- Passive default and explicit in-session pick are split (`userPicked`): an explicit dropdown pick is honored verbatim — you can still *deliberately* file into a hidden group (and previously this would have bounced back to Unfiled).

**Win 1 — destination echo (predictability)**
- The hint line under the input now names where Enter will file the todo, e.g. `↵ Add to Work › Roadmap`, flagging an out-of-view target as `(hidden)`. The destination is clear *before* you submit.

**Win 2 — "Show" toast (nothing disappears, no edits)**
- Filing into a hidden group surfaces a toast naming the destination with a one-tap **Show** action that reveals the group (reusing the existing toast/undo system). The todo never feels lost and needs no after-the-fact edit. Only fires for the genuinely out-of-view case — the normal flow stays quiet.

## Testing

- TDD throughout (failing tests written first).
- New cases: guarded default falls back to Unfiled, visible default honored, explicit hidden pick sticks (no bounce-back), destination echo (Unfiled / group›collection / hidden flag), Show toast fires + reveals, and no toast for visible destinations.
- Full web suite: **348 passing** (`npm run test --workspace=packages/web`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick-add now shows a clearer destination hint, including when items will be added to a specific collection or an unfiled location.
  * If you add a todo to a hidden group, a toast now offers a quick way to reveal that group.

* **Bug Fixes**
  * Saved quick-add destinations now behave more consistently when their group is hidden.
  * Explicitly chosen destinations are preserved, even if they’re currently out of view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->