### PR TITLE
perf(web): eliminate O(N²) work during bulk sync

### DIFF
--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -136,6 +136,15 @@ function emitModuleChange(event: {
   if (onChangeHandler) onChangeHandler({ origin: 'remote', ...event });
 }
 
+/**
+ * Item change events are batched (50ms window) before they hit the stores —
+ * see the queueItemChange buffer in stores.ts. Await this after
+ * emitModuleChange for `items/` paths to observe the applied state.
+ */
+async function flushItemChangeBatch() {
+  await new Promise((resolve) => setTimeout(resolve, 60));
+}
+
 /** Backwards-compat: single-handler lookup for events with one handler (e.g. 'connected') */
 const rsHandlers = new Proxy({} as Record<string, (...args: any[]) => any>, {
   get: (_target, prop: string) => {
@@ -871,7 +880,7 @@ describe('per-item change handling', () => {
     appConfig.set({});
   });
 
-  it('adds an incoming item to the store', () => {
+  it('adds an incoming item to the store', async () => {
     const item = {
       id: 'i1',
       type: 'note',
@@ -879,12 +888,13 @@ describe('per-item change handling', () => {
       createdAt: '2026-01-01T00:00:00.000Z',
     };
     emitModuleChange({ relativePath: 'items/i1', newValue: item });
+    await flushItemChangeBatch();
 
     expect(get(items).i1).toBeDefined();
     expect(get(items).i1.title).toBe('Test');
   });
 
-  it('removes a deleted item from the store', () => {
+  it('removes a deleted item from the store', async () => {
     items.set({
       i1: {
         id: 'i1',
@@ -899,6 +909,7 @@ describe('per-item change handling', () => {
       newValue: undefined,
       oldValue: { id: 'i1' },
     });
+    await flushItemChangeBatch();
 
     expect(get(items).i1).toBeUndefined();
   });
@@ -955,7 +966,7 @@ describe('per-item change handling', () => {
     expect(get(items).i1).toBeUndefined();
   });
 
-  it('handles multiple incoming items without calling getAll', () => {
+  it('handles multiple incoming items without calling getAll', async () => {
     for (let i = 0; i < 5; i++) {
       emitModuleChange({
         relativePath: `items/i${i}`,
@@ -967,6 +978,7 @@ describe('per-item change handling', () => {
         },
       });
     }
+    await flushItemChangeBatch();
 
     expect(Object.keys(get(items))).toHaveLength(5);
     expect(mockInbox.getAll).not.toHaveBeenCalled();

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -57,13 +57,25 @@ function stripMigrationVersion<T>(doc: T): T {
   return rest as T;
 }
 
+/**
+ * Memoized per document *reference*: `rawItems` entries are replaced (not
+ * mutated) whenever an item changes, so identity is a safe cache key. Without
+ * this, the derived count below re-runs migrateDocument + two JSON.stringify
+ * passes over EVERY item on EVERY change event — during a first sync of N
+ * items that's O(N²) (~9M ops at 3k items) and freezes the UI.
+ */
+const migrationCheckCache = new WeakMap<object, boolean>();
+
 function requiresContentMigration(doc: object): boolean {
+  const cached = migrationCheckCache.get(doc);
+  if (cached !== undefined) return cached;
   const migrated = migrator.migrateDocument('items', doc as InboxItem);
-  if (migrated === doc) return false;
-  return (
+  const result =
+    migrated !== doc &&
     JSON.stringify(stripMigrationVersion(migrated)) !==
-    JSON.stringify(stripMigrationVersion(doc))
-  );
+      JSON.stringify(stripMigrationVersion(doc));
+  migrationCheckCache.set(doc, result);
+  return result;
 }
 
 /** Count only docs whose non-version content would actually change under migration */
@@ -471,6 +483,47 @@ if (inboxRef) {
     relativePath?: string;
     newValue?: unknown;
   };
+  // Item change events are buffered and flushed as ONE store update per
+  // window. RS fires a separate `change` event for every item a sync cycle
+  // delivers; applying each one individually spreads the whole `items`
+  // record and re-runs every derived store (sortedItems sort, collectionItems
+  // rebuild, migration recount) per event — O(N²) during a bulk sync. A 50ms
+  // window coalesces a sync burst into a handful of updates while staying
+  // imperceptible for a single incoming change. Collections/groups/config
+  // change rarely and are still applied immediately below.
+  const pendingItemChanges = new Map<string, object | null>(); // null = delete
+  let itemFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function flushItemChanges() {
+    itemFlushTimer = null;
+    if (pendingItemChanges.size === 0) return;
+    const batch = new Map(pendingItemChanges);
+    pendingItemChanges.clear();
+    rawItems.update((current) => {
+      const next = { ...current };
+      for (const [key, value] of batch) {
+        if (value) next[key] = value;
+        else delete next[key];
+      }
+      return next;
+    });
+    items.update((current) => {
+      const next = { ...current };
+      for (const [key, value] of batch) {
+        if (value) next[key] = normalizeLoadedItem(value);
+        else delete next[key];
+      }
+      return next;
+    });
+  }
+
+  function queueItemChange(key: string, value: object | null) {
+    pendingItemChanges.set(key, value);
+    if (itemFlushTimer === null) {
+      itemFlushTimer = setTimeout(flushItemChanges, 50);
+    }
+  }
+
   inboxRef.onChange((rawEvent: unknown) => {
     const event = rawEvent as ChangeEvent;
     if (!event || event.origin === 'window') return;
@@ -479,24 +532,11 @@ if (inboxRef) {
 
     if (path.startsWith('items/')) {
       const key = path.slice('items/'.length);
-      if (value && typeof value === 'object' && value.id) {
+      if (value && typeof value === 'object' && 'id' in value) {
         if (key !== (value as { id: string }).id) return;
-        rawItems.update((current) => ({ ...current, [key]: value as object }));
-        items.update((current) => ({
-          ...current,
-          [key]: normalizeLoadedItem(value as object),
-        }));
+        queueItemChange(key, value);
       } else if (!value) {
-        rawItems.update((current) => {
-          const next = { ...current };
-          delete next[key];
-          return next;
-        });
-        items.update((current) => {
-          const next = { ...current };
-          delete next[key];
-          return next;
-        });
+        queueItemChange(key, null);
       }
     } else if (path.startsWith('collections/')) {
       const key = path.slice('collections/'.length);


### PR DESCRIPTION
**perf(web): eliminate O(N²) work during bulk sync**

Two fixes: (a) `requiresContentMigration` memoized per document reference (WeakMap) — the migration recount previously ran migrate + 2× stringify over every item on every change event, ~9M ops for a 3k-item first sync; (b) item change events buffered and flushed as one store update per 50 ms window instead of one full-record spread + derived cascade per event. Tests updated to await the flush window. Also fixes the untyped `value.id` access that only compiled because the package wasn't typechecked.

---
Part of a 9-PR series imported from `inbox-rs-prs.bundle`.
