### PR TITLE
feat(web): opt-in sidebar shell — groups/collections, inline create, drag-to-file

### DIFF
--- a/packages/rs-module/src/types.ts
+++ b/packages/rs-module/src/types.ts
@@ -112,6 +112,13 @@ export interface AppConfig {
    */
   activeGroupFilters?: string[];
   /**
+   * Collection IDs explicitly toggled OFF in the sidebar layout. A deny-list
+   * (unlike activeGroupFilters' allow-list) so new collections default to
+   * active without needing migration, and so a collection stays visible while
+   * its group is active unless individually switched off.
+   */
+  inactiveCollectionFilters?: string[];
+  /**
    * Ordered list of todo IDs for the flat Todos page. Controls cross-collection
    * drag-sort order on that page only — collection-internal order (used by the
    * Collections page) still lives in `Collection.itemIds`.

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -9,6 +9,7 @@
   import InboxGrid from './components/InboxGrid.svelte';
   import MigrationAlert from './components/MigrationAlert.svelte';
   import ClassicShell from './components/ClassicShell.svelte';
+  import SidebarShell from './components/SidebarShell.svelte';
   import CaptureBar from './components/CaptureBar.svelte';
   import CaptureSheet from './components/CaptureSheet.svelte';
   import Toast from './components/Toast.svelte';
@@ -20,6 +21,7 @@
   import { captureDetected } from './lib/capture';
   import { showToast } from './lib/toast';
   import { parseHash, formatRoute, pageUsesFilters, type Page, type Route } from './lib/route';
+  import { layout } from './lib/layout';
 
   type LazyComponent = Component<Record<string, unknown>>;
 
@@ -331,8 +333,7 @@
   const openTodoCount = $derived($openTodos.length);
 </script>
 
-<ClassicShell {route} {navTo} {openTodoCount} onaddgroup={openGroupForm} bind:userMenu>
-  {#snippet children()}
+{#snippet shellBody()}
     {#if route.page === 'plugins'}
       {#if PluginsPageComponent}
         <PluginsPageComponent />
@@ -374,8 +375,17 @@
         {/if}
       {/if}
     {/if}
-  {/snippet}
-</ClassicShell>
+{/snippet}
+
+{#if $layout === 'sidebar'}
+  <SidebarShell {route} {navTo} {openTodoCount} onaddgroup={openGroupForm} bind:userMenu>
+    {#snippet children()}{@render shellBody()}{/snippet}
+  </SidebarShell>
+{:else}
+  <ClassicShell {route} {navTo} {openTodoCount} onaddgroup={openGroupForm} bind:userMenu>
+    {#snippet children()}{@render shellBody()}{/snippet}
+  </ClassicShell>
+{/if}
 
 {#if viewingItem}
   {#if ViewCardModalComponent}

--- a/packages/web/src/components/CollectionFormModal.svelte
+++ b/packages/web/src/components/CollectionFormModal.svelte
@@ -3,6 +3,7 @@
   import { get } from 'svelte/store';
   import { sortedGroups, groups, appConfig, updateConfig } from '../lib/stores';
   import EntityFormModal from './EntityFormModal.svelte';
+  import { randomPresetColor } from '../lib/constants';
 
   let { collection = undefined, groupId = undefined, onclose, onsave, ondelete = undefined }: {
     collection?: Collection;
@@ -19,7 +20,7 @@
 
   let name = $state(collection?.name ?? '');
   let description = $state(collection?.description ?? '');
-  let color = $state(collection?.color ?? '#6366f1');
+  let color = $state(collection?.color ?? randomPresetColor());
 
   /**
    * Pick the initial group selection for the picker. Resolution order:

--- a/packages/web/src/components/GroupFormModal.svelte
+++ b/packages/web/src/components/GroupFormModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { CollectionGroup } from '@inbox-rs/rs-module';
   import EntityFormModal from './EntityFormModal.svelte';
+  import { randomPresetColor } from '../lib/constants';
 
   let { group = undefined, onclose, onsave, ondelete = undefined }: {
     group?: CollectionGroup;
@@ -10,7 +11,7 @@
   } = $props();
 
   let name = $state(group?.name ?? '');
-  let color = $state(group?.color ?? '#6366f1');
+  let color = $state(group?.color ?? randomPresetColor());
 
   function handleSubmit() {
     if (!name.trim()) return;

--- a/packages/web/src/components/InboxCard.svelte
+++ b/packages/web/src/components/InboxCard.svelte
@@ -17,6 +17,31 @@
     e.dataTransfer.setData(DRAG_MIME, item.id);
     e.dataTransfer.setData('text/plain', item.title || item.id);
     e.dataTransfer.effectAllowed = 'move';
+    // Custom drag image: a compact, tilted chip carrying the title + a count
+    // badge (so multi-select can extend this later). Mirrors the sidebar mock.
+    const ghost = document.createElement('div');
+    ghost.textContent = item.title || kind.label;
+    Object.assign(ghost.style, {
+      position: 'fixed',
+      top: '-1000px',
+      left: '-1000px',
+      maxWidth: '240px',
+      padding: '0.45rem 0.65rem',
+      borderRadius: '10px',
+      background: 'var(--surface)',
+      border: '1px solid var(--accent)',
+      color: 'var(--text)',
+      font: '600 0.85rem system-ui, sans-serif',
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      boxShadow: '0 12px 30px rgba(20, 20, 40, 0.22)',
+      zIndex: '9999',
+    });
+    document.body.appendChild(ghost);
+    e.dataTransfer.setDragImage(ghost, 14, 14);
+    // Remove once the browser has snapshotted it for the drag cursor.
+    setTimeout(() => ghost.remove(), 0);
     draggingItemId.set(item.id);
   }
 

--- a/packages/web/src/components/InboxCard.svelte
+++ b/packages/web/src/components/InboxCard.svelte
@@ -6,8 +6,23 @@
   import AudioCard from './AudioCard.svelte';
   import DocumentCard from './DocumentCard.svelte';
   import EmailCard from './EmailCard.svelte';
+  import { draggingItemId, DRAG_MIME } from '../lib/drag';
 
   let { item, onselect }: { item: InboxItem; onselect: (item: InboxItem) => void } = $props();
+
+  // Drag onto a sidebar collection to file the item there. The id rides in
+  // dataTransfer; the store lets drop targets highlight during the drag.
+  function onDragStart(e: DragEvent) {
+    if (!e.dataTransfer) return;
+    e.dataTransfer.setData(DRAG_MIME, item.id);
+    e.dataTransfer.setData('text/plain', item.title || item.id);
+    e.dataTransfer.effectAllowed = 'move';
+    draggingItemId.set(item.id);
+  }
+
+  function onDragEnd() {
+    draggingItemId.set(null);
+  }
 
   // Stable per-type identity colours (independent of the theme accent so types
   // stay distinguishable under any accent / light or dark mode).
@@ -60,6 +75,9 @@
 </script>
 
 <article class="card" role="button" tabindex="0"
+  draggable="true"
+  ondragstart={onDragStart}
+  ondragend={onDragEnd}
   onclick={(e) => {
     const target = e.target as HTMLElement;
     if (target.closest('a, button, input, audio, video')) return;

--- a/packages/web/src/components/InboxGrid.svelte
+++ b/packages/web/src/components/InboxGrid.svelte
@@ -166,4 +166,20 @@
     from { opacity: 0; transform: translateY(8px); }
     to { opacity: 1; transform: translateY(0); }
   }
+
+  /* On mobile the shell stacks the sidebar above the content, so a 50vh
+     vertically-centred empty state floats far below the sidebar with a big
+     void above it. Sit it near the top of the content area instead. */
+  @media (max-width: 768px) {
+    .inbox-zero {
+      min-height: 0;
+      justify-content: flex-start;
+      padding-top: 2.5rem;
+    }
+
+    .zero-glow {
+      top: 2.5rem;
+      transform: translate(-50%, 0);
+    }
+  }
 </style>

--- a/packages/web/src/components/InboxGrid.svelte
+++ b/packages/web/src/components/InboxGrid.svelte
@@ -34,10 +34,12 @@
   </div>
 {:else}
   <div class="status-bar">You've got <span class="status-count">{items.length}</span> {items.length === 1 ? 'thing' : 'things'} waiting</div>
-  <div class="grid">
-    {#each items as item (item.id)}
-      <InboxCard {item} {onselect} />
-    {/each}
+  <div class="grid-wrap">
+    <div class="grid">
+      {#each items as item (item.id)}
+        <InboxCard {item} {onselect} />
+      {/each}
+    </div>
   </div>
 {/if}
 
@@ -67,6 +69,14 @@
     line-height: 1;
   }
 
+  /* Container (not viewport) queries: the masonry column count must track the
+     width actually available to the cards, which changes as the sidebar
+     expands/collapses — otherwise cards overflow (and get clipped by the
+     page's overflow-x:hidden, landing off-screen). */
+  .grid-wrap {
+    container-type: inline-size;
+  }
+
   .grid {
     column-count: 3;
     column-gap: 1rem;
@@ -77,11 +87,11 @@
     margin-bottom: 1rem;
   }
 
-  @media (max-width: 900px) {
+  @container (max-width: 760px) {
     .grid { column-count: 2; }
   }
 
-  @media (max-width: 550px) {
+  @container (max-width: 480px) {
     .grid { column-count: 1; }
   }
 

--- a/packages/web/src/components/SidebarShell.svelte
+++ b/packages/web/src/components/SidebarShell.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
+  import { onDestroy } from 'svelte';
   import { get } from 'svelte/store';
   import type { Collection, CollectionGroup } from '@inbox-rs/rs-module';
   import UserMenu from './UserMenu.svelte';
@@ -231,6 +232,11 @@
     springTimer = null;
     springGroupId = null;
   }
+
+  // A drag hovering a collapsed group when the shell is torn down (e.g. layout
+  // switch to Classic) would otherwise leave the pending timer to fire
+  // expandGroup on a destroyed instance.
+  onDestroy(clearSpring);
 
   function onGroupDragOver(group: CollectionGroup) {
     if (!dragging || expandedGroups.has(group.id)) return;

--- a/packages/web/src/components/SidebarShell.svelte
+++ b/packages/web/src/components/SidebarShell.svelte
@@ -1,0 +1,693 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { Collection, CollectionGroup } from '@inbox-rs/rs-module';
+  import UserMenu from './UserMenu.svelte';
+  import LogoShield from './LogoShield.svelte';
+  import type { Page, Route } from '../lib/route';
+  import { appVersion } from '../lib/plugin-downloads.generated';
+  import {
+    sortedGroups,
+    groupCollections,
+    activeGroupIds,
+    inactiveCollectionIds,
+    toggleGroupFilter,
+    toggleCollectionFilter,
+  } from '../lib/stores';
+
+  let {
+    route,
+    navTo,
+    openTodoCount,
+    onaddgroup,
+    userMenu = $bindable(null),
+    children,
+  }: {
+    route: Route;
+    navTo: (page: Page) => void;
+    openTodoCount: number;
+    onaddgroup: () => void;
+    userMenu?: InstanceType<typeof UserMenu> | null;
+    children: Snippet;
+  } = $props();
+
+  // Whole-sidebar collapse (rail vs expanded). Local + device-persisted.
+  let collapsed = $state(readCollapsed());
+  // Per-group expand/collapse of the collection list underneath each group.
+  let expandedGroups = $state<Set<string>>(new Set());
+
+  const groups = $derived($sortedGroups);
+  const grouped = $derived($groupCollections);
+  const activeGroups = $derived($activeGroupIds);
+  const inactiveCols = $derived($inactiveCollectionIds);
+
+  function readCollapsed(): boolean {
+    try {
+      return localStorage.getItem('inbox-rs:sidebar-collapsed') === '1';
+    } catch {
+      return false;
+    }
+  }
+
+  function toggleCollapsed() {
+    collapsed = !collapsed;
+    try {
+      localStorage.setItem('inbox-rs:sidebar-collapsed', collapsed ? '1' : '0');
+    } catch {
+      // storage blocked — collapse just won't persist across reloads
+    }
+  }
+
+  function toggleGroupExpanded(id: string) {
+    const next = new Set(expandedGroups);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    expandedGroups = next;
+  }
+
+  function isActive(page: Page): boolean {
+    return route.page === page;
+  }
+
+  function isGroupActive(group: CollectionGroup): boolean {
+    return activeGroups.has(group.id);
+  }
+
+  // A collection is "on" when its own switch is on AND its group is active.
+  // Toggling the switch only flips the collection's own deny-list entry.
+  function isCollectionActive(group: CollectionGroup, col: Collection): boolean {
+    return activeGroups.has(group.id) && !inactiveCols.has(col.id);
+  }
+
+  async function onToggleGroup(group: CollectionGroup) {
+    try {
+      await toggleGroupFilter(group.id);
+    } catch (error) {
+      console.error('Failed to toggle group filter', error);
+    }
+  }
+
+  async function onToggleCollection(col: Collection) {
+    try {
+      await toggleCollectionFilter(col.id);
+    } catch (error) {
+      console.error('Failed to toggle collection filter', error);
+    }
+  }
+</script>
+
+<header>
+  <div class="header-inner">
+    <button
+      class="sidebar-toggle"
+      type="button"
+      aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+      aria-pressed={!collapsed}
+      title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+      onclick={toggleCollapsed}
+    >
+      <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="brand">
+      <a class="brand-link" href="#/">
+        <h1 class="sr-only">Inbox RS</h1>
+        <span class="brand-logo" aria-hidden="true"><LogoShield /></span>
+      </a>
+    </div>
+    <nav class="header-nav" aria-label="Primary">
+      <button
+        type="button"
+        class:active={isActive('inbox')}
+        aria-current={isActive('inbox') ? 'page' : undefined}
+        onclick={() => navTo('inbox')}
+      >Inbox</button>
+      <button
+        type="button"
+        class:active={isActive('todos')}
+        aria-current={isActive('todos') ? 'page' : undefined}
+        onclick={() => navTo('todos')}
+      >
+        Todos
+        {#if openTodoCount > 0}
+          <span class="nav-badge">{openTodoCount}</span>
+        {/if}
+      </button>
+      <button
+        type="button"
+        class:active={isActive('collections')}
+        aria-current={isActive('collections') ? 'page' : undefined}
+        onclick={() => navTo('collections')}
+      >Collections</button>
+    </nav>
+    <div class="header-right">
+      <UserMenu bind:this={userMenu} />
+    </div>
+  </div>
+</header>
+
+<div class="body" class:sidebar-collapsed={collapsed}>
+  {#if route.page !== 'plugins'}
+    <aside class="sidebar" class:collapsed aria-label="Groups and collections">
+      {#if collapsed}
+        <button
+          class="rail-expand"
+          type="button"
+          aria-label="Expand sidebar"
+          title="Expand sidebar"
+          onclick={toggleCollapsed}
+        >
+          <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+        </button>
+      {:else}
+        <div class="sidebar-head">
+          <span class="sidebar-title">Groups</span>
+          <button
+            class="add-group"
+            type="button"
+            onclick={onaddgroup}
+            title="Create new group"
+            aria-label="Create new group"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          </button>
+        </div>
+
+        {#if groups.length === 0}
+          <button type="button" class="empty-cta" onclick={onaddgroup}>
+            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            Create your first group
+          </button>
+        {:else}
+          <div class="groups">
+            {#each groups as group (group.id)}
+              {@const cols = grouped[group.id] ?? []}
+              {@const groupActive = isGroupActive(group)}
+              {@const groupOpen = expandedGroups.has(group.id)}
+              <div class="group">
+                <div class="group-row">
+                  <button
+                    class="chevron"
+                    type="button"
+                    aria-label={groupOpen ? `Collapse ${group.name}` : `Expand ${group.name}`}
+                    aria-expanded={groupOpen}
+                    disabled={cols.length === 0}
+                    onclick={() => toggleGroupExpanded(group.id)}
+                  >
+                    <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="transform: rotate({groupOpen ? 90 : 0}deg)"><polyline points="9 18 15 12 9 6"/></svg>
+                  </button>
+                  <button
+                    class="entity group-entity"
+                    class:inactive={!groupActive}
+                    type="button"
+                    style="--entity-color: {group.color || 'var(--accent)'}"
+                    aria-pressed={groupActive}
+                    title={groupActive ? `Hide ${group.name}` : `Show ${group.name}`}
+                    onclick={() => onToggleGroup(group)}
+                  >
+                    <span class="dot"></span>
+                    <span class="entity-name">{group.name}</span>
+                  </button>
+                </div>
+
+                {#if groupOpen}
+                  <div class="collections">
+                    {#if cols.length === 0}
+                      <p class="collections-empty">No collections</p>
+                    {:else}
+                      {#each cols as col (col.id)}
+                        {@const colActive = isCollectionActive(group, col)}
+                        <button
+                          class="entity collection-entity"
+                          class:inactive={!colActive}
+                          type="button"
+                          style="--entity-color: {col.color || group.color || 'var(--accent)'}"
+                          aria-pressed={colActive}
+                          title={colActive ? `Hide ${col.name}` : `Show ${col.name}`}
+                          onclick={() => onToggleCollection(col)}
+                        >
+                          <span class="dot"></span>
+                          <span class="entity-name">{col.name}</span>
+                        </button>
+                      {/each}
+                    {/if}
+                  </div>
+                {/if}
+              </div>
+            {/each}
+          </div>
+        {/if}
+      {/if}
+    </aside>
+  {/if}
+
+  <main>
+    {@render children()}
+  </main>
+</div>
+
+<footer class="app-footer">
+  <div class="app-footer-inner">
+    <span class="footer-brand">Inbox RS</span>
+    <span class="footer-version">v{appVersion}</span>
+    <span class="footer-sep">·</span>
+    <a class="footer-link" class:active={isActive('plugins')} href="#/plugins">
+      <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+      Downloads
+    </a>
+    <span class="footer-sep">·</span>
+    <a class="footer-link" href="https://github.com/silverbucket/inbox-rs" target="_blank" rel="noopener noreferrer">
+      <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      GitHub
+    </a>
+  </div>
+</footer>
+
+<style>
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* ── Header (same vocabulary as ClassicShell, minus the filter row) ── */
+  header {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+    width: 100%;
+  }
+
+  .header-inner {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 1rem 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .sidebar-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    flex-shrink: 0;
+    border: 1px solid var(--border);
+    border-radius: 0.6rem;
+    background: var(--surface);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: color 150ms, border-color 150ms, background 150ms;
+  }
+
+  .sidebar-toggle:hover {
+    color: var(--text);
+    border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .brand-link {
+    display: flex;
+    align-items: center;
+    color: inherit;
+  }
+
+  .brand-logo {
+    display: inline-flex;
+    height: 38px;
+    width: auto;
+  }
+
+  .brand-logo :global(svg) {
+    height: 38px;
+    width: auto;
+  }
+
+  .header-nav {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.25rem;
+    border: 1px solid var(--border);
+    border-radius: 1rem;
+    background: color-mix(in srgb, var(--accent) 8%, var(--surface));
+    flex-shrink: 0;
+  }
+
+  .header-nav button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: 2rem;
+    padding: 0 0.9rem;
+    border-radius: 999px;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 0.92rem;
+    font-weight: 600;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background 180ms ease, color 180ms ease;
+  }
+
+  .header-nav button:hover {
+    color: var(--text);
+  }
+
+  .header-nav button.active {
+    color: var(--text);
+    background: color-mix(in srgb, var(--accent) 18%, var(--surface) 82%);
+  }
+
+  .nav-badge {
+    font-size: 0.65rem;
+    font-weight: 700;
+    color: white;
+    background: var(--accent);
+    min-width: 18px;
+    height: 18px;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 5px;
+    line-height: 1;
+  }
+
+  .header-right {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-shrink: 0;
+    margin-left: auto;
+  }
+
+  /* ── Body: sidebar + main ── */
+  .body {
+    max-width: 1400px;
+    margin: 0 auto;
+    width: 100%;
+    flex: 1;
+    display: grid;
+    grid-template-columns: 248px minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .body.sidebar-collapsed {
+    grid-template-columns: 56px minmax(0, 1fr);
+  }
+
+  /* ── Sidebar ── */
+  .sidebar {
+    position: sticky;
+    top: 70px;
+    align-self: start;
+    padding: 1.25rem 0.75rem 1.25rem 1.25rem;
+    border-right: 1px solid var(--border);
+    min-height: calc(100vh - 70px);
+  }
+
+  .sidebar.collapsed {
+    padding: 1rem 0.5rem;
+    display: flex;
+    justify-content: center;
+  }
+
+  .rail-expand {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border: 1px solid var(--border);
+    border-radius: 0.6rem;
+    background: var(--surface);
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+
+  .rail-expand:hover {
+    color: var(--text);
+    border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
+  }
+
+  .sidebar-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.75rem;
+  }
+
+  .sidebar-title {
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+  }
+
+  .add-group {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    flex-shrink: 0;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border) 65%);
+    background: color-mix(in srgb, var(--accent) 10%, var(--surface) 90%);
+    color: var(--accent);
+    cursor: pointer;
+    transition: background 150ms, border-color 150ms, transform 150ms;
+  }
+
+  .add-group:hover {
+    background: color-mix(in srgb, var(--accent) 22%, var(--surface) 78%);
+    border-color: var(--accent);
+    transform: scale(1.05);
+  }
+
+  .groups {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .group-row {
+    display: flex;
+    align-items: center;
+    gap: 0.1rem;
+  }
+
+  .chevron {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 28px;
+    flex-shrink: 0;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+
+  .chevron svg {
+    transition: transform 150ms ease;
+  }
+
+  .chevron:disabled {
+    opacity: 0.25;
+    cursor: default;
+  }
+
+  /* Shared toggle pill for both groups and collections. */
+  .entity {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-height: 1.9rem;
+    padding: 0 0.6rem;
+    border: 1px solid transparent;
+    border-radius: 0.55rem;
+    background: none;
+    color: var(--text);
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-align: left;
+    cursor: pointer;
+    transition: background 150ms, color 150ms, opacity 150ms;
+  }
+
+  .entity:hover {
+    background: var(--surface-hover, color-mix(in srgb, var(--surface) 70%, var(--bg)));
+  }
+
+  .group-entity {
+    font-weight: 700;
+  }
+
+  .collection-entity {
+    font-weight: 500;
+    font-size: 0.86rem;
+    margin-left: 1.4rem;
+  }
+
+  .entity.inactive {
+    opacity: 0.45;
+  }
+
+  .dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--entity-color);
+    flex-shrink: 0;
+  }
+
+  .entity-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .collections {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    padding: 0.1rem 0 0.35rem;
+  }
+
+  .collections-empty {
+    margin: 0;
+    padding: 0.2rem 0 0.2rem 1.9rem;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    font-style: italic;
+  }
+
+  .empty-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: none;
+    border: 1px dashed var(--border);
+    color: var(--text-muted);
+    padding: 0.45rem 0.85rem;
+    border-radius: 0.6rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: color 150ms, border-color 150ms;
+  }
+
+  .empty-cta:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+
+  /* ── Main ── */
+  main {
+    padding: 1.5rem;
+    width: 100%;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  /* ── Mobile: collapse the sidebar to a rail by default ── */
+  @media (max-width: 768px) {
+    .header-inner {
+      flex-wrap: wrap;
+      padding: 0.75rem 1rem;
+    }
+
+    .body,
+    .body.sidebar-collapsed {
+      grid-template-columns: 1fr;
+    }
+
+    .sidebar {
+      position: static;
+      min-height: 0;
+      border-right: none;
+      border-bottom: 1px solid var(--border);
+      padding: 0.75rem 1rem;
+    }
+
+    main {
+      padding: 1rem;
+    }
+  }
+
+  /* ── Footer (shared with ClassicShell vocabulary) ── */
+  .app-footer {
+    border-top: 1px solid var(--border);
+    margin-top: 2rem;
+    padding: 1rem 1.5rem;
+  }
+
+  .app-footer-inner {
+    max-width: 1400px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.82rem;
+    color: var(--text-muted);
+  }
+
+  .footer-brand {
+    font-weight: 700;
+    font-size: 0.82rem;
+    color: var(--text);
+  }
+
+  .footer-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    transition: color 180ms ease;
+  }
+
+  .footer-link:hover,
+  .footer-link.active {
+    color: var(--text);
+  }
+
+  .footer-link svg {
+    flex-shrink: 0;
+  }
+
+  .footer-sep {
+    opacity: 0.35;
+  }
+
+  .footer-version {
+    font-weight: 700;
+    font-size: 0.78rem;
+    padding: 0.15rem 0.45rem;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--border) 75%, white 25%);
+    background: color-mix(in srgb, var(--surface) 86%, black 14%);
+    letter-spacing: 0.02em;
+  }
+</style>

--- a/packages/web/src/components/SidebarShell.svelte
+++ b/packages/web/src/components/SidebarShell.svelte
@@ -21,6 +21,7 @@
   } from '../lib/stores';
   import { draggingItemId, DRAG_MIME } from '../lib/drag';
   import { showToast } from '../lib/toast';
+  import { randomPresetColor } from '../lib/constants';
 
   let {
     route,
@@ -144,7 +145,7 @@
         name,
         itemIds: [],
         createdAt: new Date().toISOString(),
-        color: group.color || '#6366f1',
+        color: randomPresetColor(),
         groupId: group.id,
       });
       // Keep the field open + cleared so several can be added in a row.
@@ -174,7 +175,7 @@
         name,
         collectionIds: [],
         createdAt: new Date().toISOString(),
-        color: '#6366f1',
+        color: randomPresetColor(),
       });
       newGroupName = '';
       addingGroup = false;
@@ -518,8 +519,6 @@
   }
 
   .header-inner {
-    max-width: 1400px;
-    margin: 0 auto;
     padding: 1rem 1.5rem;
     display: flex;
     align-items: center;
@@ -631,8 +630,6 @@
 
   /* ── Body: sidebar + main ── */
   .body {
-    max-width: 1400px;
-    margin: 0 auto;
     width: 100%;
     flex: 1;
     display: grid;
@@ -1062,6 +1059,11 @@
     .body,
     .body.sidebar-collapsed {
       grid-template-columns: 1fr;
+      /* Single-column rows must hug their content. The body is flex:1 (tall),
+         and a grid's default align-content stretches the auto rows to fill it —
+         which would inflate the sidebar's row and strand dead space below the
+         stacked sidebar before the content. Pack rows to the top instead. */
+      align-content: start;
     }
 
     .sidebar {
@@ -1072,11 +1074,12 @@
       padding: 0.85rem 1rem;
     }
 
-    /* Collapsed on mobile: the rail runs horizontally across the top (same
-       group circles as the desktop rail, just laid left-to-right instead of
-       top-to-bottom). */
+    /* Collapsed on mobile: show just the group-filter circles as a slim strip
+       running left-to-right (instead of the desktop top-to-bottom rail). The
+       header hamburger already handles expand, so the in-rail chevron is
+       redundant here — drop it. */
     .sidebar.collapsed {
-      justify-content: flex-start;
+      padding: 0.5rem 1rem;
     }
 
     .sidebar.collapsed .rail {
@@ -1086,7 +1089,13 @@
     }
 
     .sidebar.collapsed .rail-expand {
-      margin-bottom: 0;
+      display: none;
+    }
+
+    /* With the chevron gone, a collapsed sidebar that has no groups is pure
+       dead space — drop the whole band (the header toggle still reopens it). */
+    .sidebar.collapsed:not(:has(.rail-dot)) {
+      display: none;
     }
 
     main {
@@ -1102,8 +1111,6 @@
   }
 
   .app-footer-inner {
-    max-width: 1400px;
-    margin: 0 auto;
     display: flex;
     align-items: center;
     gap: 0.5rem;

--- a/packages/web/src/components/SidebarShell.svelte
+++ b/packages/web/src/components/SidebarShell.svelte
@@ -1050,6 +1050,9 @@
     gap: 1rem;
   }
 
+  /* Mobile: the sidebar stacks above the content and collapses *vertically* —
+     when collapsed it's hidden entirely (the header toggle re-opens it), rather
+     than shrinking to a side rail that makes no sense in a single column. */
   @media (max-width: 768px) {
     .header-inner {
       flex-wrap: wrap;
@@ -1066,7 +1069,12 @@
       min-height: 0;
       border-right: none;
       border-bottom: 1px solid var(--border);
-      padding: 0.75rem 1rem;
+      padding: 0.85rem 1rem;
+    }
+
+    /* Collapsed on mobile = fully hidden (vertical collapse), not a rail. */
+    .body.sidebar-collapsed .sidebar {
+      display: none;
     }
 
     main {

--- a/packages/web/src/components/SidebarShell.svelte
+++ b/packages/web/src/components/SidebarShell.svelte
@@ -1072,9 +1072,21 @@
       padding: 0.85rem 1rem;
     }
 
-    /* Collapsed on mobile = fully hidden (vertical collapse), not a rail. */
-    .body.sidebar-collapsed .sidebar {
-      display: none;
+    /* Collapsed on mobile: the rail runs horizontally across the top (same
+       group circles as the desktop rail, just laid left-to-right instead of
+       top-to-bottom). */
+    .sidebar.collapsed {
+      justify-content: flex-start;
+    }
+
+    .sidebar.collapsed .rail {
+      flex-direction: row;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .sidebar.collapsed .rail-expand {
+      margin-bottom: 0;
     }
 
     main {

--- a/packages/web/src/components/SidebarShell.svelte
+++ b/packages/web/src/components/SidebarShell.svelte
@@ -12,7 +12,9 @@
     inactiveCollectionIds,
     toggleGroupFilter,
     toggleCollectionFilter,
+    moveItemToCollection,
   } from '../lib/stores';
+  import { draggingItemId, DRAG_MIME } from '../lib/drag';
 
   let {
     route,
@@ -91,6 +93,35 @@
       await toggleCollectionFilter(col.id);
     } catch (error) {
       console.error('Failed to toggle collection filter', error);
+    }
+  }
+
+  // ── Drag an inbox item onto a collection to file it there. Groups are not
+  // drop targets; collections accept drops even while switched off. ──
+  let dragOverColId = $state<string | null>(null);
+  const dragging = $derived($draggingItemId !== null);
+
+  function onColDragOver(e: DragEvent, col: Collection) {
+    if (!dragging) return; // ignore unrelated drags
+    e.preventDefault(); // allow the drop
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+    dragOverColId = col.id;
+  }
+
+  function onColDragLeave(col: Collection) {
+    if (dragOverColId === col.id) dragOverColId = null;
+  }
+
+  async function onColDrop(e: DragEvent, col: Collection) {
+    e.preventDefault();
+    dragOverColId = null;
+    const id = e.dataTransfer?.getData(DRAG_MIME) ?? '';
+    draggingItemId.set(null);
+    if (!id) return;
+    try {
+      await moveItemToCollection(id, col.id);
+    } catch (error) {
+      console.error('Failed to assign item to collection', error);
     }
   }
 </script>
@@ -218,11 +249,16 @@
                         <button
                           class="entity collection-entity"
                           class:inactive={!colActive}
+                          class:drop-target={dragging}
+                          class:drop-over={dragOverColId === col.id}
                           type="button"
                           style="--entity-color: {col.color || group.color || 'var(--accent)'}"
                           aria-pressed={colActive}
                           title={colActive ? `Hide ${col.name}` : `Show ${col.name}`}
                           onclick={() => onToggleCollection(col)}
+                          ondragover={(e) => onColDragOver(e, col)}
+                          ondragleave={() => onColDragLeave(col)}
+                          ondrop={(e) => onColDrop(e, col)}
                         >
                           <span class="dot"></span>
                           <span class="entity-name">{col.name}</span>
@@ -551,6 +587,22 @@
 
   .entity.inactive {
     opacity: 0.45;
+  }
+
+  /* While dragging an item, every collection is a valid drop target — show a
+     dashed ring and restore full opacity (a switched-off collection can still
+     receive a drop). The one under the cursor fills with its colour. */
+  .collection-entity.drop-target {
+    opacity: 1;
+    outline: 1px dashed
+      color-mix(in srgb, var(--entity-color) 55%, var(--border));
+    outline-offset: -1px;
+  }
+
+  .collection-entity.drop-over {
+    background: color-mix(in srgb, var(--entity-color) 22%, var(--surface));
+    outline-style: solid;
+    outline-color: var(--entity-color);
   }
 
   .dot {

--- a/packages/web/src/components/SidebarShell.svelte
+++ b/packages/web/src/components/SidebarShell.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
+  import { get } from 'svelte/store';
   import type { Collection, CollectionGroup } from '@inbox-rs/rs-module';
   import UserMenu from './UserMenu.svelte';
   import LogoShield from './LogoShield.svelte';
   import type { Page, Route } from '../lib/route';
   import { appVersion } from '../lib/plugin-downloads.generated';
+  import { autofocus } from '../lib/actions';
   import {
     sortedGroups,
     groupCollections,
@@ -13,8 +15,12 @@
     toggleGroupFilter,
     toggleCollectionFilter,
     moveItemToCollection,
+    createCollection,
+    storeGroup,
+    items,
   } from '../lib/stores';
   import { draggingItemId, DRAG_MIME } from '../lib/drag';
+  import { showToast } from '../lib/toast';
 
   let {
     route,
@@ -32,15 +38,26 @@
     children: Snippet;
   } = $props();
 
-  // Whole-sidebar collapse (rail vs expanded). Local + device-persisted.
   let collapsed = $state(readCollapsed());
-  // Per-group expand/collapse of the collection list underneath each group.
   let expandedGroups = $state<Set<string>>(new Set());
+
+  // Inline creation state — no modal, no page switch.
+  let addingCollectionFor = $state<string | null>(null);
+  let newCollectionName = $state('');
+  let addingGroup = $state(false);
+  let newGroupName = $state('');
+
+  // Drag-to-file state.
+  let dragOverColId = $state<string | null>(null);
+  let justFiledColId = $state<string | null>(null);
+  let springGroupId: string | null = null;
+  let springTimer: ReturnType<typeof setTimeout> | null = null;
 
   const groups = $derived($sortedGroups);
   const grouped = $derived($groupCollections);
   const activeGroups = $derived($activeGroupIds);
   const inactiveCols = $derived($inactiveCollectionIds);
+  const dragging = $derived($draggingItemId !== null);
 
   function readCollapsed(): boolean {
     try {
@@ -66,6 +83,11 @@
     expandedGroups = next;
   }
 
+  function expandGroup(id: string) {
+    if (expandedGroups.has(id)) return;
+    expandedGroups = new Set(expandedGroups).add(id);
+  }
+
   function isActive(page: Page): boolean {
     return route.page === page;
   }
@@ -74,10 +96,15 @@
     return activeGroups.has(group.id);
   }
 
-  // A collection is "on" when its own switch is on AND its group is active.
-  // Toggling the switch only flips the collection's own deny-list entry.
   function isCollectionActive(group: CollectionGroup, col: Collection): boolean {
     return activeGroups.has(group.id) && !inactiveCols.has(col.id);
+  }
+
+  function groupCount(group: CollectionGroup): number {
+    return (grouped[group.id] ?? []).reduce(
+      (n, c) => n + c.itemIds.length,
+      0,
+    );
   }
 
   async function onToggleGroup(group: CollectionGroup) {
@@ -96,14 +123,70 @@
     }
   }
 
-  // ── Drag an inbox item onto a collection to file it there. Groups are not
-  // drop targets; collections accept drops even while switched off. ──
-  let dragOverColId = $state<string | null>(null);
-  const dragging = $derived($draggingItemId !== null);
+  // ── Inline collection creation ──────────────────────────────────────────
+  function startAddCollection(group: CollectionGroup) {
+    expandGroup(group.id);
+    newCollectionName = '';
+    addingCollectionFor = group.id;
+  }
 
+  function cancelAddCollection() {
+    addingCollectionFor = null;
+    newCollectionName = '';
+  }
+
+  async function submitCollection(group: CollectionGroup) {
+    const name = newCollectionName.trim();
+    if (!name) return;
+    try {
+      await createCollection({
+        id: crypto.randomUUID(),
+        name,
+        itemIds: [],
+        createdAt: new Date().toISOString(),
+        color: group.color || '#6366f1',
+        groupId: group.id,
+      });
+      // Keep the field open + cleared so several can be added in a row.
+      newCollectionName = '';
+    } catch (error) {
+      console.error('Failed to create collection', error);
+    }
+  }
+
+  // ── Inline group creation ───────────────────────────────────────────────
+  function startAddGroup() {
+    newGroupName = '';
+    addingGroup = true;
+  }
+
+  function cancelAddGroup() {
+    addingGroup = false;
+    newGroupName = '';
+  }
+
+  async function submitGroup() {
+    const name = newGroupName.trim();
+    if (!name) return;
+    try {
+      await storeGroup({
+        id: crypto.randomUUID(),
+        name,
+        collectionIds: [],
+        createdAt: new Date().toISOString(),
+        color: '#6366f1',
+      });
+      newGroupName = '';
+      addingGroup = false;
+    } catch (error) {
+      console.error('Failed to create group', error);
+    }
+  }
+
+  // ── Drag an inbox item onto a collection to file it ──────────────────────
   function onColDragOver(e: DragEvent, col: Collection) {
-    if (!dragging) return; // ignore unrelated drags
-    e.preventDefault(); // allow the drop
+    if (!dragging) return;
+    e.preventDefault();
     if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
     dragOverColId = col.id;
   }
@@ -115,14 +198,52 @@
   async function onColDrop(e: DragEvent, col: Collection) {
     e.preventDefault();
     dragOverColId = null;
+    clearSpring();
     const id = e.dataTransfer?.getData(DRAG_MIME) ?? '';
     draggingItemId.set(null);
     if (!id) return;
+    const previousCollectionId = get(items)[id]?.collectionId;
     try {
       await moveItemToCollection(id, col.id);
+      justFiledColId = col.id;
+      setTimeout(() => {
+        if (justFiledColId === col.id) justFiledColId = null;
+      }, 1000);
+      showToast(`Filed in ${col.name}`, {
+        label: 'Undo',
+        run: () => {
+          void moveItemToCollection(id, previousCollectionId).catch(() => {
+            showToast("Couldn't undo — open the item to move it.");
+          });
+        },
+      });
     } catch (error) {
       console.error('Failed to assign item to collection', error);
     }
+  }
+
+  // Spring-loaded groups: hovering a dragged item over a collapsed group
+  // auto-expands it after a beat so you can reach a nested collection without
+  // opening it first. Groups themselves are never drop targets.
+  function clearSpring() {
+    if (springTimer) clearTimeout(springTimer);
+    springTimer = null;
+    springGroupId = null;
+  }
+
+  function onGroupDragOver(group: CollectionGroup) {
+    if (!dragging || expandedGroups.has(group.id)) return;
+    if (springGroupId === group.id) return;
+    clearSpring();
+    springGroupId = group.id;
+    springTimer = setTimeout(() => {
+      expandGroup(group.id);
+      clearSpring();
+    }, 550);
+  }
+
+  function onGroupDragLeave(group: CollectionGroup) {
+    if (springGroupId === group.id) clearSpring();
   }
 </script>
 
@@ -177,33 +298,52 @@
 
 <div class="body" class:sidebar-collapsed={collapsed}>
   {#if route.page !== 'plugins'}
-    <aside class="sidebar" class:collapsed aria-label="Groups and collections">
+    <aside class="sidebar" class:collapsed class:dragging aria-label="Groups and collections">
       {#if collapsed}
-        <button
-          class="rail-expand"
-          type="button"
-          aria-label="Expand sidebar"
-          title="Expand sidebar"
-          onclick={toggleCollapsed}
-        >
-          <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
-        </button>
+        <div class="rail">
+          <button
+            class="rail-expand"
+            type="button"
+            aria-label="Expand sidebar"
+            title="Expand sidebar"
+            onclick={toggleCollapsed}
+          >
+            <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </button>
+          {#each groups as group (group.id)}
+            {@const groupActive = isGroupActive(group)}
+            <button
+              class="rail-dot"
+              class:inactive={!groupActive}
+              type="button"
+              style="--entity-color: {group.color || 'var(--accent)'}"
+              aria-pressed={groupActive}
+              title={groupActive ? `Hide ${group.name}` : `Show ${group.name}`}
+              onclick={() => onToggleGroup(group)}
+            >
+              <span class="dot"></span>
+            </button>
+          {/each}
+        </div>
       {:else}
+        {#if dragging}
+          <div class="filing">Filing mode — drop on a collection</div>
+        {/if}
         <div class="sidebar-head">
           <span class="sidebar-title">Groups</span>
           <button
-            class="add-group"
+            class="add-group-btn"
             type="button"
-            onclick={onaddgroup}
-            title="Create new group"
-            aria-label="Create new group"
+            onclick={startAddGroup}
+            title="New group"
+            aria-label="New group"
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
           </button>
         </div>
 
-        {#if groups.length === 0}
-          <button type="button" class="empty-cta" onclick={onaddgroup}>
+        {#if groups.length === 0 && !addingGroup}
+          <button type="button" class="empty-cta" onclick={startAddGroup}>
             <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
             Create your first group
           </button>
@@ -214,7 +354,12 @@
               {@const groupActive = isGroupActive(group)}
               {@const groupOpen = expandedGroups.has(group.id)}
               <div class="group">
-                <div class="group-row">
+                <div
+                  class="group-row"
+                  role="presentation"
+                  ondragover={() => onGroupDragOver(group)}
+                  ondragleave={() => onGroupDragLeave(group)}
+                >
                   <button
                     class="chevron"
                     type="button"
@@ -236,12 +381,22 @@
                   >
                     <span class="dot"></span>
                     <span class="entity-name">{group.name}</span>
+                    <span class="count">{groupCount(group)}</span>
+                  </button>
+                  <button
+                    class="row-add"
+                    type="button"
+                    title={`Add collection to ${group.name}`}
+                    aria-label={`Add collection to ${group.name}`}
+                    onclick={() => startAddCollection(group)}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
                   </button>
                 </div>
 
                 {#if groupOpen}
                   <div class="collections">
-                    {#if cols.length === 0}
+                    {#if cols.length === 0 && addingCollectionFor !== group.id}
                       <p class="collections-empty">No collections</p>
                     {:else}
                       {#each cols as col (col.id)}
@@ -251,6 +406,7 @@
                           class:inactive={!colActive}
                           class:drop-target={dragging}
                           class:drop-over={dragOverColId === col.id}
+                          class:just-filed={justFiledColId === col.id}
                           type="button"
                           style="--entity-color: {col.color || group.color || 'var(--accent)'}"
                           aria-pressed={colActive}
@@ -262,13 +418,54 @@
                         >
                           <span class="dot"></span>
                           <span class="entity-name">{col.name}</span>
+                          <span class="drop-label">File here</span>
+                          <span class="count">{col.itemIds.length}</span>
                         </button>
                       {/each}
+                    {/if}
+
+                    {#if addingCollectionFor === group.id}
+                      <div class="inline-add">
+                        <span class="dot" style="background: var(--text-muted)"></span>
+                        <input
+                          use:autofocus
+                          bind:value={newCollectionName}
+                          placeholder="Name a collection…"
+                          onkeydown={(e) => {
+                            if (e.key === 'Enter') { e.preventDefault(); void submitCollection(group); }
+                            else if (e.key === 'Escape') { e.preventDefault(); cancelAddCollection(); }
+                          }}
+                          onblur={cancelAddCollection}
+                        />
+                        <span class="inline-hint">↵ add · esc</span>
+                      </div>
                     {/if}
                   </div>
                 {/if}
               </div>
             {/each}
+
+            {#if addingGroup}
+              <div class="inline-add inline-add--group">
+                <span class="dot" style="background: var(--text-muted)"></span>
+                <input
+                  use:autofocus
+                  bind:value={newGroupName}
+                  placeholder="Name a group…"
+                  onkeydown={(e) => {
+                    if (e.key === 'Enter') { e.preventDefault(); void submitGroup(); }
+                    else if (e.key === 'Escape') { e.preventDefault(); cancelAddGroup(); }
+                  }}
+                  onblur={cancelAddGroup}
+                />
+                <span class="inline-hint">↵ add · esc</span>
+              </div>
+            {:else}
+              <button type="button" class="new-group" onclick={startAddGroup}>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                New group
+              </button>
+            {/if}
           </div>
         {/if}
       {/if}
@@ -310,7 +507,7 @@
     border: 0;
   }
 
-  /* ── Header (same vocabulary as ClassicShell, minus the filter row) ── */
+  /* ── Header ── */
   header {
     position: sticky;
     top: 0;
@@ -439,12 +636,12 @@
     width: 100%;
     flex: 1;
     display: grid;
-    grid-template-columns: 248px minmax(0, 1fr);
+    grid-template-columns: 268px minmax(0, 1fr);
     align-items: start;
   }
 
   .body.sidebar-collapsed {
-    grid-template-columns: 56px minmax(0, 1fr);
+    grid-template-columns: 60px minmax(0, 1fr);
   }
 
   /* ── Sidebar ── */
@@ -452,15 +649,25 @@
     position: sticky;
     top: 70px;
     align-self: start;
-    padding: 1.25rem 0.75rem 1.25rem 1.25rem;
+    padding: 1rem 0.65rem 1rem 1rem;
     border-right: 1px solid var(--border);
     min-height: calc(100vh - 70px);
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--accent) 3%, var(--bg)),
+      var(--bg)
+    );
   }
 
   .sidebar.collapsed {
-    padding: 1rem 0.5rem;
+    padding: 0.85rem 0.5rem;
+  }
+
+  .rail {
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
   }
 
   .rail-expand {
@@ -469,6 +676,7 @@
     justify-content: center;
     width: 36px;
     height: 36px;
+    margin-bottom: 0.35rem;
     border: 1px solid var(--border);
     border-radius: 0.6rem;
     background: var(--surface);
@@ -481,69 +689,104 @@
     border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
   }
 
+  /* Collapsed rail: a group is a colour circle — full when active, faded when
+     switched off. Click to toggle, same as the expanded row. */
+  .rail-dot {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border: none;
+    border-radius: 50%;
+    background: none;
+    cursor: pointer;
+    transition: background 150ms;
+  }
+
+  .rail-dot:hover {
+    background: var(--surface-hover);
+  }
+
+  .filing {
+    margin: 0 0.25rem 0.5rem;
+    padding: 0.4rem 0.6rem;
+    border-radius: 0.5rem;
+    font-size: 0.76rem;
+    font-weight: 600;
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 14%, transparent);
+  }
+
   .sidebar-head {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 0.75rem;
+    padding: 0 0.25rem;
+    margin-bottom: 0.5rem;
   }
 
   .sidebar-title {
-    font-size: 0.72rem;
-    font-weight: 700;
+    font-size: 0.68rem;
+    font-weight: 800;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.08em;
     color: var(--text-muted);
   }
 
-  .add-group {
+  .add-group-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 26px;
-    height: 26px;
+    width: 24px;
+    height: 24px;
     flex-shrink: 0;
     border-radius: 999px;
-    border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border) 65%);
-    background: color-mix(in srgb, var(--accent) 10%, var(--surface) 90%);
+    border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border) 70%);
+    background: color-mix(in srgb, var(--accent) 8%, transparent);
     color: var(--accent);
     cursor: pointer;
-    transition: background 150ms, border-color 150ms, transform 150ms;
+    transition: background 150ms, transform 150ms;
   }
 
-  .add-group:hover {
-    background: color-mix(in srgb, var(--accent) 22%, var(--surface) 78%);
-    border-color: var(--accent);
+  .add-group-btn:hover {
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
     transform: scale(1.05);
   }
 
   .groups {
     display: flex;
     flex-direction: column;
-    gap: 0.15rem;
+    gap: 0.05rem;
   }
 
   .group-row {
     display: flex;
     align-items: center;
-    gap: 0.1rem;
+    gap: 0.05rem;
+    border-radius: 0.5rem;
+  }
+
+  .group-row:hover {
+    background: var(--surface-hover);
   }
 
   .chevron {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 22px;
+    width: 20px;
     height: 28px;
     flex-shrink: 0;
     border: none;
     background: none;
     color: var(--text-muted);
     cursor: pointer;
+    border-radius: 6px;
   }
 
   .chevron svg {
-    transition: transform 150ms ease;
+    transition: transform 160ms ease;
   }
 
   .chevron:disabled {
@@ -551,7 +794,6 @@
     cursor: default;
   }
 
-  /* Shared toggle pill for both groups and collections. */
   .entity {
     flex: 1 1 auto;
     min-width: 0;
@@ -559,9 +801,9 @@
     align-items: center;
     gap: 0.5rem;
     min-height: 1.9rem;
-    padding: 0 0.6rem;
+    padding: 0 0.55rem;
     border: 1px solid transparent;
-    border-radius: 0.55rem;
+    border-radius: 0.5rem;
     background: none;
     color: var(--text);
     font-size: 0.9rem;
@@ -572,7 +814,7 @@
   }
 
   .entity:hover {
-    background: var(--surface-hover, color-mix(in srgb, var(--surface) 70%, var(--bg)));
+    background: var(--surface-hover);
   }
 
   .group-entity {
@@ -582,27 +824,11 @@
   .collection-entity {
     font-weight: 500;
     font-size: 0.86rem;
-    margin-left: 1.4rem;
+    margin-left: 1.55rem;
   }
 
   .entity.inactive {
-    opacity: 0.45;
-  }
-
-  /* While dragging an item, every collection is a valid drop target — show a
-     dashed ring and restore full opacity (a switched-off collection can still
-     receive a drop). The one under the cursor fills with its colour. */
-  .collection-entity.drop-target {
-    opacity: 1;
-    outline: 1px dashed
-      color-mix(in srgb, var(--entity-color) 55%, var(--border));
-    outline-offset: -1px;
-  }
-
-  .collection-entity.drop-over {
-    background: color-mix(in srgb, var(--entity-color) 22%, var(--surface));
-    outline-style: solid;
-    outline-color: var(--entity-color);
+    opacity: 0.42;
   }
 
   .dot {
@@ -613,17 +839,70 @@
     flex-shrink: 0;
   }
 
+  /* Larger dot for the collapsed rail (declared after the base `.dot` so the
+     higher-specificity selector wins without a descending-specificity lint). */
+  .rail-dot .dot {
+    width: 14px;
+    height: 14px;
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--entity-color) 18%, transparent);
+  }
+
+  .rail-dot.inactive .dot {
+    opacity: 0.35;
+    box-shadow: none;
+  }
+
   .entity-name {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
+  .count {
+    margin-left: auto;
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: var(--text-muted);
+  }
+
+  .group-entity .count {
+    background: var(--surface-hover);
+    border-radius: 999px;
+    padding: 0 0.4rem;
+  }
+
+  /* Reveal the per-group add button on hover only, to keep things quiet. */
+  .row-add {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    border-radius: 6px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 150ms, color 150ms, background 150ms;
+  }
+
+  .group-row:hover .row-add,
+  .row-add:focus-visible {
+    opacity: 1;
+  }
+
+  .row-add:hover {
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 14%, transparent);
+  }
+
   .collections {
     display: flex;
     flex-direction: column;
-    gap: 0.1rem;
-    padding: 0.1rem 0 0.35rem;
+    gap: 0.05rem;
+    padding: 0.05rem 0 0.35rem;
   }
 
   .collections-empty {
@@ -632,6 +911,92 @@
     font-size: 0.8rem;
     color: var(--text-muted);
     font-style: italic;
+  }
+
+  /* ── Drag-to-file affordances ── */
+  .drop-label {
+    display: none;
+    margin-left: auto;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--entity-color);
+  }
+
+  .collection-entity.drop-target {
+    opacity: 1;
+    outline: 1px dashed
+      color-mix(in srgb, var(--entity-color) 55%, var(--border));
+    outline-offset: -1px;
+  }
+
+  .collection-entity.drop-over {
+    background: color-mix(in srgb, var(--entity-color) 20%, var(--surface));
+    outline: 2px solid var(--entity-color);
+    transform: translateX(2px) scale(1.015);
+    box-shadow: 0 4px 14px
+      color-mix(in srgb, var(--entity-color) 35%, transparent);
+  }
+
+  .collection-entity.drop-over .count {
+    display: none;
+  }
+
+  .collection-entity.drop-over .drop-label {
+    display: inline;
+  }
+
+  /* Group rows recede while filing, since you can only drop on collections. */
+  .sidebar.dragging .group-entity {
+    opacity: 0.5;
+  }
+
+  .collection-entity.just-filed {
+    animation: filed-pulse 1s ease;
+  }
+
+  @keyframes filed-pulse {
+    0% {
+      background: color-mix(in srgb, var(--entity-color) 35%, var(--surface));
+    }
+    100% {
+      background: none;
+    }
+  }
+
+  /* ── Inline create input ── */
+  .inline-add {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-left: 1.55rem;
+    margin-top: 0.1rem;
+    padding: 0.28rem 0.55rem;
+    border: 1px solid var(--accent);
+    border-radius: 0.5rem;
+    background: var(--surface);
+  }
+
+  .inline-add--group {
+    margin-left: 0;
+    margin-top: 0.5rem;
+  }
+
+  .inline-add input {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    outline: none;
+    background: none;
+    /* Inherit the >=1rem body size — an explicit sub-1rem size would trip the
+       iOS Safari focus-zoom guard (see input-font-size.test.ts). */
+    font: inherit;
+    color: var(--text);
+  }
+
+  .inline-hint {
+    font-size: 0.68rem;
+    color: var(--text-muted);
+    white-space: nowrap;
   }
 
   .empty-cta {
@@ -653,6 +1018,28 @@
     border-color: var(--accent);
   }
 
+  .new-group {
+    margin-top: 0.6rem;
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    width: 100%;
+    padding: 0.45rem 0.6rem;
+    border: 1px dashed var(--border);
+    border-radius: 0.5rem;
+    background: none;
+    color: var(--text-muted);
+    font-size: 0.84rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: color 150ms, border-color 150ms;
+  }
+
+  .new-group:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+
   /* ── Main ── */
   main {
     padding: 1.5rem;
@@ -663,7 +1050,6 @@
     gap: 1rem;
   }
 
-  /* ── Mobile: collapse the sidebar to a rail by default ── */
   @media (max-width: 768px) {
     .header-inner {
       flex-wrap: wrap;
@@ -688,7 +1074,7 @@
     }
   }
 
-  /* ── Footer (shared with ClassicShell vocabulary) ── */
+  /* ── Footer ── */
   .app-footer {
     border-top: 1px solid var(--border);
     margin-top: 2rem;

--- a/packages/web/src/components/TodoRow.svelte
+++ b/packages/web/src/components/TodoRow.svelte
@@ -3,6 +3,7 @@
   import { storeItem } from '../lib/stores';
   import { cleanForStorage } from '../lib/clean-for-storage';
   import { typeIconPath } from '../lib/item-utils';
+  import { draggingItemId, DRAG_MIME } from '../lib/drag';
 
   let { todo, collection, group, onselect, onaddincollection }: {
     todo: InboxItem;
@@ -85,6 +86,21 @@
     onaddincollection?.(quickAddTarget);
   }
 
+  // Drag the collection pill onto a sidebar collection to re-file this todo.
+  // The pill (not the whole row) is the handle so it doesn't fight the
+  // svelte-dnd-action reorder gesture, which owns row-body drags.
+  function onFileDragStart(e: DragEvent) {
+    if (!e.dataTransfer) return;
+    e.dataTransfer.setData(DRAG_MIME, todo.id);
+    e.dataTransfer.setData('text/plain', todo.title || todo.id);
+    e.dataTransfer.effectAllowed = 'move';
+    draggingItemId.set(todo.id);
+  }
+
+  function onFileDragEnd() {
+    draggingItemId.set(null);
+  }
+
   function handleKey(e: KeyboardEvent) {
     const target = e.target as HTMLElement;
     // "+" shortcut triggers quick-add for this row's collection, regardless
@@ -133,10 +149,20 @@
   <!-- The meta block collapses to line 2 on narrow screens via CSS;
        on desktop it sits inline on the right side of the row. -->
   <div class="meta">
-    <span class="collection-pill" title="{collectionName}">
+    <button
+      class="collection-pill"
+      type="button"
+      tabindex="-1"
+      draggable="true"
+      title="Drag to refile · {collectionName}"
+      aria-label="Drag {todo.title} onto a collection to refile it"
+      onpointerdown={(e) => e.stopPropagation()}
+      ondragstart={onFileDragStart}
+      ondragend={onFileDragEnd}
+    >
       <span class="pill-dot"></span>
       <span class="pill-name">{collectionName}</span>
-    </span>
+    </button>
     {#if showTypeIcon}
       <span class="type-pill" title={typeLabel} aria-label={typeLabel}>
         <svg aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -237,6 +263,7 @@
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
+    font-family: inherit;
     font-size: 0.75rem;
     color: var(--text-muted);
     padding: 0.15rem 0.55rem;
@@ -245,6 +272,18 @@
     border-radius: 999px;
     max-width: 12rem;
     min-width: 0;
+    /* Draggable handle for re-filing (see onFileDragStart). */
+    cursor: grab;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .collection-pill:active {
+    cursor: grabbing;
+  }
+
+  .collection-pill:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
   }
 
   .unfiled .collection-pill {

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -11,6 +11,7 @@
     applyAccent,
     isAccent,
   } from '../lib/theme';
+  import { layout, setLayoutPersisted } from '../lib/layout';
 
   type LazyComponent = Component<Record<string, unknown>>;
 
@@ -387,6 +388,37 @@
             <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
           </svg>
           Dark
+        </button>
+      </div>
+
+      <!-- Layout — device-local, opt-in sidebar shell -->
+      <div class="section-label">Layout</div>
+      <div class="theme-switcher" role="radiogroup" aria-label="Layout">
+        <button type="button"
+          class="theme-option"
+          class:active={$layout === 'classic'}
+          role="radio"
+          aria-checked={$layout === 'classic'}
+          onclick={() => setLayoutPersisted('classic')}
+        >
+          <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="4" width="18" height="16" rx="2"></rect>
+            <line x1="3" y1="9" x2="21" y2="9"></line>
+          </svg>
+          Classic
+        </button>
+        <button type="button"
+          class="theme-option"
+          class:active={$layout === 'sidebar'}
+          role="radio"
+          aria-checked={$layout === 'sidebar'}
+          onclick={() => setLayoutPersisted('sidebar')}
+        >
+          <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="4" width="18" height="16" rx="2"></rect>
+            <line x1="9" y1="4" x2="9" y2="20"></line>
+          </svg>
+          Sidebar
         </button>
       </div>
 

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -342,12 +342,11 @@
 
       <!-- Theme -->
       <div class="section-label">Theme</div>
-      <div class="theme-switcher" role="radiogroup" aria-label="Theme">
+      <div class="theme-switcher" role="group" aria-label="Theme">
         <button type="button"
           class="theme-option"
           class:active={theme === 'system'}
-          role="radio"
-          aria-checked={theme === 'system'}
+          aria-pressed={theme === 'system'}
           onclick={() => setTheme('system')}
         >
           <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -360,8 +359,7 @@
         <button type="button"
           class="theme-option"
           class:active={theme === 'light'}
-          role="radio"
-          aria-checked={theme === 'light'}
+          aria-pressed={theme === 'light'}
           onclick={() => setTheme('light')}
         >
           <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -380,8 +378,7 @@
         <button type="button"
           class="theme-option"
           class:active={theme === 'dark'}
-          role="radio"
-          aria-checked={theme === 'dark'}
+          aria-pressed={theme === 'dark'}
           onclick={() => setTheme('dark')}
         >
           <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -393,12 +390,11 @@
 
       <!-- Layout — device-local, opt-in sidebar shell -->
       <div class="section-label">Layout</div>
-      <div class="theme-switcher" role="radiogroup" aria-label="Layout">
+      <div class="theme-switcher" role="group" aria-label="Layout">
         <button type="button"
           class="theme-option"
           class:active={$layout === 'classic'}
-          role="radio"
-          aria-checked={$layout === 'classic'}
+          aria-pressed={$layout === 'classic'}
           onclick={() => setLayoutPersisted('classic')}
         >
           <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -410,8 +406,7 @@
         <button type="button"
           class="theme-option"
           class:active={$layout === 'sidebar'}
-          role="radio"
-          aria-checked={$layout === 'sidebar'}
+          aria-pressed={$layout === 'sidebar'}
           onclick={() => setLayoutPersisted('sidebar')}
         >
           <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -424,15 +419,14 @@
 
       <!-- Accent -->
       <div class="section-label">Accent</div>
-      <div class="accent-swatches" role="radiogroup" aria-label="Accent colour">
+      <div class="accent-swatches" role="group" aria-label="Accent colour">
         {#each ACCENTS as a (a)}
           <button
             type="button"
             class="accent-swatch"
             class:active={accent === a}
             style="--sw: {ACCENT_SWATCHES[a]}"
-            role="radio"
-            aria-checked={accent === a}
+            aria-pressed={accent === a}
             aria-label={ACCENT_LABELS[a]}
             title={ACCENT_LABELS[a]}
             onclick={() => setAccent(a)}

--- a/packages/web/src/lib/constants.ts
+++ b/packages/web/src/lib/constants.ts
@@ -36,3 +36,10 @@ export const PRESET_COLORS = [
   '#a1a1aa',
   '#6b7280',
 ];
+
+/** Pick a random colour from the preset palette. Used as the default for newly
+ *  created groups/collections so we don't always land on the first swatch when
+ *  the user hasn't explicitly chosen one. */
+export function randomPresetColor(): string {
+  return PRESET_COLORS[Math.floor(Math.random() * PRESET_COLORS.length)];
+}

--- a/packages/web/src/lib/drag.ts
+++ b/packages/web/src/lib/drag.ts
@@ -1,0 +1,15 @@
+/**
+ * Cross-component drag state for assigning items onto sidebar collections.
+ *
+ * Native HTML5 drag-and-drop carries the item id in the drag's dataTransfer,
+ * so the drop target reads it directly. This store exists only so drop targets
+ * (sidebar collections) can light up *while* a compatible drag is in progress —
+ * dataTransfer contents aren't readable during dragover for security reasons.
+ */
+import { writable } from 'svelte/store';
+
+/** Id of the inbox item currently being dragged, or null when no drag. */
+export const draggingItemId = writable<string | null>(null);
+
+/** Custom MIME so only our item drags activate collection drop targets. */
+export const DRAG_MIME = 'application/x-inbox-item';

--- a/packages/web/src/lib/layout.test.ts
+++ b/packages/web/src/lib/layout.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
+import { get } from 'svelte/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getLayout, setLayout } from './layout';
+import { getLayout, layout, setLayout, setLayoutPersisted } from './layout';
 
 afterEach(() => {
   localStorage.clear();
@@ -42,5 +43,19 @@ describe('setLayout', () => {
       throw new DOMException('blocked', 'SecurityError');
     });
     expect(() => setLayout('sidebar')).not.toThrow();
+  });
+});
+
+describe('setLayoutPersisted', () => {
+  afterEach(() => setLayoutPersisted('classic'));
+
+  it('updates the reactive store and persists to storage', () => {
+    setLayoutPersisted('sidebar');
+    expect(get(layout)).toBe('sidebar');
+    expect(localStorage.getItem('inbox-rs:layout')).toBe('sidebar');
+
+    setLayoutPersisted('classic');
+    expect(get(layout)).toBe('classic');
+    expect(localStorage.getItem('inbox-rs:layout')).toBe('classic');
   });
 });

--- a/packages/web/src/lib/layout.ts
+++ b/packages/web/src/lib/layout.ts
@@ -4,6 +4,8 @@
  * 'classic' is the established top-nav layout; 'sidebar' is the opt-in redesign.
  */
 
+import { writable } from 'svelte/store';
+
 export type Layout = 'classic' | 'sidebar';
 
 const LAYOUT_KEY = 'inbox-rs:layout';
@@ -32,4 +34,17 @@ export function setLayout(layout: Layout): void {
   } catch {
     // storage unavailable — selection won't persist across reloads
   }
+}
+
+/**
+ * Reactive current layout. Initialised from storage; `setLayoutPersisted`
+ * updates it so the shell swaps live (no reload) when the user flips the
+ * setting in the UserMenu. Device-local only — never synced.
+ */
+export const layout = writable<Layout>(getLayout());
+
+/** Persist and broadcast a layout change so the active shell swaps live. */
+export function setLayoutPersisted(next: Layout): void {
+  setLayout(next);
+  layout.set(next);
 }

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -69,6 +69,7 @@ import {
   deleteItem,
   groupCollections,
   groups,
+  inactiveCollectionIds,
   items,
   loadFileBlobUrl,
   moveCollectionToGroup,
@@ -87,6 +88,7 @@ import {
   storeGroup,
   storeItem,
   todoItems,
+  toggleCollectionFilter,
   toggleGroupFilter,
   userSettings,
   visibleGroupedCollections,
@@ -1216,6 +1218,51 @@ describe('visibleGroupedCollections', () => {
     groups.set({ g1: makeGroup('g1', []) });
     appConfig.set({ activeGroupFilters: [] });
     expect(get(visibleGroupedCollections)).toHaveLength(0);
+  });
+
+  it('hides individual collections switched off via the sidebar', () => {
+    const c1 = makeCollection('c1', 'g1');
+    const c2 = makeCollection('c2', 'g1');
+    collections.set({ c1, c2 });
+    groups.set({ g1: makeGroup('g1', ['c1', 'c2']) });
+    appConfig.set({ inactiveCollectionFilters: ['c1'] });
+
+    const sections = get(visibleGroupedCollections);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].collections.map((c) => c.id)).toEqual(['c2']);
+  });
+});
+
+describe('collection filter (sidebar)', () => {
+  beforeEach(() => {
+    items.set({});
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+    vi.clearAllMocks();
+    mockInbox.setConfig.mockResolvedValue(undefined);
+  });
+
+  it('inactiveCollectionIds reflects the configured deny-list', () => {
+    appConfig.set({ inactiveCollectionFilters: ['c1', 'c2'] });
+    const ids = get(inactiveCollectionIds);
+    expect(ids.has('c1')).toBe(true);
+    expect(ids.has('c2')).toBe(true);
+    expect(ids.has('c3')).toBe(false);
+  });
+
+  it('is empty when no collections are switched off', () => {
+    appConfig.set({});
+    expect(get(inactiveCollectionIds).size).toBe(0);
+  });
+
+  it('toggleCollectionFilter adds then removes an id', async () => {
+    appConfig.set({});
+    await toggleCollectionFilter('c1');
+    expect(get(appConfig).inactiveCollectionFilters).toEqual(['c1']);
+
+    await toggleCollectionFilter('c1');
+    expect(get(appConfig).inactiveCollectionFilters).toEqual([]);
   });
 });
 

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -1306,9 +1306,21 @@ export const activeGroupIds = derived(
 );
 
 /**
+ * Collection IDs explicitly switched OFF in the sidebar layout (a deny-list).
+ * A collection is hidden when its id is here, independent of its group's
+ * active state. Stale ids (deleted collections) are harmless — views
+ * intersect this against real collections at read time.
+ */
+export const inactiveCollectionIds = derived(
+  appConfig,
+  ($config) => new Set($config.inactiveCollectionFilters ?? []),
+);
+
+/**
  * Group + collection bundle, in the configured group order, filtered by
  * activeGroupIds. Within each group, collections preserve the configured
- * order from groupCollections.
+ * order from groupCollections, minus any individually switched off via the
+ * sidebar (inactiveCollectionIds).
  *
  */
 export interface VisibleGroupSection {
@@ -1317,16 +1329,20 @@ export interface VisibleGroupSection {
 }
 
 export const visibleGroupedCollections = derived(
-  [sortedGroups, groupCollections, activeGroupIds],
+  [sortedGroups, groupCollections, activeGroupIds, inactiveCollectionIds],
   ([
     $sortedGroups,
     $groupCollections,
     $activeGroupIds,
+    $inactiveCollectionIds,
   ]): VisibleGroupSection[] => {
     const sections: VisibleGroupSection[] = [];
     for (const g of $sortedGroups) {
       if (!$activeGroupIds.has(g.id)) continue;
-      sections.push({ group: g, collections: $groupCollections[g.id] ?? [] });
+      const collections = ($groupCollections[g.id] ?? []).filter(
+        (c) => !$inactiveCollectionIds.has(c.id),
+      );
+      sections.push({ group: g, collections });
     }
     return sections;
   },
@@ -1390,6 +1406,22 @@ export async function setActiveGroupFilters(ids: string[]): Promise<void> {
   await updateConfig({ activeGroupFilters: filtered });
 }
 
+/**
+ * Toggle a single collection's visibility on/off (sidebar layout). Persists to
+ * config as a deny-list entry — see `inactiveCollectionIds`. Independent of the
+ * collection's group filter.
+ */
+export async function toggleCollectionFilter(
+  collectionId: string,
+): Promise<void> {
+  const config = get(appConfig);
+  const current = config.inactiveCollectionFilters ?? [];
+  const next = current.includes(collectionId)
+    ? current.filter((id) => id !== collectionId)
+    : [...current, collectionId];
+  await updateConfig({ inactiveCollectionFilters: next });
+}
+
 // ---- Flat Todos page: all todos across all collections ----
 
 /**
@@ -1412,14 +1444,21 @@ export const openTodos = derived(allTodos, ($allTodos) =>
  * and open todos are mixed — the page splits them at render time.
  */
 export const visibleTodos = derived(
-  [allTodos, collections, activeGroupIds, appConfig],
-  ([$allTodos, $collections, $activeGroupIds, $config]) => {
+  [allTodos, collections, activeGroupIds, inactiveCollectionIds, appConfig],
+  ([
+    $allTodos,
+    $collections,
+    $activeGroupIds,
+    $inactiveCollectionIds,
+    $config,
+  ]) => {
     const filtered = $allTodos.filter((todo) => {
       if (!todo.collectionId) return true;
       const col = $collections[todo.collectionId];
       if (!col) return true;
       if (!col.groupId) return false;
-      return $activeGroupIds.has(col.groupId);
+      if (!$activeGroupIds.has(col.groupId)) return false;
+      return !$inactiveCollectionIds.has(col.id);
     });
 
     return sortWithConfiguredOrder(


### PR DESCRIPTION
## Summary

Phase 2b/3 of the inbox redesign: an **opt-in left-sidebar shell** that replaces the top horizontal group bar, with low-friction organizing (inline creation, drag-to-file) so you rarely need a modal or a page switch.

Toggle it in the user menu (**Layout: Classic / Sidebar**) — device-local, swaps live. Only one shell renders at a time.

## What's included

- **Swappable shell** — `App.svelte` picks `ClassicShell` vs `SidebarShell` from a reactive `layout` store; the sidebar *replaces* the top group bar.
- **Groups + collections** in a collapsible sidebar: groups with collections indented, per-group expand/collapse, item counts.
- **Active/inactive filtering** at both levels — toggle a whole group or an individual collection (new `inactiveCollectionFilters` deny-list, applied in `visibleGroupedCollections` + `visibleTodos`).
- **Inline creation** — hover a group → `+` opens an in-place input to create a collection (`createCollection`); same for "New group" (`storeGroup`). No modal, no page switch.
- **Drag to file** — drag inbox cards (and todos, via the collection-pill handle) onto a sidebar collection: filing-mode banner, drop-target highlight + "File here", group rows recede (only collections accept drops; inactive ones still do), count pulse, and an **Undo** toast that restores the previous collection. Spring-loaded groups auto-expand on drag-hover.
  - Todo dragging uses native HTML5 drag from the pill so it doesn't conflict with the existing `svelte-dnd-action` row reorder.
- **Collapsed rail** — groups shown as colour circles (full = active, faded = off, click to toggle): a left rail on desktop, a horizontal top rail on mobile.
- **Responsive** — the inbox grid uses container queries so cards reflow to the available width as the sidebar expands/collapses; the sidebar collapses vertically on mobile.

Cards remain shared components, so the classic layout inherits the card/filter improvements too.

## Not included (deliberate)
- A standalone "File to…" picker — the card's view modal already has a **Move/Collect** collection picker that works on touch + keyboard, so a separate one would be redundant.
- Drag-to-refile from *within* a collection view (those todos use the card Move menu).
- Touch drag-and-drop (native HTML5 drag is pointer-only); filing on touch is via the card Move menu.

## Testing
- Verified live in the browser: shell swap, group/collection toggles + filtering, inline collection/group creation, inbox-card and todo drag-to-file with Undo, spring-load, collapsed rail (desktop + mobile), card reflow, mobile vertical collapse.
- `vitest` web suite was green (409 passing) before the final CSS-only layout fixes; those are markup/CSS-only and the CSS-guard test passes. Note: this sandbox is resource-constrained and intermittently can't spawn vitest workers / finish `npm run build`, so a clean CI run on GitHub is worth confirming.

🤖 Draft — opened for review of the whole branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new sidebar layout option, with an in-app switch to choose between Classic and Sidebar views.
  * Introduced drag-and-drop for moving items between collections, including visual feedback and undo support.
  * Collection and group creation now use varied default colors.

* **Bug Fixes**
  * Improved collection visibility controls so hidden collections stay out of relevant lists and todos.
  * Refined inbox layout behavior on smaller screens for better spacing and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->