### PR TITLE
chore: sync package-lock.json workspace versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9116,7 +9116,7 @@
     },
     "packages/extension": {
       "name": "@inbox-rs/extension",
-      "version": "2.3.0",
+      "version": "2.3.3",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "remotestoragejs": "^2.0.0-beta.9",
@@ -9173,7 +9173,7 @@
     },
     "packages/rs-module": {
       "name": "@inbox-rs/rs-module",
-      "version": "2.3.2",
+      "version": "2.3.4",
       "dependencies": {
         "remotestoragejs": "^2.0.0-beta.9",
         "rs-migrate": "^1.0.2"
@@ -9185,7 +9185,7 @@
     },
     "packages/thunderbird": {
       "name": "@inbox-rs/thunderbird",
-      "version": "2.3.0",
+      "version": "2.3.3",
       "dependencies": {
         "@inbox-rs/rs-module": "*"
       },
@@ -9239,7 +9239,7 @@
     },
     "packages/web": {
       "name": "@inbox-rs/web",
-      "version": "2.3.2",
+      "version": "2.3.4",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "@tiptap/core": "^3.22.1",
@@ -9311,7 +9311,7 @@
     },
     "scripts": {
       "name": "@inbox-rs/scripts",
-      "version": "2.3.2",
+      "version": "2.3.4",
       "devDependencies": {
         "vitest": "^4.1.2"
       }


### PR DESCRIPTION
## Summary

Regenerates `package-lock.json` so its workspace `version` fields match the current `package.json` versions.

The release flow (`scripts/release-bump.mjs`) writes new versions into each package's `package.json` but never regenerates the lockfile, so the lock's workspace `version` entries drift one or more releases behind. This brings them back in sync:

- `@inbox-rs/extension`, `@inbox-rs/thunderbird` → `2.3.3`
- `@inbox-rs/rs-module`, `@inbox-rs/web`, `@inbox-rs/scripts` → `2.3.4`

Produced with `npm install --package-lock-only`. **No dependency additions, removals, or version changes** — only the workspace self-version fields.

## Follow-up (optional)

To stop this drift recurring, `release-bump.mjs` could run `npm install --package-lock-only` after editing the package.json versions.