### PR TITLE
perf(web): cut SW precache 2.2MB→0.9MB; protect /capture/ navigations

### DIFF
--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -37,8 +37,40 @@ export default defineConfig({
         ],
         cleanupOutdatedCaches: true,
         navigateFallback: '/index.html',
+        // The quick-capture app is its own shell (capture/index.html). Without
+        // this, any /capture/ navigation that isn't an exact precache match
+        // (query params from OAuth redirects or a future share_target, sub-
+        // paths) falls through to the MAIN app's index.html and boots the
+        // wrong app inside the capture PWA window.
+        navigateFallbackDenylist: [/^\/capture\//],
         globPatterns: ['**/*.{js,css,html,png,svg,webmanifest,wasm}'],
-        globIgnores: ['ml/**/*'],
+        globIgnores: [
+          'ml/**/*',
+          // Lazy-only heavyweights (~1.4 MB minified combined). They're
+          // dynamic-imported and most sessions never execute them, yet
+          // precaching forces every visitor to download them on install and
+          // re-download on every release (content hashes change). Excluding
+          // them cuts the precache from ~2.2 MB to ~0.85 MB; the runtime
+          // CacheFirst route below still makes them offline-available after
+          // first use (hashed filenames are immutable, so CacheFirst is safe).
+          'assets/transformers-*.js',
+          'assets/MarkdownEditor-*.js',
+          'assets/MarkdownEditor-*.css',
+        ],
+        runtimeCaching: [
+          {
+            urlPattern: /\/assets\/(transformers|MarkdownEditor)-[^/]*\.(js|css)$/,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'lazy-chunks',
+              expiration: {
+                maxEntries: 12,
+                maxAgeSeconds: 60 * 60 * 24 * 60, // 60 days
+              },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+        ],
       },
     }),
   ],

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -59,7 +59,8 @@ export default defineConfig({
         ],
         runtimeCaching: [
           {
-            urlPattern: /\/assets\/(transformers|MarkdownEditor)-[^/]*\.(js|css)$/,
+            urlPattern:
+              /\/assets\/(transformers|MarkdownEditor)-[^/]*\.(js|css)$/,
             handler: 'CacheFirst',
             options: {
               cacheName: 'lazy-chunks',


### PR DESCRIPTION
**perf(web): cut SW precache from 2.2 MB to 0.9 MB; protect /capture/ navigations**

Excludes the dynamic-imported `transformers` (825 kB) and `MarkdownEditor` (553 kB) chunks from the Workbox precache and serves them via a runtime `CacheFirst` route instead. Measured: 77 entries / 2233 KiB → 74 entries / 885 KiB. Offline transcription/editing still work after first use (hashed filenames are immutable). Also adds `navigateFallbackDenylist: [/^\/capture\//]` so capture navigations with query params (OAuth, share_target) can't fall through to the main app shell.

Trade-off documented in the diff: an update touching MarkdownEditor isn't pre-fetched, so the first note-edit after a deploy needs network once.

---
Part of a 9-PR series imported from `inbox-rs-prs.bundle`. Suggested merge order: 1 → 6 → 3 → 5 → 2 → 7 → 4 → 8 → 9.
