### PR TITLE
fix(web): todoNote returns null for a whitespace-only first line

### DIFF
--- a/packages/web/src/lib/item-utils.test.ts
+++ b/packages/web/src/lib/item-utils.test.ts
@@ -211,10 +211,10 @@ describe('todoNote', () => {
     expect(todoNote(item)).toBe('Description first');
   });
 
-  it('returns an empty string when the first line is whitespace-only', () => {
-    // Documents current behavior: the truthiness guard runs on the untrimmed
-    // multi-line value, so a whitespace-only first line trims to '' and is
-    // returned as-is rather than collapsing to null.
+  it('returns null when the first line is whitespace-only', () => {
+    // A whitespace-only first line has nothing to show, so it collapses to
+    // null (consistent with the empty/absent cases) rather than rendering a
+    // blank note row in todo tiles.
     const item: NoteItem = {
       id: 'note-1',
       type: 'note',
@@ -222,7 +222,7 @@ describe('todoNote', () => {
       body: '   \nsecond line',
       createdAt: '2026-04-01T00:00:00.000Z',
     };
-    expect(todoNote(item)).toBe('');
+    expect(todoNote(item)).toBeNull();
   });
 });
 

--- a/packages/web/src/lib/item-utils.ts
+++ b/packages/web/src/lib/item-utils.ts
@@ -68,6 +68,11 @@ export function todoNote(item: InboxItem): string | null {
     item.description ||
     ('body' in item ? (r.body as string | undefined) : null);
   if (!notes) return null;
+  // Trim the first line *before* deciding there's nothing to show — the guard
+  // above runs on the full (possibly multi-line) value, so an input whose
+  // first line is only whitespace (e.g. `'   \nsecond'`) would otherwise
+  // return '' and render a blank note row in todo tiles.
   const firstLine = notes.split('\n')[0].trim();
+  if (!firstLine) return null;
   return firstLine.length > 80 ? `${firstLine.slice(0, 80)}...` : firstLine;
 }


### PR DESCRIPTION
## Summary

`todoNote` (`packages/web/src/lib/item-utils.ts`) guarded `if (!notes) return null` on the untrimmed, multi-line value. So an input whose first line is whitespace but which has later content (e.g. `body: '   \nsecond line'`) passed the guard, then `.split('\n')[0].trim()` produced `''`, which was returned as-is instead of `null`.

Fix: trim the first line **before** deciding there's nothing to show; return `null` when it's empty — consistent with the empty/absent cases, and avoids a blank note row in todo tiles.

The test added in #153 that documented the old `''` behavior is flipped to assert `null`.

Closes #155.