### PR TITLE
feat(capture): Web Share Target

### DIFF
--- a/packages/web/public/capture/manifest.webmanifest
+++ b/packages/web/public/capture/manifest.webmanifest
@@ -37,5 +37,14 @@
       "type": "image/png",
       "purpose": "maskable"
     }
-  ]
+  ],
+  "share_target": {
+    "action": "/capture/",
+    "method": "GET",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
+  }
 }

--- a/packages/web/public/manifest.webmanifest
+++ b/packages/web/public/manifest.webmanifest
@@ -51,5 +51,14 @@
         }
       ]
     }
-  ]
+  ],
+  "share_target": {
+    "action": "/capture/",
+    "method": "GET",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
+  }
 }

--- a/packages/web/src/capture/App.svelte
+++ b/packages/web/src/capture/App.svelte
@@ -87,6 +87,26 @@
     status = idleStatus();
     void syncNow();
 
+    // Web Share Target: the OS share sheet lands here as
+    // /capture/?title=…&text=…&url=…. Prefill the note composer and scrub the
+    // params from the address bar so a reload doesn't re-prefill. These keys
+    // never collide with the OAuth callback (access_token/error), which
+    // finishConnectFromRedirect has already consumed above.
+    const shareParams = new URLSearchParams(window.location.search);
+    const sharedParts = [
+      shareParams.get('title'),
+      shareParams.get('text'),
+      shareParams.get('url'),
+    ].filter((part): part is string => !!part?.trim());
+    if (sharedParts.length > 0) {
+      mode = 'note';
+      noteText = noteText
+        ? `${noteText}\n${sharedParts.join('\n')}`
+        : sharedParts.join('\n');
+      window.history.replaceState(null, '', window.location.pathname);
+      requestAnimationFrame(() => noteField?.focus());
+    }
+
     // Drive the app height from the *visual* viewport so the layout shrinks when
     // the on-screen keyboard opens, keeping the Send button above it. The layout
     // viewport (100%/100vh) ignores the keyboard, which otherwise hides Send.


### PR DESCRIPTION
**feat(capture): Web Share Target**

_Land after #PR1 (`pr/1-sw-precache-diet`): its `navigateFallbackDenylist` keeps these share navigations from falling through to the main app shell. Base is master (this branch is independent, not stacked)._

`share_target` (GET) in both manifests pointing at `/capture/`. Sharing a URL/text from the OS share sheet on Android/ChromeOS prefills the capture composer; params are scrubbed from the address bar and never collide with the OAuth callback keys. Works offline through the existing capture queue. Image-file sharing (POST + multipart + SW fetch handler) is a described follow-up.

---
Part of a 9-PR series imported from `inbox-rs-prs.bundle`.
