### PR TITLE
fix(capture): keep send button above keyboard + refocus input after send

### DIFF
--- a/packages/web/capture/index.html
+++ b/packages/web/capture/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <title>Inbox RS Capture</title>
     <link rel="icon" href="/src/assets/logos/favicon-shield.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />

--- a/packages/web/src/capture/App.svelte
+++ b/packages/web/src/capture/App.svelte
@@ -34,6 +34,7 @@
 
   let mode = $state<CaptureMode>('note');
   let noteText = $state('');
+  let noteField = $state<HTMLTextAreaElement | null>(null);
   let history = $state<CaptureRecord[]>([]);
   let status = $state('');
   let syncing = $state(false);
@@ -85,6 +86,18 @@
     status = idleStatus();
     void syncNow();
 
+    // Drive the app height from the *visual* viewport so the layout shrinks when
+    // the on-screen keyboard opens, keeping the Send button above it. The layout
+    // viewport (100%/100vh) ignores the keyboard, which otherwise hides Send.
+    const vv = window.visualViewport;
+    const applyViewportHeight = () => {
+      const h = vv ? vv.height : window.innerHeight;
+      document.documentElement.style.setProperty('--app-height', `${h}px`);
+    };
+    applyViewportHeight();
+    vv?.addEventListener('resize', applyViewportHeight);
+    vv?.addEventListener('scroll', applyViewportHeight);
+
     const onOnline = () => void syncNow();
     const onInstallPrompt = (event: Event) => {
       event.preventDefault();
@@ -97,6 +110,8 @@
       if (recording && mediaRecorder) {
         for (const track of mediaRecorder.stream.getTracks()) track.stop();
       }
+      vv?.removeEventListener('resize', applyViewportHeight);
+      vv?.removeEventListener('scroll', applyViewportHeight);
       window.removeEventListener('online', onOnline);
       window.removeEventListener('beforeinstallprompt', onInstallPrompt);
       if (recordTimer) clearInterval(recordTimer);
@@ -116,6 +131,9 @@
     if (mode === 'note') {
       captureNote(noteText);
       noteText = '';
+      // Refocus synchronously (still within the tap gesture) so the keyboard
+      // stays up for rapid write → send → write entry.
+      noteField?.focus();
     } else if (mode === 'voice' && recordedBlob) {
       await captureVoice(recordedBlob, recordDuration);
       clearVoice();
@@ -348,6 +366,7 @@
     {#if mode === 'note'}
       <textarea
         class="field"
+        bind:this={noteField}
         bind:value={noteText}
         use:autofocus
         onkeydown={onNoteKey}
@@ -521,7 +540,7 @@
 
 <style>
   .screen {
-    height: 100%;
+    height: var(--app-height, 100%);
     width: min(100%, 30rem);
     margin: 0 auto;
     display: flex;


### PR DESCRIPTION
## Problem

On phones, two papercuts hurt rapid capture:

1. **Keyboard covers the Send button.** Tapping the note field raised the keyboard, which overlapped Send — you couldn't tap it without dismissing the keyboard first.
2. **Focus is lost after sending.** After each send you had to re-tap the field to keep typing, breaking the write → send → write → send rhythm.

## Changes

**Keyboard no longer covers Send**
- The screen was sized with `height: 100%`, which tracks the *layout* viewport and ignores the on-screen keyboard. It now uses `height: var(--app-height, 100%)`, driven by a `visualViewport` resize/scroll listener that writes the live visible height — so the layout shrinks to the space above the keyboard and Send stays in view. Listeners are cleaned up on unmount.
- Added `interactive-widget=resizes-content` to the viewport meta so Chrome Android resizes content instead of overlaying the keyboard.

**Focus returns to the input after send**
- Added `bind:this` on the note textarea and call `.focus()` synchronously within the send tap gesture (before any `await`), so iOS/Android keep the keyboard up for rapid consecutive entry.

Voice/image modes are unchanged (no keyboard involved); the History/Settings sheets already scroll, so they're left as-is.

## Testing
- `npm run -w @inbox-rs/web build` passes.
- Manual: on a phone, tap the note field — Send sits just above the keyboard; after each send the cursor stays in the field.
