### PR TITLE
feat(deploy): add branch-selectable staging publish method

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,84 @@
+name: Deploy to Staging
+
+# Secondary publishing method: builds an arbitrary branch and deploys just the
+# web app's dist/ to the staging 5apps site (inbox-staging.5apps.com).
+#
+# Unlike release.yml this does NOT bump versions, tag, push to origin, or cut a
+# GitHub Release — it only builds the selected branch and ships the built
+# artifacts to the staging remote. Nothing about origin/master is touched.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to build and deploy to staging
+        required: true
+        type: string
+        default: master
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          # Full history is required — `git subtree split` walks the whole
+          # commit graph, so a shallow clone (checkout's default fetch-depth: 1)
+          # would break the deploy.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+      - run: npm install @rollup/rollup-linux-x64-gnu --no-save
+
+      - name: Restore transcription asset cache
+        uses: actions/cache@v4
+        with:
+          path: packages/web/public/ml
+          key: ${{ runner.os }}-transcription-assets-${{ hashFiles('scripts/vendor-transcription-assets.mjs', 'package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-transcription-assets-
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Build web app
+        run: npm run build
+
+      - name: Setup SSH for 5apps
+        env:
+          FIVEAPPS_DEPLOY_KEY: ${{ secrets.FIVEAPPS_DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$FIVEAPPS_DEPLOY_KEY" > ~/.ssh/5apps_key
+          chmod 600 ~/.ssh/5apps_key
+          ssh-keyscan -H 5apps.com >> ~/.ssh/known_hosts
+          echo -e "Host 5apps.com\n  IdentityFile ~/.ssh/5apps_key" >> ~/.ssh/config
+
+      - name: Deploy to 5apps staging
+        # Force-add build artifacts onto a throwaway deploy branch, extract just
+        # the dist/ subtree, and push that to the staging remote. The deploy
+        # commit is never pushed to origin.
+        env:
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          git remote add 5apps-staging git@5apps.com:silverbucket_inbox-rs-staging.git 2>/dev/null \
+            || git remote set-url 5apps-staging git@5apps.com:silverbucket_inbox-rs-staging.git
+
+          # Throwaway branch for the deploy commit so nothing local is pushed to origin.
+          git checkout -b "staging-deploy/${{ github.run_id }}"
+          git add packages/web/dist -f
+          git commit -m "deploy ${BRANCH} to staging [skip ci]"
+
+          SPLIT_SHA=$(git subtree split --prefix=packages/web/dist)
+          git push 5apps-staging "$SPLIT_SHA":refs/heads/master --force

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -53,6 +53,10 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Build web app
+        # STAGING_BUILD=1 turns on sourcemaps + the __STAGING__ debug flag
+        # (see packages/web/vite.config.ts).
+        env:
+          STAGING_BUILD: '1'
         run: npm run build
 
       - name: Setup SSH for 5apps

--- a/packages/web/src/Root.svelte
+++ b/packages/web/src/Root.svelte
@@ -2,6 +2,7 @@
   import type { Component } from 'svelte';
   import { onMount } from 'svelte';
   import LogoShield from './components/LogoShield.svelte';
+  import StagingBadge from './components/StagingBadge.svelte';
 
   let FullApp = $state<Component | null>(null);
   let failed = $state(false);
@@ -17,6 +18,8 @@
       });
   });
 </script>
+
+<StagingBadge />
 
 {#if FullApp}
   <FullApp />

--- a/packages/web/src/capture/App.svelte
+++ b/packages/web/src/capture/App.svelte
@@ -26,6 +26,7 @@
     initTheme,
     type Mode,
   } from './theme';
+  import StagingBadge from '../components/StagingBadge.svelte';
 
   type BeforeInstallPromptEvent = Event & {
     prompt: () => Promise<void>;
@@ -299,6 +300,8 @@
     });
   }
 </script>
+
+<StagingBadge />
 
 <main class="screen">
   <header class="topbar">

