### PR TITLE
fix(web): keep user menu in header row on mobile sidebar view

### DIFF
--- a/packages/web/src/components/SidebarShell.svelte
+++ b/packages/web/src/components/SidebarShell.svelte
@@ -1057,9 +1057,37 @@
      when collapsed it's hidden entirely (the header toggle re-opens it), rather
      than shrinking to a side rail that makes no sense in a single column. */
   @media (max-width: 768px) {
+    /* Flex-wrap would let the user menu spill onto its own line below the nav on
+       narrow screens. Use a grid instead (like ClassicShell): toggle, brand and
+       the user menu share the top row; the nav spans a full second row. */
     .header-inner {
-      flex-wrap: wrap;
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      grid-template-rows: auto auto;
+      gap: 0.5rem 0.75rem;
+      align-items: center;
       padding: 0.75rem 1rem;
+    }
+
+    .sidebar-toggle {
+      grid-column: 1;
+      grid-row: 1;
+    }
+
+    .brand {
+      grid-column: 2;
+      grid-row: 1;
+    }
+
+    .header-right {
+      grid-column: 3;
+      grid-row: 1;
+    }
+
+    .header-nav {
+      grid-column: 1 / -1;
+      grid-row: 2;
+      justify-content: center;
     }
 
     .body,


### PR DESCRIPTION
## Problem

On smaller mobile displays in the **sidebar** view, the user menu drops down *below* the nav (collection) bar instead of staying in the top header row. This doesn't happen in the classic view.

## Cause

`SidebarShell`'s mobile header used `flex-wrap: wrap` on `.header-inner`. The toggle, brand, nav, and user menu are all flex siblings, so once the row runs out of width the user menu wraps onto its own line beneath the wide nav bar.

`ClassicShell` avoids this by switching to a CSS **grid** at the same breakpoint (brand + user menu on row 1, nav spanning a full row 2).

## Fix

Apply the same grid approach to `SidebarShell`'s `@media (max-width: 768px)` header, accounting for its extra sidebar-toggle button:

- Row 1: `[toggle] [brand] … [user menu]` via `grid-template-columns: auto 1fr auto`
- Row 2: the nav spans the full width (`grid-column: 1 / -1`)

## Testing
- `npm run -w @inbox-rs/web build` passes.
- Manual: at narrow widths in sidebar view, the user menu now stays top-right alongside the brand; the nav sits on its own row below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the mobile header layout for the sidebar shell.
  * Reworked the top bar into a cleaner two-row arrangement on smaller screens, keeping the toggle, brand, and user menu on the first row and the main navigation on the second.
  * Updated spacing to better match the new layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->