### PR TITLE
perf(web): SEEN caching, cache-first reads, lazy card media, blob LRU

### DIFF
--- a/packages/web/src/components/AudioCard.svelte
+++ b/packages/web/src/components/AudioCard.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+  import { inview } from '../lib/actions';
   import type { AudioItem } from '@inbox-rs/rs-module';
   import { blobUrls, connected, loadFileBlobUrl } from '../lib/stores';
 
   let { item }: { item: AudioItem } = $props();
   let audioEl = $state<HTMLAudioElement | null>(null);
   let playing = $state(false);
+  // Fetch bytes only once the card approaches the viewport.
+  let entered = $state(false);
 
   const audioSrc = $derived($blobUrls[item.filePath] || null);
 
@@ -26,7 +29,7 @@
   // this so we retry over the network once a connection is established.
   $effect(() => {
     void $connected;
-    if (item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
+    if (entered && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
   });
 
   // Decorative waveform bars derived deterministically from the item id, so
@@ -60,7 +63,7 @@
   }
 </script>
 
-<div class="audio">
+<div class="audio" use:inview={() => { entered = true; }}>
   <h3 class="title">{item.title || 'Voice memo'}</h3>
   <div class="voice">
     <button

--- a/packages/web/src/components/AudioCard.svelte
+++ b/packages/web/src/components/AudioCard.svelte
@@ -26,10 +26,15 @@
   // play. Pass mimeType so the blob is tagged with the clean type from item
   // metadata rather than whatever the server echoes back (e.g.
   // `audio/webm; charset=binary` on 5apps). Referencing `$connected` re-runs
-  // this so we retry over the network once a connection is established.
+  // this so we retry over the network once a connection is established; reading
+  // `$blobUrls[item.filePath]` re-runs it when the LRU cache evicts this path,
+  // so an evicted card reloads on scroll-back instead of losing playback (the
+  // `inview` observer is one-shot, so `entered` alone never fires again).
   $effect(() => {
     void $connected;
-    if (entered && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
+    if (entered && item.filePath && !$blobUrls[item.filePath]) {
+      loadFileBlobUrl(item.filePath, item.mimeType);
+    }
   });
 
   // Decorative waveform bars derived deterministically from the item id, so

--- a/packages/web/src/components/BookmarkCard.svelte
+++ b/packages/web/src/components/BookmarkCard.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+  import { inview } from '../lib/actions';
   import type { BookmarkItem } from '@inbox-rs/rs-module';
   import { blobUrls, connected, loadFileBlobUrl } from '../lib/stores';
   import Lightbox from './Lightbox.svelte';
 
   let { item }: { item: BookmarkItem } = $props();
   let showLightbox = $state(false);
+  // Fetch bytes only once the card approaches the viewport.
+  let entered = $state(false);
 
   const imageSrc = $derived(
     (item.filePath ? ($blobUrls[item.filePath] || null) : null) || item.ogImage || null
@@ -18,11 +21,11 @@
   // network once a connection is established.
   $effect(() => {
     void $connected;
-    if (item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
+    if (entered && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
   });
 </script>
 
-<div class="bookmark">
+<div class="bookmark" use:inview={() => { entered = true; }}>
   {#if imageSrc}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -31,6 +34,8 @@
         class="og-image"
         src={imageSrc}
         alt=""
+        loading="lazy"
+        decoding="async"
         onerror={(e) => (e.currentTarget as HTMLImageElement).style.display = 'none'}
       />
     </div>

--- a/packages/web/src/components/BookmarkCard.svelte
+++ b/packages/web/src/components/BookmarkCard.svelte
@@ -18,10 +18,15 @@
   // with the clean type from item metadata rather than the server's
   // Content-Type (which on 5apps carries the `; charset=binary` suffix that
   // Chrome won't render as <img>). Referencing `$connected` retries over the
-  // network once a connection is established.
+  // network once a connection is established; reading `$blobUrls[item.filePath]`
+  // re-runs it when the LRU cache evicts this path, so an evicted card reloads
+  // on scroll-back instead of going blank (the `inview` observer is one-shot,
+  // so `entered` alone never fires again).
   $effect(() => {
     void $connected;
-    if (entered && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
+    if (entered && item.filePath && !$blobUrls[item.filePath]) {
+      loadFileBlobUrl(item.filePath, item.mimeType);
+    }
   });
 </script>
 

--- a/packages/web/src/components/ImageCard.svelte
+++ b/packages/web/src/components/ImageCard.svelte
@@ -19,10 +19,15 @@
   // as `image/jpeg` rather than whatever the server echoes back (e.g.
   // `image/jpeg; charset=binary` on 5apps, which Chrome refuses to render).
   // Referencing `$connected` re-runs this so we retry over the network once a
-  // connection is established.
+  // connection is established. Reading `$blobUrls[item.filePath]` also re-runs
+  // it when the LRU cache evicts this path (blobUrls entry deleted), so a card
+  // that scrolled out and lost its blob reloads instead of going blank — the
+  // `inview` observer is one-shot, so `entered` alone never fires again.
   $effect(() => {
     void $connected;
-    if (entered && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
+    if (entered && item.filePath && !$blobUrls[item.filePath]) {
+      loadFileBlobUrl(item.filePath, item.mimeType);
+    }
   });
 </script>
 

--- a/packages/web/src/components/ImageCard.svelte
+++ b/packages/web/src/components/ImageCard.svelte
@@ -1,22 +1,28 @@
 <script lang="ts">
+  import { inview } from '../lib/actions';
   import type { ImageItem } from '@inbox-rs/rs-module';
   import { blobUrls, connected, loadFileBlobUrl } from '../lib/stores';
   import Lightbox from './Lightbox.svelte';
 
   let { item }: { item: ImageItem } = $props();
   let showLightbox = $state(false);
+  // Only start fetching bytes once the card approaches the viewport (see the
+  // inview action) — otherwise opening a large inbox fires a fetch for every
+  // image at once.
+  let entered = $state(false);
 
   const imageSrc = $derived($blobUrls[item.filePath] || null);
 
-  // Load the image bytes. loadFileBlobUrl fetches from the remote when
-  // connected and the local cache otherwise, so files captured while offline
-  // still render. Pass mimeType so the blob is tagged as `image/jpeg` rather
-  // than whatever the server echoes back (e.g. `image/jpeg; charset=binary` on
-  // 5apps, which Chrome refuses to render). Referencing `$connected` re-runs
-  // this so we retry over the network once a connection is established.
+  // Load the image bytes once visible. loadFileBlobUrl reads the local cache
+  // first (file paths are immutable) and falls back to the remote, so files
+  // captured while offline still render. Pass mimeType so the blob is tagged
+  // as `image/jpeg` rather than whatever the server echoes back (e.g.
+  // `image/jpeg; charset=binary` on 5apps, which Chrome refuses to render).
+  // Referencing `$connected` re-runs this so we retry over the network once a
+  // connection is established.
   $effect(() => {
     void $connected;
-    if (item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
+    if (entered && item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
   });
 </script>
 
@@ -26,11 +32,13 @@
   {/if}
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="image-wrapper" onclick={(e) => { e.stopPropagation(); if (imageSrc) showLightbox = true; }}>
+  <div class="image-wrapper" use:inview={() => { entered = true; }} onclick={(e) => { e.stopPropagation(); if (imageSrc) showLightbox = true; }}>
     {#if imageSrc}
       <img
         src={imageSrc}
         alt={item.title || 'Image'}
+        loading="lazy"
+        decoding="async"
         onerror={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
       />
     {:else}

--- a/packages/web/src/lib/actions.ts
+++ b/packages/web/src/lib/actions.ts
@@ -45,3 +45,37 @@ export function autofocus(node: HTMLElement) {
 export function autofocusIf(node: HTMLElement, enabled: boolean) {
   if (enabled) requestAnimationFrame(() => node.focus());
 }
+
+/**
+ * Run `onEnter` once when the bound element first approaches the viewport.
+ *
+ * Used to gate expensive work (binary fetches for card media) on visibility,
+ * so opening a large inbox doesn't kick off a fetch for every image at once.
+ * The 400px rootMargin starts loading a little before the element scrolls
+ * into view, so media is usually ready by the time it's visible.
+ *
+ * Falls back to firing immediately when IntersectionObserver is unavailable
+ * (very old browsers, some test environments).
+ *
+ * Example:
+ * ```svelte
+ * <div use:inview={() => loadFileBlobUrl(item.filePath, item.mimeType)}>
+ * ```
+ */
+export function inview(node: HTMLElement, onEnter: () => void) {
+  if (typeof IntersectionObserver === 'undefined') {
+    onEnter();
+    return {};
+  }
+  const io = new IntersectionObserver(
+    (entries) => {
+      if (entries.some((e) => e.isIntersecting)) {
+        onEnter();
+        io.disconnect();
+      }
+    },
+    { rootMargin: '400px' },
+  );
+  io.observe(node);
+  return { destroy: () => io.disconnect() };
+}

--- a/packages/web/src/lib/rs.ts
+++ b/packages/web/src/lib/rs.ts
@@ -336,6 +336,17 @@ const rs = new RemoteStorage({
 rs.access.claim('inbox', 'rw');
 rs.access.claim('shares', 'rw');
 rs.caching.enable('/inbox/');
+// Binaries on demand: the parent ALL strategy would make sync proactively
+// download EVERY file under /inbox/files/ to every device — gigabytes for a
+// media-heavy inbox, and duplicated bandwidth since cards fetch bytes anyway.
+// SEEN caches a file after the app first reads or writes it, so offline
+// capture still lands in the local cache and viewed files stay available
+// offline, but never-viewed files aren't pulled down. Nested caching rules
+// override the parent by longest-prefix match. Metadata (items/, collections/,
+// groups/, config/) keeps ALL and remains fully offline.
+// NOTE: caching strategies are not persisted — this must run on every init,
+// before the first sync (it does: module scope, ahead of any connect).
+rs.caching.set('/inbox/files/', 'SEEN');
 
 /**
  * Fetch a file from an RS server using Authorization header and return a blob URL.

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -270,6 +270,11 @@ describe('loadFileBlobUrl', () => {
     loadFileBlobUrl('files/photo.jpg');
     loadFileBlobUrl('files/photo.jpg');
 
+    // The loader checks the local cache first (async), so the network fetch
+    // fires a microtask later — wait for it, then confirm it only fired once.
+    await vi.waitFor(() => {
+      expect(mockFetchFileBlobUrl).toHaveBeenCalled();
+    });
     expect(mockFetchFileBlobUrl).toHaveBeenCalledTimes(1);
 
     resolveFirst('blob:test/deduped');

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -409,6 +409,7 @@ rs.on('disconnected', () => {
     }
   }
   blobUrls.set({});
+  blobLruOrder.length = 0;
   pendingBlobLoads.clear();
   revokedBlobPaths.clear();
 
@@ -712,6 +713,47 @@ export const collectionItems = derived(
 /** Incremented on full blob URL revocation (e.g. disconnect) to invalidate in-flight loads. */
 let blobLoadGeneration = 0;
 const pendingBlobLoads = new Map<string, number>();
+
+/**
+ * Cap on how many blob URLs stay alive at once. Each entry pins the file's
+ * full bytes in memory, and nothing else ever revokes them during a session —
+ * a long browse through a media-heavy inbox would otherwise accumulate
+ * hundreds of MB. Evicted paths simply reload on next view (cheap: the bytes
+ * stay in the RS local cache, only the in-memory Blob is dropped). The cap is
+ * generous enough that anything on screen — including the Lightbox's current
+ * image — is effectively never the eviction victim.
+ */
+const BLOB_CACHE_MAX = 150;
+/** filePaths in least-recently-used order (most recent last). */
+const blobLruOrder: string[] = [];
+
+function touchBlobLru(filePath: string) {
+  const i = blobLruOrder.indexOf(filePath);
+  if (i >= 0) blobLruOrder.splice(i, 1);
+  blobLruOrder.push(filePath);
+  while (blobLruOrder.length > BLOB_CACHE_MAX) {
+    const evict = blobLruOrder.shift();
+    if (!evict) break;
+    const url = get(blobUrls)[evict];
+    if (url) {
+      try {
+        URL.revokeObjectURL(url);
+      } catch {
+        // ignore
+      }
+      blobUrls.update((current) => {
+        const next = { ...current };
+        delete next[evict];
+        return next;
+      });
+    }
+  }
+}
+
+function dropBlobLru(filePath: string) {
+  const i = blobLruOrder.indexOf(filePath);
+  if (i >= 0) blobLruOrder.splice(i, 1);
+}
 /** Paths for which we have explicitly revoked (via deleteItem) so in-flight loads don't re-insert. */
 const revokedBlobPaths = new Set<string>();
 
@@ -729,18 +771,37 @@ async function resolveFileBlobUrl(
   filePath: string,
   mimeType?: string,
 ): Promise<string | null> {
-  if (get(connected)) {
-    const url = await fetchFileBlobUrl(filePath, mimeType);
-    if (url) return url;
-  }
+  // Cache first: file paths are UUID-based and immutable, so a local copy can
+  // never be stale. Reading the remote first (the previous order) re-downloaded
+  // every visible file on every page load even though the bytes were already —
+  // or about to be — in the local cache.
   const inbox = getInbox();
-  if (!inbox) return null;
-  const cached = await inbox.getFile(filePath);
-  if (!cached?.data) return null;
-  const blob = new Blob([cached.data], {
-    type: cached.mimeType || mimeType || '',
-  });
-  return URL.createObjectURL(blob);
+  if (inbox) {
+    try {
+      const cached = await inbox.getFile(filePath);
+      if (cached?.data) {
+        // Prefer the caller's mimeType, and strip any `; charset=...` suffix
+        // from the cached type — files pulled from the remote by the sync
+        // layer can carry 5apps' `; charset=binary` echo, which Chrome
+        // refuses to render as an <img> blob.
+        const cleanType =
+          mimeType?.trim() ||
+          (cached.mimeType || '').split(';')[0].trim() ||
+          '';
+        const blob = new Blob([cached.data], { type: cleanType });
+        return URL.createObjectURL(blob);
+      }
+    } catch {
+      // fall through to the network path
+    }
+  }
+  // Not cached yet (e.g. captured on another device and not viewed here) —
+  // fetch over authenticated HTTP. The bytes land in the SEEN cache via the
+  // sync layer the next time RS reads the node; subsequent loads are local.
+  if (get(connected)) {
+    return fetchFileBlobUrl(filePath, mimeType);
+  }
+  return null;
 }
 
 /**
@@ -778,6 +839,7 @@ export function loadFileBlobUrl(filePath: string, mimeType?: string): void {
       const old = get(blobUrls)[filePath];
       if (old) URL.revokeObjectURL(old);
       blobUrls.update((current) => ({ ...current, [filePath]: url }));
+      touchBlobLru(filePath);
     })
     .finally(() => {
       if (pendingBlobLoads.get(filePath) === gen) {
@@ -801,6 +863,7 @@ export async function storeItem(item: InboxItem, fileData?: ArrayBuffer) {
       ...current,
       [item.filePath as string]: url,
     }));
+    touchBlobLru(item.filePath as string);
   }
   rawItems.update((current) => ({
     ...current,
@@ -835,6 +898,7 @@ export async function deleteItem(id: string, item?: InboxItem) {
         return next;
       });
     }
+    dropBlobLru(filePath);
     // Also drop any in-flight load for this specific file (no global gen bump needed).
     pendingBlobLoads.delete(filePath);
     // Mark as revoked so any concurrent in-flight load for this exact path is ignored on resolution.


### PR DESCRIPTION
**perf(web): SEEN caching, cache-first reads, lazy card media, blob LRU**

The strategy change you were open to: `/inbox/files/` switches from inherited ALL to SEEN, so sync stops proactively downloading every binary to every device; offline capture and viewed files stay locally cached. `resolveFileBlobUrl` reads the local cache before the network (paths are UUID-immutable, so a local copy can't be stale — previously every visible file re-downloaded every page load). Image/Bookmark/Audio cards gate their byte-fetch on viewport entry via a new `inview` action (400 px rootMargin; immediate fallback where IntersectionObserver is missing) and get `loading=lazy decoding=async`. `blobUrls` is LRU-capped at 150 entries so a long session can't pin hundreds of MB.

Behavioral note to decide consciously: with SEEN, never-viewed files are not available offline. If you want full-offline media back, revert the one `rs.caching.set` line — everything else in the PR still stands.

---
Part of a 9-PR series imported from `inbox-rs-prs.bundle`. PRs 8 and 9 stack on this branch.