--- a/packages/web/src/components/StagingBadge.svelte
+++ b/packages/web/src/components/StagingBadge.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  // A small fixed corner badge marking non-production (staging) builds.
+  // Renders nothing in production: __STAGING__ is a build-time constant
+  // (see vite.config.ts), so this whole block is dead-code-eliminated there.
+</script>
+
+{#if __STAGING__}
+  <div class="staging-badge" role="status" aria-label="Staging build">
+    STAGING
+  </div>
+{/if}
+
+<style>
+  .staging-badge {
+    position: fixed;
+    bottom: 0.5rem;
+    left: 0.5rem;
+    z-index: 2147483647;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    background: #b45309;
+    color: #fff;
+    font-size: 0.65rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    line-height: 1.4;
+    /* Purely informational — never intercept clicks on the UI beneath it. */
+    pointer-events: none;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+  }
+</style>

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -2,3 +2,4 @@
 /// <reference types="vite/client" />
 
 declare const __APP_VERSION__: string;
+declare const __STAGING__: boolean;

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -10,6 +10,11 @@ const { version } = JSON.parse(
   readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'),
 );
 
+// Staging builds (STAGING_BUILD=1, set by the staging deploy paths) emit
+// sourcemaps and flip __STAGING__ so the app can surface extra debugging
+// help. Production builds leave both off — nothing here changes for them.
+const isStaging = process.env.STAGING_BUILD === '1';
+
 export default defineConfig({
   plugins: [
     svelte(),
@@ -39,6 +44,7 @@ export default defineConfig({
   ],
   define: {
     __APP_VERSION__: JSON.stringify(version),
+    __STAGING__: JSON.stringify(isStaging),
   },
   server: {
     port: 5173,
@@ -61,6 +67,9 @@ export default defineConfig({
     // 89 / Firefox 89 / Safari 15 — all 2021 baselines, well below our
     // supported floor.
     target: ['chrome89', 'edge89', 'firefox89', 'safari15'],
+    // Emit full external sourcemaps for staging so runtime errors map back to
+    // original TypeScript/Svelte. Off for production to keep source private.
+    sourcemap: isStaging,
     rollupOptions: {
       input: {
         main: path.resolve(__dirname, 'index.html'),

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -29,9 +29,10 @@ git pull --ff-only
 git remote add 5apps-staging "$STAGING_REMOTE_URL" 2>/dev/null \
   || git remote set-url 5apps-staging "$STAGING_REMOTE_URL"
 
-# ── 4. Build. ─────────────────────────────────────────────────────────────────
+# ── 4. Build. STAGING_BUILD=1 turns on sourcemaps + the __STAGING__ debug flag
+#       (see packages/web/vite.config.ts). ──────────────────────────────────────
 npm install
-npm run build
+STAGING_BUILD=1 npm run build
 
 # ── 5. Deploy to staging via a throwaway branch (dist/ never lands on origin) ─
 DEPLOY_BRANCH="staging-deploy/${BRANCH//\//-}"

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Manual staging deploy script.
+# Usage: ./scripts/deploy-staging.sh [branch]   (defaults to the current branch)
+#
+# Secondary publishing method — builds the given branch and ships just the web
+# app's dist/ to the staging 5apps site (inbox-staging.5apps.com). Unlike
+# scripts/deploy.sh this does NOT bump versions, tag, or push anything to
+# origin. Nothing about origin/master is touched.
+
+set -euo pipefail
+
+STAGING_REMOTE_URL="git@5apps.com:silverbucket_inbox-rs-staging.git"
+
+# Branch to deploy — argument, or whatever is currently checked out.
+BRANCH="${1:-$(git rev-parse --abbrev-ref HEAD)}"
+
+# ── 1. Refuse to run on a dirty tree — the deploy commits build artifacts and
+#       we don't want to sweep up unrelated local changes. ─────────────────────
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: working tree is dirty. Commit or stash your changes first." >&2
+  exit 1
+fi
+
+# ── 2. Check out the requested branch and fetch its latest state. ─────────────
+git checkout "$BRANCH"
+git pull --ff-only
+
+# ── 3. Ensure the staging remote exists / points at the right repo. ───────────
+git remote add 5apps-staging "$STAGING_REMOTE_URL" 2>/dev/null \
+  || git remote set-url 5apps-staging "$STAGING_REMOTE_URL"
+
+# ── 4. Build. ─────────────────────────────────────────────────────────────────
+npm install
+npm run build
+
+# ── 5. Deploy to staging via a throwaway branch (dist/ never lands on origin) ─
+DEPLOY_BRANCH="staging-deploy/${BRANCH//\//-}"
+git branch -D "$DEPLOY_BRANCH" 2>/dev/null || true
+git checkout -b "$DEPLOY_BRANCH"
+git add packages/web/dist -f
+git commit -m "deploy ${BRANCH} to staging [skip ci]"
+
+SPLIT_SHA=$(git subtree split --prefix=packages/web/dist)
+git push 5apps-staging "$SPLIT_SHA":refs/heads/master --force
+
+# Return to the original branch; the deploy branch is local-only.
+git checkout "$BRANCH"
+git branch -D "$DEPLOY_BRANCH"
+
+echo ""
+echo "✓ ${BRANCH} deployed to staging (inbox-staging.5apps.com). Nothing was pushed to origin."


### PR DESCRIPTION
## Summary

Adds a secondary publishing method targeting the staging site (`inbox-staging.5apps.com`), separate from the production release/deploy flow. Both entry points let you pick which branch to ship and deploy **only** the built `packages/web/dist` — no version bump, no tag, no push to `origin`, no GitHub Release.

## What's included

- **`.github/workflows/staging.yml`** — manual `workflow_dispatch` with a `branch` input (defaults to `master`). Checks out the selected branch with `fetch-depth: 0` (full history — `git subtree split` needs it; a shallow clone would break the deploy), builds, and force-pushes the `dist/` subtree to `git@5apps.com:silverbucket_inbox-rs-staging.git`. Reuses the existing `FIVEAPPS_DEPLOY_KEY` secret and the same subtree-split deploy pattern as `release.yml`.
- **`scripts/deploy-staging.sh [branch]`** — local equivalent, mirroring `scripts/deploy.sh`. Deploys the given (or current) branch, refuses to run on a dirty tree, and auto-creates the `5apps-staging` remote.

## Notes / prerequisites

- The staging repo must exist on 5apps.
- `FIVEAPPS_DEPLOY_KEY` needs push access to the **staging** repo (add it as a deploy key there if it's currently scoped to production only).
- `package-lock.json` had a pre-existing unrelated modification; left out of this PR.