### PR TITLE
fix(web): plugins page squeezed into sidebar track in sidebar layout

### DIFF
--- a/packages/web/src/components/SidebarShell.svelte
+++ b/packages/web/src/components/SidebarShell.svelte
@@ -262,16 +262,18 @@
 
 <header>
   <div class="header-inner">
-    <button
-      class="sidebar-toggle"
-      type="button"
-      aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-      aria-pressed={!collapsed}
-      title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-      onclick={toggleCollapsed}
-    >
-      <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-    </button>
+    {#if !noSidebar}
+      <button
+        class="sidebar-toggle"
+        type="button"
+        aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        aria-pressed={!collapsed}
+        title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        onclick={toggleCollapsed}
+      >
+        <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
+    {/if}
     <div class="brand">
       <a class="brand-link" href="#/">
         <h1 class="sr-only">Inbox RS</h1>

--- a/packages/web/src/components/SidebarShell.svelte
+++ b/packages/web/src/components/SidebarShell.svelte
@@ -63,6 +63,9 @@
   const activeGroups = $derived($activeGroupIds);
   const inactiveCols = $derived($inactiveCollectionIds);
   const dragging = $derived($draggingItemId !== null);
+  // The plugins/Downloads page has no groups to filter — the sidebar is
+  // omitted entirely and the body grid must collapse to a single column.
+  const noSidebar = $derived(route.page === 'plugins');
 
   function readCollapsed(): boolean {
     try {
@@ -306,8 +309,8 @@
   </div>
 </header>
 
-<div class="body" class:sidebar-collapsed={collapsed}>
-  {#if route.page !== 'plugins'}
+<div class="body" class:sidebar-collapsed={collapsed} class:no-sidebar={noSidebar}>
+  {#if !noSidebar}
     <aside class="sidebar" class:collapsed class:dragging aria-label="Groups and collections">
       {#if collapsed}
         <div class="rail">
@@ -648,6 +651,13 @@
 
   .body.sidebar-collapsed {
     grid-template-columns: 60px minmax(0, 1fr);
+  }
+
+  /* No sidebar rendered (plugins page): without this, <main> would land in
+     the narrow first track and squeeze the whole page against the left edge. */
+  .body.no-sidebar,
+  .body.no-sidebar.sidebar-collapsed {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   /* ── Sidebar ── */

--- a/tests/e2e/desktop/navigation.spec.ts
+++ b/tests/e2e/desktop/navigation.spec.ts
@@ -37,6 +37,37 @@ test('plugins page loads when disconnected', async ({ page, webOrigin }) => {
   await expect(downloads).toHaveClass(/active/);
 });
 
+test('plugins page spans the full width in the sidebar layout', async ({
+  page,
+  webOrigin,
+}) => {
+  // Regression: SidebarShell omits the sidebar on the plugins route, but the
+  // body grid used to keep its 268px sidebar track — squeezing the whole page
+  // into that narrow first column with the rest of the viewport empty.
+  await page.addInitScript(() =>
+    localStorage.setItem('inbox-rs:layout', 'sidebar'),
+  );
+  await page.goto(`${webOrigin}/#/plugins`);
+  await page.waitForLoadState('networkidle');
+
+  const viewport = page.viewportSize();
+  if (!viewport) throw new Error('viewport must be set for this test');
+
+  const main = page.locator('main');
+  await expect(main).toBeVisible();
+  const mainBox = await main.boundingBox();
+  expect(mainBox, 'main must be laid out').not.toBeNull();
+  expect(mainBox!.width).toBeGreaterThan(viewport.width * 0.9);
+
+  // The download cards are the densest content — if the grid regresses they
+  // collapse and overlap, so pin a sane minimum width on the first card too.
+  const card = page.locator('.download-card').first();
+  await expect(card).toBeVisible();
+  const cardBox = await card.boundingBox();
+  expect(cardBox, 'download card must be laid out').not.toBeNull();
+  expect(cardBox!.width).toBeGreaterThan(viewport.width * 0.3);
+});
+
 test('nav buttons swap routes when connected', async ({
   connectedPage,
   webOrigin,


### PR DESCRIPTION
## Problem

In the **sidebar layout**, the Downloads/Plugins page rendered crushed into a ~268px strip on the left edge, with the download cards overlapping and the rest of the viewport empty.

`SidebarShell` intentionally omits the sidebar `<aside>` on the plugins route (there are no groups to filter there), but the `.body` grid kept its two-column template (`268px minmax(0, 1fr)`) — so `<main>` slid into the narrow sidebar track. The classic layout was unaffected.

## Fix

A `noSidebar` derived flag adds a `no-sidebar` class to `.body`, collapsing the grid to a single full-width column whenever the sidebar isn't rendered. Verified via screenshots in light/dark, expanded/collapsed sidebar, desktop and mobile.

## Test

New desktop e2e spec: **plugins page spans the full width in the sidebar layout** — sets `inbox-rs:layout=sidebar`, opens `#/plugins`, and asserts `<main>` fills ≥90% of the viewport width and the first `.download-card` ≥30%. Confirmed it fails against the buggy version and passes with the fix; the full navigation spec (5 tests) is green against the production preview build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the layout on the Plugins/Downloads page so the sidebar is hidden there and the main content uses the full width.
  * Prevented the page from squeezing into a narrow column when the sidebar layout is enabled.
  * Added end-to-end coverage for the Plugins/Downloads desktop view to help keep the layout stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->