### PR TITLE
feat: image thumbnails

### DIFF
--- a/packages/rs-module/src/index.ts
+++ b/packages/rs-module/src/index.ts
@@ -86,6 +86,8 @@ export interface InboxModuleExports {
     thumbData?: ArrayBuffer,
   ): Promise<void>;
   remove(id: string, item?: InboxItem): Promise<void>;
+  /** Delete a single stored file by path (e.g. an orphaned thumbnail). */
+  removeFile(path: string): Promise<void>;
   getFile(
     path: string,
   ): Promise<{ data: ArrayBuffer; mimeType: string } | undefined>;
@@ -277,6 +279,10 @@ const InboxModule = {
           if (item && 'thumbPath' in item && item.thumbPath) {
             await privateClient.remove(item.thumbPath);
           }
+        },
+
+        async removeFile(path: string): Promise<void> {
+          await privateClient.remove(path);
         },
 
         async getFile(

--- a/packages/rs-module/src/index.ts
+++ b/packages/rs-module/src/index.ts
@@ -80,7 +80,11 @@ export type {
 export interface InboxModuleExports {
   getAll(): Promise<Record<string, InboxItem>>;
   getById(id: string): Promise<InboxItem | undefined>;
-  store(item: InboxItem, fileData?: ArrayBuffer): Promise<void>;
+  store(
+    item: InboxItem,
+    fileData?: ArrayBuffer,
+    thumbData?: ArrayBuffer,
+  ): Promise<void>;
   remove(id: string, item?: InboxItem): Promise<void>;
   getFile(
     path: string,
@@ -214,7 +218,11 @@ const InboxModule = {
           return item;
         },
 
-        async store(item: InboxItem, fileData?: ArrayBuffer): Promise<void> {
+        async store(
+          item: InboxItem,
+          fileData?: ArrayBuffer,
+          thumbData?: ArrayBuffer,
+        ): Promise<void> {
           // Stamp new items with the current migration version so they aren't
           // flagged as needing migration by getPending().
           if (item._migrateVersion === undefined) {
@@ -236,6 +244,19 @@ const InboxModule = {
               fileData,
             );
           }
+          if (
+            thumbData &&
+            'thumbPath' in item &&
+            item.thumbPath &&
+            'thumbMimeType' in item &&
+            item.thumbMimeType
+          ) {
+            await privateClient.storeFile(
+              item.thumbMimeType,
+              item.thumbPath,
+              thumbData,
+            );
+          }
           await privateClient.storeObject(
             schemaAlias(item.type),
             `items/${item.id}`,
@@ -252,6 +273,9 @@ const InboxModule = {
           await privateClient.remove(`items/${id}`);
           if (item && 'filePath' in item && item.filePath) {
             await privateClient.remove(item.filePath);
+          }
+          if (item && 'thumbPath' in item && item.thumbPath) {
+            await privateClient.remove(item.thumbPath);
           }
         },
 

--- a/packages/rs-module/src/runtime.ts
+++ b/packages/rs-module/src/runtime.ts
@@ -269,11 +269,21 @@ export class DirectRS {
    * `filePath`/`mimeType`, the file is uploaded first, then the item metadata.
    */
   async store(
-    item: { id: string; filePath?: string; mimeType?: string },
+    item: {
+      id: string;
+      filePath?: string;
+      mimeType?: string;
+      thumbPath?: string;
+      thumbMimeType?: string;
+    },
     fileData?: ArrayBuffer,
+    thumbData?: ArrayBuffer,
   ): Promise<void> {
     if (fileData && item.filePath && item.mimeType) {
       await this.storeFile(item.filePath, fileData, item.mimeType);
+    }
+    if (thumbData && item.thumbPath && item.thumbMimeType) {
+      await this.storeFile(item.thumbPath, thumbData, item.thumbMimeType);
     }
     await this.storeObject(`items/${item.id}`, item);
   }

--- a/packages/rs-module/src/schemas.ts
+++ b/packages/rs-module/src/schemas.ts
@@ -63,6 +63,8 @@ export const imageMetaSchema = {
     filePath: { type: 'string' },
     mimeType: { type: 'string' },
     sourceUrl: { type: 'string' },
+    thumbPath: { type: 'string' },
+    thumbMimeType: { type: 'string' },
     createdAt: { type: 'string' },
     ...todoFields,
     ...collectionFields,

--- a/packages/rs-module/src/types.ts
+++ b/packages/rs-module/src/types.ts
@@ -42,6 +42,14 @@ export interface ImageItem extends InboxItemBase {
   filePath: string;
   mimeType: string;
   sourceUrl?: string; // original URL the image was saved from
+  /**
+   * Optional downscaled preview stored alongside the original (grid cards
+   * load this; the lightbox loads filePath). Absent on items captured by
+   * clients that don't generate thumbnails — consumers must fall back to
+   * filePath.
+   */
+  thumbPath?: string;
+  thumbMimeType?: string;
 }
 
 export interface AudioItem extends InboxItemBase {

--- a/packages/web/src/capture/store.ts
+++ b/packages/web/src/capture/store.ts
@@ -10,6 +10,7 @@ import {
   extractTokenFromRedirect,
   type RSConfig,
 } from '@inbox-rs/rs-module/runtime';
+import { generateThumbnail, THUMB_MIME_TYPE } from '../lib/thumbnail';
 
 /** The three ways to capture. Maps to inbox item types note / audio / image. */
 export type CaptureMode = 'note' | 'voice' | 'image';
@@ -31,6 +32,8 @@ export type CaptureRecord = {
   lastError?: string;
   item: InboxItem;
   hasBlob: boolean;
+  /** A generated thumbnail is queued in IndexedDB under `<id>:thumb`. */
+  hasThumb?: boolean;
 };
 
 const CONFIG_KEY = 'inbox-rs-capture:config';
@@ -192,18 +195,35 @@ export function captureNote(text: string): CaptureRecord {
 export async function captureImage(file: File): Promise<CaptureRecord> {
   const id = crypto.randomUUID();
   const ext = extFromName(file.name) || extFromMime(file.type) || '.jpg';
+  // Best-effort thumbnail (null when the source is already small or can't be
+  // decoded); queued alongside the original and uploaded on flush.
+  const thumb = await generateThumbnail(file);
   const item: ImageItem = {
     id,
     type: 'image',
     title: file.name || 'Photo',
     filePath: `files/${id}${ext}`,
     mimeType: file.type || 'image/jpeg',
+    thumbPath: thumb ? `files/${id}.thumb.jpg` : undefined,
+    thumbMimeType: thumb ? THUMB_MIME_TYPE : undefined,
     createdAt: new Date().toISOString(),
   };
   await putBlob(id, file);
+  if (thumb) {
+    await putBlob(
+      thumbKey(id),
+      new Blob([thumb.data], { type: thumb.mimeType }),
+    );
+  }
   const record = newRecord(id, 'image', file.name || 'Photo', item, true);
-  prepend(record);
-  return record;
+  const withThumb: CaptureRecord = { ...record, hasThumb: !!thumb };
+  prepend(withThumb);
+  return withThumb;
+}
+
+/** IndexedDB key for a capture's queued thumbnail bytes. */
+function thumbKey(id: string): string {
+  return `${id}:thumb`;
 }
 
 /** Queue a voice memo for delivery; the binary is held in IndexedDB. */
@@ -257,12 +277,16 @@ export async function flushQueue(
     saveHistory(records);
     try {
       const fileData = entry.hasBlob ? await getBlobBytes(entry.id) : undefined;
-      await rs.store(entry.item, fileData);
+      const thumbData = entry.hasThumb
+        ? await getBlobBytes(thumbKey(entry.id))
+        : undefined;
+      await rs.store(entry.item, fileData, thumbData);
       records = patch(records, entry.id, {
         status: 'synced',
         lastError: undefined,
       });
       if (entry.hasBlob) await deleteBlob(entry.id);
+      if (entry.hasThumb) await deleteBlob(thumbKey(entry.id));
     } catch (error) {
       records = patch(records, entry.id, {
         status: 'failed',
@@ -279,6 +303,7 @@ export async function removeRecord(id: string): Promise<CaptureRecord[]> {
   const records = getHistory().filter((r) => r.id !== id);
   saveHistory(records);
   await deleteBlob(id);
+  await deleteBlob(thumbKey(id));
   return records;
 }
 

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -3,6 +3,7 @@
   import {
     storeItem,
     moveItemToCollection,
+    removeFile,
     sortedGroups,
     groupCollections,
   } from '../lib/stores';
@@ -196,7 +197,7 @@
         : new Date().toISOString();
       const result = await formBuildItem({ id, createdAt, isEdit, editItem });
       if (!result) return;
-      const { item, fileData, thumbData } = result;
+      const { item, fileData, thumbData, removePaths } = result;
 
       // Preserve todo fields when editing non-todo types (converted items).
       // For actual todo types, the form's completed checkbox is the source
@@ -213,6 +214,11 @@
       //                              collection/group written)
       //   real id                 → assign via moveItemToCollection after storage
       await storeItem(item, fileData, thumbData);
+      // Clean up files this edit orphaned (e.g. a previous thumbnail that the
+      // replacement image no longer produces). Best-effort; never blocks save.
+      if (removePaths) {
+        for (const path of removePaths) await removeFile(path);
+      }
       if (selectedCollectionId && !isEdit) {
         await moveItemToCollection(item.id, selectedCollectionId);
       }

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -196,7 +196,7 @@
         : new Date().toISOString();
       const result = await formBuildItem({ id, createdAt, isEdit, editItem });
       if (!result) return;
-      const { item, fileData } = result;
+      const { item, fileData, thumbData } = result;
 
       // Preserve todo fields when editing non-todo types (converted items).
       // For actual todo types, the form's completed checkbox is the source
@@ -212,7 +212,7 @@
       //   undefined + todo        → unfiled todo (no collectionId, no fake
       //                              collection/group written)
       //   real id                 → assign via moveItemToCollection after storage
-      await storeItem(item, fileData);
+      await storeItem(item, fileData, thumbData);
       if (selectedCollectionId && !isEdit) {
         await moveItemToCollection(item.id, selectedCollectionId);
       }

--- a/packages/web/src/components/ImageCard.svelte
+++ b/packages/web/src/components/ImageCard.svelte
@@ -11,7 +11,18 @@
   // image at once.
   let entered = $state(false);
 
-  const imageSrc = $derived($blobUrls[item.filePath] || null);
+  // Grid cards prefer the downscaled thumbnail; the Lightbox always gets the
+  // original. Items captured by clients that don't generate thumbnails have
+  // no thumbPath and fall back to the full file.
+  const displayPath = $derived(item.thumbPath || item.filePath);
+  const displayMime = $derived(
+    item.thumbPath ? item.thumbMimeType : item.mimeType,
+  );
+  const imageSrc = $derived($blobUrls[displayPath] || null);
+  // Lightbox shows the original at full resolution — kick off its load when
+  // opened and show the thumbnail as a progressive placeholder until the
+  // original's blob URL lands.
+  const fullSrc = $derived($blobUrls[item.filePath] || imageSrc);
 
   // Load the image bytes once visible. loadFileBlobUrl reads the local cache
   // first (file paths are immutable) and falls back to the remote, so files
@@ -19,13 +30,21 @@
   // as `image/jpeg` rather than whatever the server echoes back (e.g.
   // `image/jpeg; charset=binary` on 5apps, which Chrome refuses to render).
   // Referencing `$connected` re-runs this so we retry over the network once a
-  // connection is established. Reading `$blobUrls[item.filePath]` also re-runs
-  // it when the LRU cache evicts this path (blobUrls entry deleted), so a card
+  // connection is established. Reading `$blobUrls[displayPath]` also re-runs it
+  // when the LRU cache evicts this path (blobUrls entry deleted), so a card
   // that scrolled out and lost its blob reloads instead of going blank — the
   // `inview` observer is one-shot, so `entered` alone never fires again.
   $effect(() => {
     void $connected;
-    if (entered && item.filePath && !$blobUrls[item.filePath]) {
+    if (entered && displayPath && !$blobUrls[displayPath]) {
+      loadFileBlobUrl(displayPath, displayMime);
+    }
+  });
+
+  // Lightbox needs the original; re-fetch if it was never loaded or got
+  // evicted (guard on `$blobUrls[item.filePath]` for the same eviction reason).
+  $effect(() => {
+    if (showLightbox && item.filePath && !$blobUrls[item.filePath]) {
       loadFileBlobUrl(item.filePath, item.mimeType);
     }
   });
@@ -51,7 +70,7 @@
     {/if}
   </div>
   {#if showLightbox && imageSrc}
-    <Lightbox src={imageSrc} alt={item.title || 'Image'} onclose={() => showLightbox = false} filePath={item.filePath} mimeType={item.mimeType} filename={item.title || undefined} />
+    <Lightbox src={fullSrc || imageSrc} alt={item.title || 'Image'} onclose={() => showLightbox = false} filePath={item.filePath} mimeType={item.mimeType} filename={item.title || undefined} />
   {/if}
   {#if item.sourceUrl}
     <a class="source-link" href={item.sourceUrl} target="_blank" rel="noopener noreferrer">

--- a/packages/web/src/lib/add-entry-modal.ts
+++ b/packages/web/src/lib/add-entry-modal.ts
@@ -23,6 +23,8 @@ export interface BuildItemContext {
 export interface BuildItemResult {
   item: InboxItem;
   fileData?: ArrayBuffer;
+  /** Downscaled preview bytes for image items (see lib/thumbnail.ts). */
+  thumbData?: ArrayBuffer;
 }
 
 /**

--- a/packages/web/src/lib/add-entry-modal.ts
+++ b/packages/web/src/lib/add-entry-modal.ts
@@ -25,6 +25,12 @@ export interface BuildItemResult {
   fileData?: ArrayBuffer;
   /** Downscaled preview bytes for image items (see lib/thumbnail.ts). */
   thumbData?: ArrayBuffer;
+  /**
+   * Storage paths orphaned by this build that the caller should delete after
+   * saving — e.g. an edited image whose replacement bytes yielded no thumbnail
+   * leaves the previous `*.thumb.jpg` unreferenced.
+   */
+  removePaths?: string[];
 }
 
 /**

--- a/packages/web/src/lib/build-item.test.ts
+++ b/packages/web/src/lib/build-item.test.ts
@@ -310,6 +310,55 @@ describe('buildImageItem', () => {
       description: 'a new caption',
     });
   });
+
+  // In jsdom there's no createImageBitmap, so generateThumbnail resolves to
+  // null — the same path a real replacement that can't be downscaled takes.
+  it('flags the previous thumbnail for removal when a replacement yields no thumb', async () => {
+    const editItem: ImageItem = {
+      id: 'img-1',
+      type: 'image',
+      title: 'Old',
+      filePath: 'files/img-1.png',
+      mimeType: 'image/png',
+      thumbPath: 'files/img-1.thumb.jpg',
+      thumbMimeType: 'image/jpeg',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    };
+    const replacement = new File(['xyz'], 'replacement.jpg', {
+      type: 'image/jpeg',
+    });
+
+    const result = await buildImageItem(ctx({ id: 'img-1', editItem }), {
+      title: '',
+      description: '',
+      file: replacement,
+    });
+
+    expect((result?.item as ImageItem).thumbPath).toBeUndefined();
+    expect(result?.removePaths).toEqual(['files/img-1.thumb.jpg']);
+  });
+
+  it('does not flag removal when the edited image had no previous thumbnail', async () => {
+    const editItem: ImageItem = {
+      id: 'img-1',
+      type: 'image',
+      title: 'Old',
+      filePath: 'files/img-1.png',
+      mimeType: 'image/png',
+      createdAt: '2026-04-29T08:00:00.000Z',
+    };
+    const replacement = new File(['xyz'], 'replacement.jpg', {
+      type: 'image/jpeg',
+    });
+
+    const result = await buildImageItem(ctx({ id: 'img-1', editItem }), {
+      title: '',
+      description: '',
+      file: replacement,
+    });
+
+    expect(result?.removePaths).toBeUndefined();
+  });
 });
 
 describe('buildAudioItem', () => {

--- a/packages/web/src/lib/build-item.ts
+++ b/packages/web/src/lib/build-item.ts
@@ -132,6 +132,15 @@ export async function buildImageItem(
     const thumbPath = thumb
       ? existingThumbPath || `files/${ctx.id}.thumb.jpg`
       : undefined;
+    // If an edit drops the thumbnail (new bytes can't be downscaled) or moves
+    // it to a different path, the old thumb file is no longer referenced by
+    // anything — flag it for the caller to delete so it doesn't linger in
+    // storage. When the thumb is regenerated at the same path it's simply
+    // overwritten, so there's nothing to remove.
+    const removePaths =
+      existingThumbPath && existingThumbPath !== thumbPath
+        ? [existingThumbPath]
+        : undefined;
     const item: ImageItem = {
       id: ctx.id,
       type: 'image',
@@ -147,6 +156,7 @@ export async function buildImageItem(
       item: preserveCollection(ctx, item),
       fileData,
       thumbData: thumb?.data,
+      ...(removePaths ? { removePaths } : {}),
     };
   }
   if (ctx.editItem && ctx.editItem.type === 'image') {

--- a/packages/web/src/lib/build-item.ts
+++ b/packages/web/src/lib/build-item.ts
@@ -26,6 +26,7 @@ import type {
   TodoItem,
 } from '@inbox-rs/rs-module';
 import { type BuildItemResult, getFileExtension } from './add-entry-modal';
+import { generateThumbnail, THUMB_MIME_TYPE } from './thumbnail';
 
 export interface BuildContext {
   id: string;
@@ -122,16 +123,31 @@ export async function buildImageItem(
     const ext = getFileExtension(data.file.name);
     const filePath = existingPath || `files/${ctx.id}${ext}`;
     const fileData = await data.file.arrayBuffer();
+    // Best-effort thumbnail for grid cards (null when the original is already
+    // small or the browser can't decode it — consumers fall back to filePath).
+    // On edit, reuse the existing thumb path so replaced bytes overwrite it.
+    const existingThumbPath =
+      ctx.editItem?.type === 'image' ? ctx.editItem.thumbPath : undefined;
+    const thumb = await generateThumbnail(data.file);
+    const thumbPath = thumb
+      ? existingThumbPath || `files/${ctx.id}.thumb.jpg`
+      : undefined;
     const item: ImageItem = {
       id: ctx.id,
       type: 'image',
       title: data.title || data.file.name,
       filePath,
       mimeType: data.file.type,
+      thumbPath,
+      thumbMimeType: thumb ? THUMB_MIME_TYPE : undefined,
       description: data.description || undefined,
       createdAt: ctx.createdAt,
     };
-    return { item: preserveCollection(ctx, item), fileData };
+    return {
+      item: preserveCollection(ctx, item),
+      fileData,
+      thumbData: thumb?.data,
+    };
   }
   if (ctx.editItem && ctx.editItem.type === 'image') {
     const item: ImageItem = {

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -18,6 +18,7 @@ const { mockRs, mockInbox } = vi.hoisted(() => {
     onChange: vi.fn(),
     store: vi.fn().mockResolvedValue(undefined),
     remove: vi.fn().mockResolvedValue(undefined),
+    removeFile: vi.fn().mockResolvedValue(undefined),
     getFile: vi.fn().mockResolvedValue(undefined),
     storeCollection: vi.fn().mockResolvedValue(undefined),
     removeCollection: vi.fn().mockResolvedValue(undefined),

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -540,7 +540,7 @@ describe('todoItems ordering', () => {
 
     await storeItem(todo);
 
-    expect(mockInbox.store).toHaveBeenCalledWith(todo, undefined);
+    expect(mockInbox.store).toHaveBeenCalledWith(todo, undefined, undefined);
     expect(get(items).quick).toMatchObject({
       id: 'quick',
       title: 'Quick thought',

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -890,6 +890,48 @@ export async function storeItem(
   items.update((current) => ({ ...current, [cleanItem.id]: cleanItem }));
 }
 
+/**
+ * Revoke and forget a single stored file's in-memory blob URL, and clear its
+ * LRU / in-flight / revoked bookkeeping. Shared by deleteItem and removeFile.
+ */
+function releaseBlobPath(path: string) {
+  const existing = get(blobUrls)[path];
+  if (existing) {
+    try {
+      URL.revokeObjectURL(existing);
+    } catch {
+      // ignore
+    }
+    blobUrls.update((current) => {
+      const next = { ...current };
+      delete next[path];
+      return next;
+    });
+  }
+  dropBlobLru(path);
+  // Drop any in-flight load for this specific file (no global gen bump needed).
+  pendingBlobLoads.delete(path);
+  // Mark as revoked so a concurrent in-flight load for this exact path is
+  // ignored on resolution.
+  revokedBlobPaths.add(path);
+}
+
+/**
+ * Delete a single stored file by path (e.g. an orphaned thumbnail left behind
+ * when an image edit produced no new thumbnail) and release its blob URL.
+ * Best-effort: a storage failure is logged, not thrown, so it never fails the
+ * surrounding save.
+ */
+export async function removeFile(path: string) {
+  if (!path) return;
+  try {
+    await requireInbox().removeFile(path);
+  } catch (e) {
+    console.error('[inbox] removeFile failed:', path, e);
+  }
+  releaseBlobPath(path);
+}
+
 export async function deleteItem(id: string, item?: InboxItem) {
   const inbox = requireInbox();
   await inbox.remove(id, item);
@@ -908,24 +950,7 @@ export async function deleteItem(id: string, item?: InboxItem) {
     asFileItem?.thumbPath || stored?.thumbPath,
   ]) {
     if (typeof path !== 'string' || !path) continue;
-    const existing = get(blobUrls)[path];
-    if (existing) {
-      try {
-        URL.revokeObjectURL(existing);
-      } catch {
-        // ignore
-      }
-      blobUrls.update((current) => {
-        const next = { ...current };
-        delete next[path];
-        return next;
-      });
-    }
-    dropBlobLru(path);
-    // Also drop any in-flight load for this specific file (no global gen bump needed).
-    pendingBlobLoads.delete(path);
-    // Mark as revoked so any concurrent in-flight load for this exact path is ignored on resolution.
-    revokedBlobPaths.add(path);
+    releaseBlobPath(path);
   }
 
   rawItems.update((current) => {

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -850,10 +850,14 @@ export function loadFileBlobUrl(filePath: string, mimeType?: string): void {
 
 // ---- Item operations ----
 
-export async function storeItem(item: InboxItem, fileData?: ArrayBuffer) {
+export async function storeItem(
+  item: InboxItem,
+  fileData?: ArrayBuffer,
+  thumbData?: ArrayBuffer,
+) {
   const inbox = requireInbox();
   const cleanItem = cleanForStorage(item);
-  await inbox.store(cleanItem, fileData);
+  await inbox.store(cleanItem, fileData, thumbData);
   if (fileData && 'filePath' in item && item.filePath && 'mimeType' in item) {
     const blob = new Blob([fileData], {
       type: (item as { mimeType?: string }).mimeType,
@@ -864,6 +868,20 @@ export async function storeItem(item: InboxItem, fileData?: ArrayBuffer) {
       [item.filePath as string]: url,
     }));
     touchBlobLru(item.filePath as string);
+  }
+  // Register the freshly generated thumbnail too, so the grid card shows it
+  // immediately without a round trip through the loader.
+  if (thumbData && 'thumbPath' in item && item.thumbPath) {
+    const url = URL.createObjectURL(
+      new Blob([thumbData], {
+        type: (item as { thumbMimeType?: string }).thumbMimeType,
+      }),
+    );
+    blobUrls.update((current) => ({
+      ...current,
+      [item.thumbPath as string]: url,
+    }));
+    touchBlobLru(item.thumbPath as string);
   }
   rawItems.update((current) => ({
     ...current,
@@ -876,16 +894,21 @@ export async function deleteItem(id: string, item?: InboxItem) {
   const inbox = requireInbox();
   await inbox.remove(id, item);
 
-  // Revoke and remove any associated blob URL to prevent memory leaks.
-  // All current callers pass the full item; we also do a defensive lookup.
-  const filePath =
-    (item && 'filePath' in item && (item as { filePath?: string }).filePath) ||
-    (get(items)[id] &&
-      'filePath' in get(items)[id] &&
-      (get(items)[id] as { filePath?: string }).filePath);
-
-  if (typeof filePath === 'string' && filePath) {
-    const existing = get(blobUrls)[filePath];
+  // Revoke and remove any associated blob URLs (original + thumbnail) to
+  // prevent memory leaks. All current callers pass the full item; we also do
+  // a defensive lookup.
+  const stored = get(items)[id] as
+    | { filePath?: string; thumbPath?: string }
+    | undefined;
+  const asFileItem = item as
+    | { filePath?: string; thumbPath?: string }
+    | undefined;
+  for (const path of [
+    asFileItem?.filePath || stored?.filePath,
+    asFileItem?.thumbPath || stored?.thumbPath,
+  ]) {
+    if (typeof path !== 'string' || !path) continue;
+    const existing = get(blobUrls)[path];
     if (existing) {
       try {
         URL.revokeObjectURL(existing);
@@ -894,15 +917,15 @@ export async function deleteItem(id: string, item?: InboxItem) {
       }
       blobUrls.update((current) => {
         const next = { ...current };
-        delete next[filePath];
+        delete next[path];
         return next;
       });
     }
-    dropBlobLru(filePath);
+    dropBlobLru(path);
     // Also drop any in-flight load for this specific file (no global gen bump needed).
-    pendingBlobLoads.delete(filePath);
+    pendingBlobLoads.delete(path);
     // Mark as revoked so any concurrent in-flight load for this exact path is ignored on resolution.
-    revokedBlobPaths.add(filePath);
+    revokedBlobPaths.add(path);
   }
 
   rawItems.update((current) => {

--- a/packages/web/src/lib/thumbnail.ts
+++ b/packages/web/src/lib/thumbnail.ts
@@ -1,0 +1,88 @@
+/**
+ * Client-side thumbnail generation for image captures.
+ *
+ * The inbox grid renders images into ~300px masonry columns, but cards were
+ * decoding the full-resolution original. A downscaled JPEG stored alongside
+ * the original (files/<id>.thumb.jpg) lets cards load a few tens of KB while
+ * the lightbox still fetches the untouched original.
+ *
+ * Generation is strictly best-effort: any failure (unsupported codec like
+ * HEIC in some browsers, missing canvas in odd environments, zero-byte input)
+ * returns null and the caller stores the item without a thumbnail — every
+ * consumer falls back to filePath, and items captured by clients that don't
+ * generate thumbnails (extension, mobile, older versions) remain fully
+ * supported.
+ */
+
+/** Longest edge of the generated thumbnail, in CSS pixels. */
+export const THUMB_MAX_DIM = 640;
+
+export const THUMB_MIME_TYPE = 'image/jpeg';
+
+const THUMB_QUALITY = 0.82;
+
+export interface ThumbnailResult {
+  data: ArrayBuffer;
+  mimeType: string;
+}
+
+/**
+ * Downscale an image blob to at most {@link THUMB_MAX_DIM} on its longest
+ * edge. Returns null when the source is already small enough (callers should
+ * just use the original) or when generation fails for any reason.
+ */
+export async function generateThumbnail(
+  source: Blob,
+): Promise<ThumbnailResult | null> {
+  if (typeof createImageBitmap !== 'function') return null;
+  let bitmap: ImageBitmap;
+  try {
+    bitmap = await createImageBitmap(source);
+  } catch {
+    return null; // undecodable in this browser — store without a thumb
+  }
+  try {
+    const { width, height } = bitmap;
+    if (width <= THUMB_MAX_DIM && height <= THUMB_MAX_DIM) {
+      // Original is thumbnail-sized already; a second copy buys nothing.
+      return null;
+    }
+    const scale = THUMB_MAX_DIM / Math.max(width, height);
+    const w = Math.max(1, Math.round(width * scale));
+    const h = Math.max(1, Math.round(height * scale));
+
+    const blob = await drawToJpeg(bitmap, w, h);
+    if (!blob) return null;
+    return { data: await blob.arrayBuffer(), mimeType: THUMB_MIME_TYPE };
+  } catch {
+    return null;
+  } finally {
+    bitmap.close();
+  }
+}
+
+async function drawToJpeg(
+  bitmap: ImageBitmap,
+  w: number,
+  h: number,
+): Promise<Blob | null> {
+  if (typeof OffscreenCanvas !== 'undefined') {
+    const canvas = new OffscreenCanvas(w, h);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return null;
+    ctx.drawImage(bitmap, 0, 0, w, h);
+    return canvas.convertToBlob({
+      type: THUMB_MIME_TYPE,
+      quality: THUMB_QUALITY,
+    });
+  }
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  return new Promise((resolve) =>
+    canvas.toBlob(resolve, THUMB_MIME_TYPE, THUMB_QUALITY),
+  );
+}


### PR DESCRIPTION
**feat: image thumbnails**

_Stacked on #PR4 (`pr/4-binaries-on-demand`) — base is that branch (ImageCard changes). Merge PR 4 first; also touches rs-module `remove()` like PR 5 (one-line reconcile if PR 5 lands first)._

Image captures also store a best-effort thumbnail (max 640 px, JPEG q0.82) at `files/<id>.thumb.jpg`. Grid cards load the thumb; the Lightbox loads the original with the thumb as a progressive placeholder. Schema addition is optional/additive (no migration); generation failures (HEIC, small originals) simply store without a thumb, and every consumer falls back to `filePath`, so extension/mobile/older captures keep working unchanged. Capture app generates at capture time, queues under `<id>:thumb` in IndexedDB, uploads on flush. Follow-ups noted in the commit: backfill script for existing items; extension-side generation.

---
Part of a 9-PR series imported from `inbox-rs-prs.bundle`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image uploads now support thumbnails for faster preview loading.
  * Added support for deleting individual stored files when needed.

* **Bug Fixes**
  * Improved image replacement so old thumbnail files are cleaned up automatically.
  * Image previews now load the best available version first, with the full image shown in the lightbox.

* **Tests**
  * Updated coverage for thumbnail generation, storage, and cleanup flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->