### PR TITLE
feat(web): drag-drop & paste an image/file onto the capture bar

### DIFF
--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -14,7 +14,7 @@
     createCollection, storeGroup,
     appConfig, setActiveGroupFilters,
   } from './lib/stores';
-  import { captureDetected } from './lib/capture';
+  import { captureDetected, captureFile } from './lib/capture';
   import { showToast } from './lib/toast';
   import { parseHash, formatRoute, pageUsesFilters, type Page, type Route } from './lib/route';
   import { layout } from './lib/layout';
@@ -48,6 +48,8 @@
   let isTouch = $state(
     typeof window !== 'undefined' && window.matchMedia('(max-width: 600px)').matches,
   );
+  // Highlights the inbox feed while a file is dragged over it (desktop only).
+  let feedDragOver = $state(false);
 
   $effect(() => {
     if (typeof window === 'undefined') return;
@@ -224,6 +226,40 @@
     });
   }
 
+  // Drop/paste onto the bar or inbox feed: store the file directly (no form),
+  // mirroring the text quick-capture Undo. `deleteItem` removes the file and
+  // thumbnail bytes too, so Undo leaves nothing orphaned.
+  async function handleFileCapture(file: File, caption = '') {
+    const res = await captureFile(file, caption);
+    if (!res) return;
+    const label = res.item.type === 'image' ? 'Saved image' : 'Saved file';
+    showToast(label, {
+      label: 'Undo',
+      run: () => {
+        void deleteItem(res.item.id, res.item).catch(() => {
+          showToast("Couldn't undo — open the item to remove it.");
+        });
+      },
+    });
+  }
+
+  // A multi-file drop captures only the first; tell the user the rest were
+  // skipped so nothing is silently dropped.
+  function notifyExtraFiles(ignored: number) {
+    showToast(
+      `Captured the first file — ignored ${ignored} other${ignored === 1 ? '' : 's'}.`,
+    );
+  }
+
+  function handleFeedDrop(e: DragEvent) {
+    if (!e.dataTransfer?.types.includes('Files')) return;
+    e.preventDefault();
+    const files = e.dataTransfer.files;
+    if (files.length === 0) return;
+    void handleFileCapture(files[0]);
+    if (files.length > 1) notifyExtraFiles(files.length - 1);
+  }
+
   function handleOpenEditor(text: string) {
     editingItem = undefined;
     preselectedCollectionId = undefined;
@@ -359,11 +395,35 @@
               oncapture={handleQuickCapture}
               onopeneditor={handleOpenEditor}
               onfile={handleFile}
+              onfilecapture={handleFileCapture}
+              onextrafiles={notifyExtraFiles}
               onrecord={handleRecord}
             />
           {/if}
         </div>
-        <InboxGrid onselect={openView} onconnect={openConnectMenu} />
+        {#if isTouch}
+          <InboxGrid onselect={openView} onconnect={openConnectMenu} />
+        {:else}
+          <!-- Desktop: dropping a file anywhere on the feed captures it
+               directly (the bar handles its own drops separately). -->
+          <div
+            class="feed-dropzone"
+            class:drag-over={feedDragOver}
+            role="group"
+            ondragover={(e) => {
+              if (!e.dataTransfer?.types.includes('Files')) return;
+              e.preventDefault();
+              feedDragOver = true;
+            }}
+            ondragleave={() => (feedDragOver = false)}
+            ondrop={(e) => {
+              feedDragOver = false;
+              handleFeedDrop(e);
+            }}
+          >
+            <InboxGrid onselect={openView} onconnect={openConnectMenu} />
+          </div>
+        {/if}
       {:else if route.page === 'todos'}
         {#if TodosPageComponent}
           <TodosPageComponent onselect={openView} onaddtodo={openAddTodo} onaddtodoincollection={openAddTodoInCollection} />
@@ -432,6 +492,19 @@
   /* Inbox add-entry toolbar — the only chrome that lives with the page
      content (rendered into the shell's main slot). All header/footer styling
      belongs to the shell component. */
+  /* Wraps the inbox feed so a file dragged anywhere over it can be dropped.
+     A dashed accent outline appears on drag-over; no layout shift (the
+     outline draws outside the box). */
+  .feed-dropzone {
+    border-radius: 0.85rem;
+    outline: 2px dashed transparent;
+    outline-offset: 4px;
+    transition: outline-color 0.12s ease;
+  }
+  .feed-dropzone.drag-over {
+    outline-color: var(--accent);
+  }
+
   .page-toolbar {
     display: flex;
     align-items: center;

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -415,7 +415,11 @@
               e.preventDefault();
               feedDragOver = true;
             }}
-            ondragleave={() => (feedDragOver = false)}
+            ondragleave={(e) => {
+              // Ignore leaves onto child cards so the highlight doesn't flicker.
+              if ((e.currentTarget as Node).contains(e.relatedTarget as Node | null)) return;
+              feedDragOver = false;
+            }}
             ondrop={(e) => {
               feedDragOver = false;
               handleFeedDrop(e);

--- a/packages/web/src/components/CaptureBar.svelte
+++ b/packages/web/src/components/CaptureBar.svelte
@@ -32,6 +32,7 @@
   let value = $state('');
   let focused = $state(false);
   let fileInputEl = $state<HTMLInputElement | null>(null);
+  let textInputEl = $state<HTMLInputElement | null>(null);
   // A file dropped or pasted onto the bar, staged as a chip until Enter
   // confirms it (Escape or the chip's ✕ discards).
   let pendingFile = $state<File | null>(null);
@@ -77,13 +78,14 @@
     value = '';
   }
 
-  /** Take the first file from a drop/paste, stage it, and report any extras.
-      Returns true when a file was staged. */
-  function stageFiles(files: FileList | null | undefined): boolean {
-    if (!files || files.length === 0) return false;
+  /** Stage the first of `files`, report any extras, and focus the input so
+      Enter/Escape and caption-typing work immediately (a drop doesn't focus
+      the input on its own). */
+  function stageFiles(files: File[]) {
+    if (files.length === 0) return;
     pendingFile = files[0];
     if (files.length > 1) onextrafiles?.(files.length - 1);
-    return true;
+    textInputEl?.focus();
   }
 
   function onPaste(e: ClipboardEvent) {
@@ -93,8 +95,7 @@
     );
     if (imageFiles.length === 0) return;
     e.preventDefault();
-    pendingFile = imageFiles[0];
-    if (imageFiles.length > 1) onextrafiles?.(imageFiles.length - 1);
+    stageFiles(imageFiles);
   }
 
   function onDragOver(e: DragEvent) {
@@ -104,11 +105,19 @@
     dragOver = true;
   }
 
+  // dragleave also fires when the cursor crosses onto a child (button, chip,
+  // input); ignore those so the highlight doesn't flicker — only clear when the
+  // pointer actually leaves the bar.
+  function onDragLeave(e: DragEvent) {
+    if ((e.currentTarget as Node).contains(e.relatedTarget as Node | null)) return;
+    dragOver = false;
+  }
+
   function onDrop(e: DragEvent) {
     if (!e.dataTransfer?.types.includes('Files')) return;
     e.preventDefault();
     dragOver = false;
-    stageFiles(e.dataTransfer.files);
+    stageFiles(Array.from(e.dataTransfer.files));
   }
 
   function onFileChange(e: Event) {
@@ -125,7 +134,7 @@
     class:drag-over={dragOver}
     role="group"
     ondragover={onDragOver}
-    ondragleave={() => (dragOver = false)}
+    ondragleave={onDragLeave}
     ondrop={onDrop}
   >
     <button
@@ -157,6 +166,7 @@
       </span>
     {/if}
     <input
+      bind:this={textInputEl}
       use:autofocusIf={focusOnMount}
       class="text-input"
       type="text"

--- a/packages/web/src/components/CaptureBar.svelte
+++ b/packages/web/src/components/CaptureBar.svelte
@@ -8,12 +8,21 @@
     oncapture,
     onopeneditor,
     onfile,
+    onfilecapture,
+    onextrafiles,
     onrecord,
     focusOnMount = false,
   }: {
     oncapture: (raw: string) => void;
     onopeneditor: (text: string) => void;
+    /** The ⊕ picker: opens the full add-entry form with the file pre-attached. */
     onfile: (file: File) => void;
+    /** Drop/paste: store the staged file directly (chrome-less), with the
+        typed text as its caption. Enter confirms; the parent offers Undo. */
+    onfilecapture: (file: File, caption: string) => void;
+    /** Fired when a drop carried more than one file — only the first is
+        captured; the parent surfaces "ignored the rest". */
+    onextrafiles?: (ignored: number) => void;
     onrecord: () => void;
     /** Focus the input on mount (the inbox does; the collection view doesn't,
         to avoid stealing focus when a collection is expanded). */
@@ -23,15 +32,39 @@
   let value = $state('');
   let focused = $state(false);
   let fileInputEl = $state<HTMLInputElement | null>(null);
+  // A file dropped or pasted onto the bar, staged as a chip until Enter
+  // confirms it (Escape or the chip's ✕ discards).
+  let pendingFile = $state<File | null>(null);
+  let dragOver = $state(false);
   const mod = modLabel();
 
   const detected = $derived(detectCaptureKind(value));
   const enterHint = $derived(
     detected.kind === 'bookmark' ? 'Save bookmark' : 'Save as note',
   );
+  const pendingIsImage = $derived(!!pendingFile?.type.startsWith('image/'));
+
+  function confirmPending() {
+    if (!pendingFile) return;
+    onfilecapture(pendingFile, value.trim());
+    pendingFile = null;
+    value = '';
+  }
 
   function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && pendingFile) {
+      e.preventDefault();
+      pendingFile = null;
+      return;
+    }
     if (e.key !== 'Enter') return;
+    // A staged file takes precedence over text detection: Enter stores it,
+    // using whatever's typed as the caption.
+    if (pendingFile) {
+      e.preventDefault();
+      confirmPending();
+      return;
+    }
     if (e.metaKey || e.ctrlKey) {
       e.preventDefault();
       onopeneditor(value);
@@ -44,6 +77,40 @@
     value = '';
   }
 
+  /** Take the first file from a drop/paste, stage it, and report any extras.
+      Returns true when a file was staged. */
+  function stageFiles(files: FileList | null | undefined): boolean {
+    if (!files || files.length === 0) return false;
+    pendingFile = files[0];
+    if (files.length > 1) onextrafiles?.(files.length - 1);
+    return true;
+  }
+
+  function onPaste(e: ClipboardEvent) {
+    // Prefer an image on the clipboard over its text/URL representation.
+    const imageFiles = Array.from(e.clipboardData?.files ?? []).filter((f) =>
+      f.type.startsWith('image/'),
+    );
+    if (imageFiles.length === 0) return;
+    e.preventDefault();
+    pendingFile = imageFiles[0];
+    if (imageFiles.length > 1) onextrafiles?.(imageFiles.length - 1);
+  }
+
+  function onDragOver(e: DragEvent) {
+    // Only react to file drags, not text selections dragged within the input.
+    if (!e.dataTransfer?.types.includes('Files')) return;
+    e.preventDefault();
+    dragOver = true;
+  }
+
+  function onDrop(e: DragEvent) {
+    if (!e.dataTransfer?.types.includes('Files')) return;
+    e.preventDefault();
+    dragOver = false;
+    stageFiles(e.dataTransfer.files);
+  }
+
   function onFileChange(e: Event) {
     const input = e.currentTarget as HTMLInputElement;
     const file = input.files?.[0];
@@ -53,7 +120,14 @@
 </script>
 
 <div class="capture">
-  <div class="bar">
+  <div
+    class="bar"
+    class:drag-over={dragOver}
+    role="group"
+    ondragover={onDragOver}
+    ondragleave={() => (dragOver = false)}
+    ondrop={onDrop}
+  >
     <button
       class="icon plus"
       type="button"
@@ -62,13 +136,36 @@
     >
       <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
     </button>
+    {#if pendingFile}
+      <span class="chip" title={pendingFile.name}>
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+          {#if pendingIsImage}
+            <rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/>
+          {:else}
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/>
+          {/if}
+        </svg>
+        <span class="chip-name">{pendingFile.name}</span>
+        <button
+          type="button"
+          class="chip-remove"
+          aria-label="Remove attachment"
+          onclick={() => (pendingFile = null)}
+        >
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+        </button>
+      </span>
+    {/if}
     <input
       use:autofocusIf={focusOnMount}
       class="text-input"
       type="text"
-      placeholder="Paste a link, jot a note, or drop a file…"
+      placeholder={pendingFile
+        ? 'Add a caption…'
+        : 'Paste a link, jot a note, or drop a file…'}
       bind:value
       onkeydown={onKeydown}
+      onpaste={onPaste}
       onfocus={() => (focused = true)}
       onblur={() => (focused = false)}
     />
@@ -94,7 +191,11 @@
   <!-- Always rendered with a fixed height so the hint appearing on focus
        never shifts the content below it. -->
   <div class="hint">
-    {#if focused && value.trim()}
+    {#if pendingFile}
+      <span>↵ Save {pendingIsImage ? 'image' : 'file'}</span>
+      <span class="sep">·</span>
+      <span>⎋ Discard</span>
+    {:else if focused && value.trim()}
       <span>↵ {enterHint}</span>
       <span class="sep">·</span>
       <span>{mod}↵ Open editor</span>
@@ -114,6 +215,32 @@
     padding: 0.5rem 0.75rem;
   }
   .bar:focus-within { border-color: var(--accent); }
+  /* Drop target: a dashed accent outline that reads as "release here" without
+     shifting layout (border stays 1px; box-shadow draws the emphasis). */
+  .bar.drag-over {
+    border-color: var(--accent);
+    border-style: dashed;
+    box-shadow: 0 0 0 2px var(--accent-subtle);
+  }
+  .chip {
+    display: inline-flex; align-items: center; gap: 0.35rem;
+    flex-shrink: 0; max-width: 45%;
+    padding: 0.2rem 0.35rem 0.2rem 0.5rem;
+    background: var(--accent-subtle); color: var(--accent);
+    border-radius: 8px;
+    font-size: 0.8rem;
+  }
+  .chip svg { width: 14px; height: 14px; flex-shrink: 0; }
+  .chip-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .chip-remove {
+    display: inline-flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+    width: 18px; height: 18px; padding: 0;
+    border: none; border-radius: 5px;
+    background: none; color: inherit; cursor: pointer;
+  }
+  .chip-remove svg { width: 12px; height: 12px; }
+  .chip-remove:hover { background: var(--accent-subtle-strong); }
   .icon {
     width: 30px; height: 30px;
     flex-shrink: 0;

--- a/packages/web/src/components/CaptureBar.svelte.test.ts
+++ b/packages/web/src/components/CaptureBar.svelte.test.ts
@@ -9,12 +9,16 @@ describe('CaptureBar', () => {
   let oncapture: ReturnType<typeof vi.fn>;
   let onopeneditor: ReturnType<typeof vi.fn>;
   let onfile: ReturnType<typeof vi.fn>;
+  let onfilecapture: ReturnType<typeof vi.fn>;
+  let onextrafiles: ReturnType<typeof vi.fn>;
   let onrecord: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     oncapture = vi.fn();
     onopeneditor = vi.fn();
     onfile = vi.fn();
+    onfilecapture = vi.fn();
+    onextrafiles = vi.fn();
     onrecord = vi.fn();
     host = document.createElement('div');
     document.body.appendChild(host);
@@ -27,19 +31,48 @@ describe('CaptureBar', () => {
   function render() {
     component = mount(CaptureBar, {
       target: host,
-      props: { oncapture, onopeneditor, onfile, onrecord },
+      props: {
+        oncapture,
+        onopeneditor,
+        onfile,
+        onfilecapture,
+        onextrafiles,
+        onrecord,
+      },
     });
     flushSync();
   }
 
-  function typeAndKey(value: string, init: KeyboardEventInit) {
+  function type(value: string) {
     const input = host.querySelector('.text-input') as HTMLInputElement;
     input.value = value;
     input.dispatchEvent(new Event('input', { bubbles: true }));
     flushSync();
+  }
+
+  function key(init: KeyboardEventInit) {
+    const input = host.querySelector('.text-input') as HTMLInputElement;
     input.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, ...init }),
     );
+    flushSync();
+  }
+
+  function typeAndKey(value: string, init: KeyboardEventInit) {
+    type(value);
+    key(init);
+  }
+
+  /** Build a DataTransfer-like stub carrying files — jsdom has no real one. */
+  function fileTransfer(files: File[]) {
+    return { types: ['Files'], files } as unknown as DataTransfer;
+  }
+
+  function dropFiles(files: File[]) {
+    const bar = host.querySelector('.bar') as HTMLElement;
+    const e = new Event('drop', { bubbles: true }) as DragEvent;
+    Object.defineProperty(e, 'dataTransfer', { value: fileTransfer(files) });
+    bar.dispatchEvent(e);
     flushSync();
   }
 
@@ -82,5 +115,86 @@ describe('CaptureBar', () => {
     fileInput.dispatchEvent(new Event('change', { bubbles: true }));
     flushSync();
     expect(onfile).toHaveBeenCalledWith(file);
+  });
+
+  it('stages a dropped file as a chip without capturing it yet', () => {
+    render();
+    const file = new File(['x'], 'photo.png', { type: 'image/png' });
+    dropFiles([file]);
+    const chip = host.querySelector('.chip-name');
+    expect(chip?.textContent).toBe('photo.png');
+    // Nothing stored until the user confirms.
+    expect(onfilecapture).not.toHaveBeenCalled();
+  });
+
+  it('Enter confirms a staged file with the typed caption', () => {
+    render();
+    const file = new File(['x'], 'photo.png', { type: 'image/png' });
+    dropFiles([file]);
+    typeAndKey('a nice sunset', {});
+    expect(onfilecapture).toHaveBeenCalledWith(file, 'a nice sunset');
+    // The chip and text clear after confirming.
+    expect(host.querySelector('.chip')).toBeNull();
+    expect((host.querySelector('.text-input') as HTMLInputElement).value).toBe('');
+    // A staged file must not also fire a text capture.
+    expect(oncapture).not.toHaveBeenCalled();
+  });
+
+  it('Escape discards a staged file without capturing', () => {
+    render();
+    dropFiles([new File(['x'], 'photo.png', { type: 'image/png' })]);
+    key({ key: 'Escape' });
+    expect(host.querySelector('.chip')).toBeNull();
+    expect(onfilecapture).not.toHaveBeenCalled();
+  });
+
+  it('the chip ✕ button discards the staged file', () => {
+    render();
+    dropFiles([new File(['x'], 'photo.png', { type: 'image/png' })]);
+    (host.querySelector('.chip-remove') as HTMLButtonElement).click();
+    flushSync();
+    expect(host.querySelector('.chip')).toBeNull();
+    expect(onfilecapture).not.toHaveBeenCalled();
+  });
+
+  it('reports extra files when several are dropped, staging only the first', () => {
+    render();
+    dropFiles([
+      new File(['a'], 'a.png', { type: 'image/png' }),
+      new File(['b'], 'b.png', { type: 'image/png' }),
+      new File(['c'], 'c.png', { type: 'image/png' }),
+    ]);
+    expect((host.querySelector('.chip-name') as HTMLElement).textContent).toBe(
+      'a.png',
+    );
+    expect(onextrafiles).toHaveBeenCalledWith(2);
+  });
+
+  it('pasting an image stages it; a staged file takes precedence over text', () => {
+    render();
+    type('existing text');
+    const input = host.querySelector('.text-input') as HTMLInputElement;
+    const file = new File(['x'], 'clip.png', { type: 'image/png' });
+    const e = new Event('paste', { bubbles: true }) as ClipboardEvent;
+    Object.defineProperty(e, 'clipboardData', { value: { files: [file] } });
+    input.dispatchEvent(e);
+    flushSync();
+    expect(host.querySelector('.chip-name')?.textContent).toBe('clip.png');
+    // Enter now confirms the image, using the pre-existing text as the caption.
+    key({});
+    expect(onfilecapture).toHaveBeenCalledWith(file, 'existing text');
+    expect(oncapture).not.toHaveBeenCalled();
+  });
+
+  it('ignores a paste with no image (leaves text capture intact)', () => {
+    render();
+    const input = host.querySelector('.text-input') as HTMLInputElement;
+    const e = new Event('paste', { bubbles: true }) as ClipboardEvent;
+    Object.defineProperty(e, 'clipboardData', { value: { files: [] } });
+    input.dispatchEvent(e);
+    flushSync();
+    expect(host.querySelector('.chip')).toBeNull();
+    typeAndKey('just text', {});
+    expect(oncapture).toHaveBeenCalledWith('just text');
   });
 });

--- a/packages/web/src/components/CaptureBar.svelte.test.ts
+++ b/packages/web/src/components/CaptureBar.svelte.test.ts
@@ -127,6 +127,12 @@ describe('CaptureBar', () => {
     expect(onfilecapture).not.toHaveBeenCalled();
   });
 
+  it('focuses the input after a drop so Enter/Escape and captions work', () => {
+    render();
+    dropFiles([new File(['x'], 'photo.png', { type: 'image/png' })]);
+    expect(document.activeElement).toBe(host.querySelector('.text-input'));
+  });
+
   it('Enter confirms a staged file with the typed caption', () => {
     render();
     const file = new File(['x'], 'photo.png', { type: 'image/png' });
@@ -135,7 +141,9 @@ describe('CaptureBar', () => {
     expect(onfilecapture).toHaveBeenCalledWith(file, 'a nice sunset');
     // The chip and text clear after confirming.
     expect(host.querySelector('.chip')).toBeNull();
-    expect((host.querySelector('.text-input') as HTMLInputElement).value).toBe('');
+    expect((host.querySelector('.text-input') as HTMLInputElement).value).toBe(
+      '',
+    );
     // A staged file must not also fire a text capture.
     expect(oncapture).not.toHaveBeenCalled();
   });

--- a/packages/web/src/components/CollectionView.svelte
+++ b/packages/web/src/components/CollectionView.svelte
@@ -19,7 +19,7 @@
   import { slide, fade } from 'svelte/transition';
   import { flip } from 'svelte/animate';
   import { dndzone } from 'svelte-dnd-action';
-  import { captureDetected } from '../lib/capture';
+  import { captureDetected, captureFile } from '../lib/capture';
   import { showToast } from '../lib/toast';
   import InboxCard from './InboxCard.svelte';
   import CaptureBar from './CaptureBar.svelte';
@@ -96,6 +96,33 @@
     prefillTitle = '';
     prefillFile = file;
     addingType = file.type.startsWith('image/') ? 'image' : 'document';
+  }
+
+  // Drop/paste onto the bar: store the file directly into this collection,
+  // with the same Undo as a text capture.
+  async function handleFileCaptureDirect(file: File, caption = '') {
+    let res: Awaited<ReturnType<typeof captureFile>>;
+    try {
+      res = await captureFile(file, caption, collection.id);
+    } catch (error) {
+      console.error('Failed to capture file into collection', error);
+      showToast("Couldn't save — this collection is no longer available.");
+      return;
+    }
+    if (!res) return;
+    const label = res.item.type === 'image' ? 'Saved image' : 'Saved file';
+    showToast(label, {
+      label: 'Undo',
+      run: () => {
+        void deleteItem(res.item.id, res.item);
+      },
+    });
+  }
+
+  function notifyExtraFiles(ignored: number) {
+    showToast(
+      `Captured the first file — ignored ${ignored} other${ignored === 1 ? '' : 's'}.`,
+    );
   }
 
   function handleRecord() {
@@ -317,6 +344,8 @@
           oncapture={handleCapture}
           onopeneditor={handleOpenEditor}
           onfile={handleCaptureFile}
+          onfilecapture={handleFileCaptureDirect}
+          onextrafiles={notifyExtraFiles}
           onrecord={handleRecord}
         />
 

--- a/packages/web/src/lib/capture.test.ts
+++ b/packages/web/src/lib/capture.test.ts
@@ -19,7 +19,7 @@ const { storeItem, moveItemToCollection, collections } = vi.hoisted(() => {
 });
 vi.mock('./stores', () => ({ storeItem, moveItemToCollection, collections }));
 
-import { captureDetected } from './capture';
+import { captureFile, captureDetected } from './capture';
 
 afterEach(() => vi.clearAllMocks());
 
@@ -61,6 +61,45 @@ describe('captureDetected', () => {
       captureDetected('remember the milk', 'gone'),
     ).rejects.toThrow();
     // Nothing stored or filed — no orphaned item left in the Inbox.
+    expect(storeItem).not.toHaveBeenCalled();
+    expect(moveItemToCollection).not.toHaveBeenCalled();
+  });
+});
+
+describe('captureFile', () => {
+  it('stores an image item for an image file, defaulting the title to the name', async () => {
+    const file = new File(['x'], 'sunset.png', { type: 'image/png' });
+    const res = await captureFile(file);
+    expect(res?.item.type).toBe('image');
+    expect(res?.item.title).toBe('sunset.png');
+    expect(storeItem).toHaveBeenCalledOnce();
+    // The binary payload is passed alongside the metadata item.
+    expect(storeItem.mock.calls[0][1]).toBeInstanceOf(ArrayBuffer);
+  });
+
+  it('stores a document item for a non-image file', async () => {
+    const file = new File(['x'], 'report.pdf', { type: 'application/pdf' });
+    const res = await captureFile(file);
+    expect(res?.item.type).toBe('document');
+    expect(res?.item.title).toBe('report.pdf');
+    expect(storeItem).toHaveBeenCalledOnce();
+  });
+
+  it('uses a caption as the item title when given', async () => {
+    const file = new File(['x'], 'sunset.png', { type: 'image/png' });
+    const res = await captureFile(file, '  Golden hour  ');
+    expect(res?.item.title).toBe('Golden hour');
+  });
+
+  it('files the item into a collection when a collectionId is given', async () => {
+    const file = new File(['x'], 'sunset.png', { type: 'image/png' });
+    const res = await captureFile(file, '', 'col-1');
+    expect(moveItemToCollection).toHaveBeenCalledWith(res?.item.id, 'col-1');
+  });
+
+  it('throws before storing when the target collection no longer exists', async () => {
+    const file = new File(['x'], 'sunset.png', { type: 'image/png' });
+    await expect(captureFile(file, '', 'gone')).rejects.toThrow();
     expect(storeItem).not.toHaveBeenCalled();
     expect(moveItemToCollection).not.toHaveBeenCalled();
   });

--- a/packages/web/src/lib/capture.test.ts
+++ b/packages/web/src/lib/capture.test.ts
@@ -19,7 +19,7 @@ const { storeItem, moveItemToCollection, collections } = vi.hoisted(() => {
 });
 vi.mock('./stores', () => ({ storeItem, moveItemToCollection, collections }));
 
-import { captureFile, captureDetected } from './capture';
+import { captureDetected, captureFile } from './capture';
 
 afterEach(() => vi.clearAllMocks());
 

--- a/packages/web/src/lib/capture.ts
+++ b/packages/web/src/lib/capture.ts
@@ -1,6 +1,11 @@
 import type { InboxItem } from '@inbox-rs/rs-module';
 import { get } from 'svelte/store';
-import { buildBookmarkItem, buildNoteItem } from './build-item';
+import {
+  buildBookmarkItem,
+  buildDocumentItem,
+  buildImageItem,
+  buildNoteItem,
+} from './build-item';
 import { detectCaptureKind } from './capture-detect';
 import { collections, moveItemToCollection, storeItem } from './stores';
 
@@ -35,6 +40,39 @@ export async function captureDetected(
       : buildNoteItem(ctx, { title: '', body: detected.body, description: '' });
 
   await storeItem(built.item);
+  if (collectionId) {
+    await moveItemToCollection(built.item.id, collectionId);
+  }
+  return { item: built.item };
+}
+
+/** Build and store a dropped/pasted file directly — the chrome-less counterpart
+ *  to the ⊕ picker, which opens the full form. Images become image items,
+ *  everything else a document item. An optional caption becomes the title
+ *  (the builders fall back to the filename when it's blank). Returns the
+ *  created item so the caller can offer Undo. */
+export async function captureFile(
+  file: File,
+  caption = '',
+  collectionId?: string,
+): Promise<{ item: InboxItem } | null> {
+  const ctx = { id: crypto.randomUUID(), createdAt: new Date().toISOString() };
+  const title = caption.trim();
+
+  // Mirror captureDetected: validate the destination before storing so a
+  // missing collection fails up front rather than silently orphaning the item
+  // in the Inbox (moveItemToCollection no-ops for a missing collection).
+  if (collectionId && !get(collections)[collectionId]) {
+    throw new Error('Target collection no longer exists');
+  }
+
+  const built = file.type.startsWith('image/')
+    ? await buildImageItem(ctx, { title, description: '', file })
+    : await buildDocumentItem(ctx, { title, description: '', file });
+  // The builders only return null without a file; we always pass one.
+  if (!built) return null;
+
+  await storeItem(built.item, built.fileData, built.thumbData);
   if (collectionId) {
     await moveItemToCollection(built.item.id, collectionId);
   }


### PR DESCRIPTION
Closes #146.

Implements the deferred attachment path from the smart capture bar: dropping or pasting a file/image directly, instead of going through the `⊕` → form flow.

## Behavior (desktop only)
- **Drop or paste onto the bar** → stages a removable chip; typed text becomes the caption; **Enter** stores it, **Escape** / chip-✕ discards.
- **Drop onto the inbox feed** → stores immediately with an Undo toast.
- **Drop onto a collection view's bar** → files directly into that collection.
- **Multi-file drop** → captures the first file, toasts that the rest were ignored (per the spec's singular "an image/file").
- Images → image items (with the usual auto-thumbnail), everything else → document items. Caption becomes the title, falling back to the filename.

Mobile is unchanged — it keeps the `⊕` / OS pickers via the capture sheet.

## Implementation
- **`lib/capture.ts`** — new `captureFile(file, caption?, collectionId?)`, a chrome-less counterpart to `captureDetected()`. Routes by mime type, reuses `buildImageItem`/`buildDocumentItem` + `storeItem`, and validates the target collection up front.
- **`CaptureBar.svelte`** — chip state, `paste`/`dragover`/`drop` handlers, Enter-confirms-staged-file logic, a drop-target outline, and an updated hint line. New `onfilecapture` + `onextrafiles` props.
- **`App.svelte`** — `handleFileCapture` with the same Undo toast as text captures, plus a drop zone wrapping the inbox feed.
- **`CollectionView.svelte`** — direct file capture that files into the open collection.

Undo reuses `deleteItem`, which already removes the file and thumbnail bytes, so nothing is orphaned.

## Tests
- +12 `CaptureBar` cases (chip staging, paste, drop, multi-file, Enter/Escape, image-over-text precedence).
- +5 `captureFile` cases (image vs. document routing, caption→title, collection filing, missing-collection guard).
- Full web suite: **423 passing**. `svelte-check`: 0 errors. Build: clean.

## Out of scope / possible follow-up
A *near-miss* drop (onto the page margin or header, not the bar or feed) still triggers the browser's default open-the-file behavior. The issue scopes drops to the bar and feed, so this PR doesn't add a window-level `preventDefault` guard — a small hardening we could add separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capture images and documents directly from drag-and-drop or paste into the inbox/feed, with “Saved image”/“Saved file” feedback.
  * Undo is available after a direct capture, and extra files dropped are now reported (only the first is captured).
  * Files can be staged first in the capture bar, then saved with the typed caption using Enter.
* **Bug Fixes**
  * Improved drag-and-drop/paste handling with clearer drag-over highlighting.
  * Staged attachments can be discarded via Escape or removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->