### PR TITLE
fix(web): render server-fetched images faithfully on fresh devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9204,7 +9204,7 @@
     },
     "packages/extension": {
       "name": "@inbox-rs/extension",
-      "version": "2.3.3",
+      "version": "2.3.5",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "remotestoragejs": "^2.0.0-beta.9",
@@ -9261,7 +9261,7 @@
     },
     "packages/rs-module": {
       "name": "@inbox-rs/rs-module",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "dependencies": {
         "remotestoragejs": "^2.0.0-beta.9",
         "rs-migrate": "^1.0.2"
@@ -9273,7 +9273,7 @@
     },
     "packages/thunderbird": {
       "name": "@inbox-rs/thunderbird",
-      "version": "2.3.3",
+      "version": "2.3.5",
       "dependencies": {
         "@inbox-rs/rs-module": "*"
       },
@@ -9327,7 +9327,7 @@
     },
     "packages/web": {
       "name": "@inbox-rs/web",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "@tiptap/core": "^3.22.1",
@@ -9401,7 +9401,7 @@
     },
     "scripts": {
       "name": "@inbox-rs/scripts",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "devDependencies": {
         "vitest": "^4.1.2"
       }

--- a/packages/web/src/components/ImageCard.svelte
+++ b/packages/web/src/components/ImageCard.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import { inview } from '../lib/actions';
   import type { ImageItem } from '@inbox-rs/rs-module';
-  import { blobUrls, connected, loadFileBlobUrl } from '../lib/stores';
+  import {
+    blobLoadFailures,
+    blobUrls,
+    connected,
+    loadFileBlobUrl,
+  } from '../lib/stores';
   import Lightbox from './Lightbox.svelte';
 
   let { item }: { item: ImageItem } = $props();
@@ -14,9 +19,20 @@
   // Grid cards prefer the downscaled thumbnail; the Lightbox always gets the
   // original. Items captured by clients that don't generate thumbnails have
   // no thumbPath and fall back to the full file.
-  const displayPath = $derived(item.thumbPath || item.filePath);
+  //
+  // If the thumbnail itself can't be loaded — it was never uploaded, or its
+  // best-effort upload failed, so the remote 404s — fall back to the full
+  // image rather than leaving the card blank. `blobLoadFailures` only records
+  // genuine online failures, so this never fires just because the thumb is
+  // still in flight.
+  const thumbFailed = $derived(
+    !!item.thumbPath && $blobLoadFailures.has(item.thumbPath),
+  );
+  const displayPath = $derived(
+    item.thumbPath && !thumbFailed ? item.thumbPath : item.filePath,
+  );
   const displayMime = $derived(
-    item.thumbPath ? item.thumbMimeType : item.mimeType,
+    item.thumbPath && !thumbFailed ? item.thumbMimeType : item.mimeType,
   );
   const imageSrc = $derived($blobUrls[displayPath] || null);
   // Lightbox shows the original at full resolution — kick off its load when

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -29,6 +29,35 @@ function requireInbox() {
 /** Blob URLs for files that were just uploaded (available before remote sync completes) */
 export const blobUrls = writable<Record<string, string>>({});
 
+/**
+ * File paths whose bytes could not be loaded while *connected* — i.e. the
+ * remote returned no usable file (a 404, or a fetch error) and there was no
+ * local copy either. Distinct from "not loaded yet": a path only lands here
+ * after a genuine online failure. Grid cards use it to fall back from a
+ * missing thumbnail to the full image (see ImageCard), so a thumb that was
+ * never uploaded — or failed its best-effort upload — doesn't leave a
+ * permanently blank card when the original image is perfectly fetchable.
+ */
+export const blobLoadFailures = writable<Set<string>>(new Set());
+
+function markBlobLoadFailed(filePath: string) {
+  blobLoadFailures.update((s) => {
+    if (s.has(filePath)) return s;
+    const next = new Set(s);
+    next.add(filePath);
+    return next;
+  });
+}
+
+function clearBlobLoadFailed(filePath: string) {
+  blobLoadFailures.update((s) => {
+    if (!s.has(filePath)) return s;
+    const next = new Set(s);
+    next.delete(filePath);
+    return next;
+  });
+}
+
 export const connected = writable(false);
 export const syncing = writable(false);
 
@@ -771,10 +800,27 @@ async function resolveFileBlobUrl(
   filePath: string,
   mimeType?: string,
 ): Promise<string | null> {
-  // Cache first: file paths are UUID-based and immutable, so a local copy can
-  // never be stale. Reading the remote first (the previous order) re-downloaded
-  // every visible file on every page load even though the bytes were already —
-  // or about to be — in the local cache.
+  // Network first when connected. We deliberately do NOT read remoteStorage's
+  // local cache before the remote for binaries: remotestorage.js's sync layer
+  // corrupts a *remotely-fetched* binary body by running it through a
+  // non-fatal UTF-8 decode, so bytes like 0x89 (a PNG's first byte) come back
+  // as U+FFFD (0xFD) with the length shifted. The loss is not recoverable
+  // (`recoverLegacyBinaryStringEncoding` only reverses the lossless legacy
+  // shapes), so a device that never *wrote* the file itself — i.e. any device
+  // other than the one that captured it — would render a broken image from
+  // cache. `fetchFileWithAuth` reads the raw response bytes and is always
+  // faithful. The extra fetch is deduped within a session by the in-memory
+  // `blobUrls` LRU cache, so a given path is only fetched once per session.
+  if (get(connected)) {
+    const url = await fetchFileBlobUrl(filePath, mimeType);
+    if (url) return url;
+  }
+  // Offline, or the remote 404'd because the file was captured on this device
+  // and hasn't synced yet: read the local cache, where `store()` writes the
+  // bytes regardless of connection state. This copy is faithful because *we*
+  // wrote the raw ArrayBuffer into it — it never went through the sync layer's
+  // corrupting decode. Without this fallback, offline-captured files would
+  // vanish on reload even though their bytes are sitting in the cache.
   const inbox = getInbox();
   if (inbox) {
     try {
@@ -792,14 +838,8 @@ async function resolveFileBlobUrl(
         return URL.createObjectURL(blob);
       }
     } catch {
-      // fall through to the network path
+      // No cached copy either — give up (returns null → placeholder).
     }
-  }
-  // Not cached yet (e.g. captured on another device and not viewed here) —
-  // fetch over authenticated HTTP. The bytes land in the SEEN cache via the
-  // sync layer the next time RS reads the node; subsequent loads are local.
-  if (get(connected)) {
-    return fetchFileBlobUrl(filePath, mimeType);
   }
   return null;
 }
@@ -823,7 +863,15 @@ export function loadFileBlobUrl(filePath: string, mimeType?: string): void {
   pendingBlobLoads.set(filePath, gen);
   resolveFileBlobUrl(filePath, mimeType)
     .then((url) => {
-      if (!url) return;
+      if (!url) {
+        // A null result while connected is a genuine failure (remote 404 or
+        // fetch error, and no local copy) — record it so grid cards can fall
+        // back from a missing thumbnail to the full image. While offline it
+        // just means "not available yet"; the `$connected` re-run retries.
+        if (get(connected)) markBlobLoadFailed(filePath);
+        return;
+      }
+      clearBlobLoadFailed(filePath);
       // Ignore (and revoke) results that are stale due to disconnect, delete, etc.
       if (
         pendingBlobLoads.get(filePath) !== gen ||

--- a/tests/e2e/helpers/armadietto.ts
+++ b/tests/e2e/helpers/armadietto.ts
@@ -189,3 +189,52 @@ export async function putInboxItem(
     );
   }
 }
+
+/**
+ * Write a single binary file directly to RS, bypassing the web app.
+ *
+ * Targets `PUT /storage/<user>/inbox/<path>`, the same location the
+ * rs-module's `storeFile(...)` writes to (image bytes live under
+ * `files/<id>.<ext>`, thumbnails under `files/<id>.thumb.jpg`). Pairing
+ * this with `putInboxItem` lets a test stage an image that exists *only*
+ * on the server — never in any browser's local cache — which is exactly
+ * the state a brand-new device (e.g. a phone that captured nothing) sees.
+ *
+ * The device that captured an image always has its bytes in local
+ * IndexedDB, so it renders regardless of whether the upload reached the
+ * server. Only a fresh device actually exercises the authenticated
+ * `fetchFileWithAuth` GET path — so seeding via the server (not the UI)
+ * is the only way to test that path honestly.
+ */
+export async function putInboxFile(
+  user: RsUser,
+  token: string,
+  options: {
+    path: string;
+    body: ArrayBuffer | Uint8Array;
+    contentType: string;
+  },
+): Promise<void> {
+  const { path, body, contentType } = options;
+  if (!path.startsWith('files/')) {
+    throw new Error(`inbox file path must start with "files/": ${path}`);
+  }
+  const r = await fetch(
+    `${ARMADIETTO_ORIGIN}/storage/${user.username}/inbox/${path}`,
+    {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': contentType,
+      },
+      body,
+      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+    },
+  );
+  if (r.status !== 200 && r.status !== 201) {
+    const text = await r.text().catch(() => '');
+    throw new Error(
+      `PUT /inbox/${path} for ${user.username} failed: HTTP ${r.status} — ${text.slice(0, 200)}`,
+    );
+  }
+}

--- a/tests/e2e/mobile/image-rendering.spec.ts
+++ b/tests/e2e/mobile/image-rendering.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Cross-device image rendering (issue: "on mobile I don't see my images").
+ *
+ * The reported symptom: an image captured on the desktop shows there, but the
+ * card is blank on the phone even though the phone is connected and the card
+ * is correctly typed as an image with its title.
+ *
+ * Root-cause shape this spec pins down:
+ *
+ * - Item metadata lives under `/inbox/items/` (cached `ALL`) and syncs to
+ *   every device, so the phone always has the title + type.
+ * - Image *bytes* live under `/inbox/files/` (cached `SEEN`) and are never
+ *   proactively pushed to a new device. The capturing device keeps them in
+ *   its own IndexedDB, so it renders regardless of whether the upload ever
+ *   reached the server. Only a fresh device fetches the bytes over
+ *   authenticated HTTP (`fetchFileWithAuth`) — so only a fresh device tests
+ *   that path.
+ *
+ * We therefore stage the image entirely on the *server* (metadata + bytes,
+ * never through the UI) and load it in a brand-new browser context. That
+ * context is, for all purposes that matter here, the phone: connected, with
+ * the item metadata, but an empty file cache.
+ *
+ * Runs under both mobile projects — `mobile-chromium` (Pixel 5) and
+ * `mobile-webkit` (iPhone / Safari engine), the closest automatable proxy for
+ * real iOS Safari.
+ */
+
+import { putInboxFile, putInboxItem } from '../helpers/armadietto';
+import { expect, test } from '../helpers/fixtures';
+import { seedRsSession } from '../helpers/pwa';
+
+// Standard 1×1 transparent PNG (67 bytes). A real decodable image, so a
+// painted <img> reports naturalWidth ≥ 1 while a blank card reports 0.
+const PNG_1x1 = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+/** Poll the first grid image's decoded width; 0 means "never painted". */
+async function paintedWidth(page: import('@playwright/test').Page) {
+  const img = page.locator('.image-card img');
+  if ((await img.count()) === 0) return 0;
+  return img
+    .first()
+    .evaluate((el: HTMLImageElement) => el.naturalWidth)
+    .catch(() => 0);
+}
+
+test('a fresh device renders an image that exists only on the server', async ({
+  context,
+  freshRsUser,
+  freshRsToken,
+  webOrigin,
+}) => {
+  const id = 'e2e-plain-image-1';
+
+  // Stage the image on the server exactly as a *different* device's capture
+  // would have left it: metadata + full bytes, no thumbnail (mirrors the
+  // pre-thumbnail images that the bug report says are also blank).
+  await putInboxItem(freshRsUser, freshRsToken, {
+    item: {
+      id,
+      type: 'image',
+      title: 'Server-only photo',
+      filePath: `files/${id}.png`,
+      mimeType: 'image/png',
+      createdAt: '2024-01-01T00:00:00.000Z',
+    },
+  });
+  await putInboxFile(freshRsUser, freshRsToken, {
+    path: `files/${id}.png`,
+    body: PNG_1x1,
+    contentType: 'image/png',
+  });
+
+  await seedRsSession(context, freshRsUser, freshRsToken, {
+    clientOrigin: webOrigin,
+  });
+  const page = await context.newPage();
+
+  // Record what the device's authenticated file GET actually returns — this
+  // is the single fact that diagnoses a blank card (404 vs 401/403 vs blocked
+  // vs a 200 that still doesn't paint).
+  const fileResponses: string[] = [];
+  page.on('response', (r) => {
+    if (r.url().includes('/inbox/files/')) {
+      fileResponses.push(`${r.status()} ${r.request().method()} ${r.url()}`);
+    }
+  });
+  page.on('requestfailed', (r) => {
+    if (r.url().includes('/inbox/files/')) {
+      fileResponses.push(`FAILED ${r.failure()?.errorText ?? '?'} ${r.url()}`);
+    }
+  });
+
+  await page.goto(webOrigin);
+
+  // The card renders from synced metadata first (title + image type). If this
+  // never appears, the failure is sync, not image loading — a different bug.
+  await expect(page.locator('.image-card')).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByText('Server-only photo')).toBeVisible();
+
+  // The actual assertion: the bytes fetched from the server paint.
+  await expect
+    .poll(() => paintedWidth(page), {
+      timeout: 15_000,
+      message:
+        'image bytes never painted on a fresh device — file GETs seen: ' +
+        JSON.stringify(fileResponses),
+    })
+    .toBeGreaterThan(0);
+
+  // And the "Not connected" placeholder must be gone.
+  await expect(page.getByText('Not connected')).toHaveCount(0);
+});
+
+test('a thumbnailed image still renders when only the thumbnail is missing on the server', async ({
+  context,
+  freshRsUser,
+  freshRsToken,
+  webOrigin,
+}) => {
+  const id = 'e2e-thumb-missing-1';
+
+  // Item advertises a thumbPath, and the full image is on the server, but the
+  // thumbnail bytes never made it (best-effort upload, cross-client capture,
+  // etc.). The grid prefers `thumbPath`; if it can't fall back to the full
+  // image when the thumb 404s, the card is blank on every fresh device.
+  await putInboxItem(freshRsUser, freshRsToken, {
+    item: {
+      id,
+      type: 'image',
+      title: 'Thumb-missing photo',
+      filePath: `files/${id}.png`,
+      mimeType: 'image/png',
+      thumbPath: `files/${id}.thumb.jpg`,
+      thumbMimeType: 'image/jpeg',
+      createdAt: '2024-01-01T00:00:00.000Z',
+    },
+  });
+  await putInboxFile(freshRsUser, freshRsToken, {
+    path: `files/${id}.png`,
+    body: PNG_1x1,
+    contentType: 'image/png',
+  });
+  // Deliberately do NOT put files/<id>.thumb.jpg.
+
+  await seedRsSession(context, freshRsUser, freshRsToken, {
+    clientOrigin: webOrigin,
+  });
+  const page = await context.newPage();
+  await page.goto(webOrigin);
+
+  await expect(page.locator('.image-card')).toBeVisible({ timeout: 20_000 });
+  await expect
+    .poll(() => paintedWidth(page), {
+      timeout: 15_000,
+      message: 'card blank: grid did not fall back to the full image',
+    })
+    .toBeGreaterThan(0);
+});

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "test": "playwright test",
-    "test:install": "playwright install --with-deps chromium",
+    "test:install": "playwright install --with-deps chromium webkit",
     "report": "playwright show-report"
   },
   "dependencies": {

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -65,6 +65,19 @@ export default defineConfig({
         ...devices['Pixel 5'],
       },
     },
+    {
+      // iPhone 13 runs Playwright's WebKit build — the same engine that ships
+      // in iOS Safari. It's the closest automatable proxy for a real iPhone
+      // (there is no true iOS simulator in headless CI), and it's what guards
+      // image rendering on the platform users actually reported blank cards
+      // on. Requires the WebKit browser: `playwright install --with-deps
+      // webkit` (the chromium-only `test:install` script doesn't cover it).
+      name: 'mobile-webkit',
+      testDir: './mobile',
+      use: {
+        ...devices['iPhone 13'],
+      },
+    },
   ],
   webServer: [
     {


### PR DESCRIPTION
## Symptom

Images captured on one device (e.g. desktop) showed there, but were **blank on any other device** (e.g. a phone) — even when the phone was connected and the card was correctly typed as an image with its title. Even old, pre-thumbnail images were blank.

## Root cause

`resolveFileBlobUrl` read file bytes from `inbox.getFile()` (remotestorage.js's local cache) **before** the authenticated fetch. remotestorage.js's sync layer corrupts a *remotely-fetched* binary body by running it through a **non-fatal UTF-8 decode**: a PNG's leading `0x89` comes back as `U+FFFD` (`0xFD`) with the length shifted, so the blob decodes as a broken image. The loss is not recoverable (`recoverLegacyBinaryStringEncoding` only reverses the lossless legacy shapes).

The **capturing device is immune** because it wrote the raw `ArrayBuffer` into its own cache directly — it never goes through the corrupting fetch path. Every *other* device does. That's the exact "desktop fine, phone blank" split.

Verified end-to-end: the server's HTTP response is clean (`200 image/png`, correct 70-byte PNG), but the `<img>`'s blob contained `fd 50 4e 47…` (69 bytes) instead of `89 50 4e 47…` (70 bytes).

## Fix

- **`stores.ts`** — when connected, read bytes over the authenticated fetch (always faithful); fall back to the local cache only when offline, where the copy is clean because we wrote it. Added a `blobLoadFailures` store that records genuine online load failures.
- **`ImageCard.svelte`** — related gap: the grid requested only `thumbPath` and never fell back to the full image when a thumbnail was missing/unfetchable. It now falls back via `blobLoadFailures`.

### Tradeoff

Connected page loads now re-fetch visible image bytes from the server instead of reading the (corrupt-for-remote-files) cache. Within a session the in-memory blob LRU dedupes, and thumbnails are small, so the cost is modest — and the previous cache-first ordering was silently serving corrupt images to every non-capturing device. A deeper future optimization would be to fix remotestorage.js's binary caching so cache-first can safely return.

## Tests (now standard in the e2e suite)

- **`tests/e2e/mobile/image-rendering.spec.ts`** — cross-device regression: stage an image entirely on the server, load it in a fresh browser context (a device with no local cache = the phone), and assert the `<img>` actually paints (`naturalWidth > 0`). Covers the plain full image and the thumb-missing fallback. **Both cases failed before this fix.**
- **`tests/e2e/helpers/armadietto.ts`** — new `putInboxFile()` to seed file bytes directly on the server.
- **`tests/e2e/playwright.config.ts`** — new `mobile-webkit` (iPhone 13 / Safari engine) project — the closest automatable proxy for real iOS.
- **`tests/e2e/package.json`** — `test:install` now provisions WebKit for CI.

## Verification

- New spec: 4/4 pass (both tests × Pixel-5 Chromium + iPhone WebKit); both failed before the fix.
- Full e2e suite green across all 3 projects.
- Web unit tests: 411 pass. `svelte-check`: 0 errors. Biome: clean.

## Note

`package-lock.json` reconciles stale workspace versions left by the `release v2.3.5` commit so `npm ci` is consistent.