### PR TITLE
fix(web): recover from failed lazy-chunk loads instead of freezing the app

### DIFF
--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -15,6 +15,7 @@
     appConfig, setActiveGroupFilters,
   } from './lib/stores';
   import { captureDetected, captureFile } from './lib/capture';
+  import { loadLazy } from './lib/lazy-load';
   import { showToast } from './lib/toast';
   import { parseHash, formatRoute, pageUsesFilters, type Page, type Route } from './lib/route';
   import { layout } from './lib/layout';
@@ -64,59 +65,43 @@
 
   let route = $state<Route>(parseHash(window.location.hash));
 
-  // A failed chunk fetch (stale tab after a deploy, flaky network) must never
-  // leave a modal "open" with no UI — undo the state that summoned it and tell
-  // the user. In production a deploy-invalidated chunk also triggers a one-shot
-  // reload via vite:preloadError (see main.ts); this catch covers the rest.
-  async function loadLazy(
-    importer: () => Promise<{ default: unknown }>,
-    onerror?: () => void,
-  ): Promise<LazyComponent | null> {
-    try {
-      return (await importer()).default as LazyComponent;
-    } catch (error) {
-      console.error('Failed to load lazy component', error);
-      onerror?.();
-      showToast("Couldn't load that view — reload the app and try again.");
-      return null;
-    }
-  }
-
+  // A failed lazy load must never leave a modal "open" with no UI — the
+  // onerror callbacks undo the state that summoned it (see lib/lazy-load.ts).
   async function loadAddEntryModal() {
-    AddEntryModalComponent ??= await loadLazy(
+    AddEntryModalComponent ??= await loadLazy<LazyComponent>(
       () => import('./components/AddEntryModal.svelte'),
       closeModal,
     );
   }
 
   async function loadViewCardModal() {
-    ViewCardModalComponent ??= await loadLazy(
+    ViewCardModalComponent ??= await loadLazy<LazyComponent>(
       () => import('./components/ViewCardModal.svelte'),
       () => { viewingItem = null; },
     );
   }
 
   async function loadPluginsPage() {
-    PluginsPageComponent ??= await loadLazy(() => import('./components/PluginsPage.svelte'));
+    PluginsPageComponent ??= await loadLazy<LazyComponent>(() => import('./components/PluginsPage.svelte'));
   }
 
   async function loadTodosPage() {
-    TodosPageComponent ??= await loadLazy(() => import('./components/TodosPage.svelte'));
+    TodosPageComponent ??= await loadLazy<LazyComponent>(() => import('./components/TodosPage.svelte'));
   }
 
   async function loadCollectionsPage() {
-    CollectionsPageComponent ??= await loadLazy(() => import('./components/CollectionsPage.svelte'));
+    CollectionsPageComponent ??= await loadLazy<LazyComponent>(() => import('./components/CollectionsPage.svelte'));
   }
 
   async function loadCollectionFormModal() {
-    CollectionFormModalComponent ??= await loadLazy(
+    CollectionFormModalComponent ??= await loadLazy<LazyComponent>(
       () => import('./components/CollectionFormModal.svelte'),
       () => { showCollectionForm = false; },
     );
   }
 
   async function loadGroupFormModal() {
-    GroupFormModalComponent ??= await loadLazy(
+    GroupFormModalComponent ??= await loadLazy<LazyComponent>(
       () => import('./components/GroupFormModal.svelte'),
       () => { showGroupForm = false; },
     );

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -64,32 +64,62 @@
 
   let route = $state<Route>(parseHash(window.location.hash));
 
+  // A failed chunk fetch (stale tab after a deploy, flaky network) must never
+  // leave a modal "open" with no UI — undo the state that summoned it and tell
+  // the user. In production a deploy-invalidated chunk also triggers a one-shot
+  // reload via vite:preloadError (see main.ts); this catch covers the rest.
+  async function loadLazy(
+    importer: () => Promise<{ default: unknown }>,
+    onerror?: () => void,
+  ): Promise<LazyComponent | null> {
+    try {
+      return (await importer()).default as LazyComponent;
+    } catch (error) {
+      console.error('Failed to load lazy component', error);
+      onerror?.();
+      showToast("Couldn't load that view — reload the app and try again.");
+      return null;
+    }
+  }
+
   async function loadAddEntryModal() {
-    AddEntryModalComponent ??= (await import('./components/AddEntryModal.svelte')).default as LazyComponent;
+    AddEntryModalComponent ??= await loadLazy(
+      () => import('./components/AddEntryModal.svelte'),
+      closeModal,
+    );
   }
 
   async function loadViewCardModal() {
-    ViewCardModalComponent ??= (await import('./components/ViewCardModal.svelte')).default as LazyComponent;
+    ViewCardModalComponent ??= await loadLazy(
+      () => import('./components/ViewCardModal.svelte'),
+      () => { viewingItem = null; },
+    );
   }
 
   async function loadPluginsPage() {
-    PluginsPageComponent ??= (await import('./components/PluginsPage.svelte')).default as LazyComponent;
+    PluginsPageComponent ??= await loadLazy(() => import('./components/PluginsPage.svelte'));
   }
 
   async function loadTodosPage() {
-    TodosPageComponent ??= (await import('./components/TodosPage.svelte')).default as LazyComponent;
+    TodosPageComponent ??= await loadLazy(() => import('./components/TodosPage.svelte'));
   }
 
   async function loadCollectionsPage() {
-    CollectionsPageComponent ??= (await import('./components/CollectionsPage.svelte')).default as LazyComponent;
+    CollectionsPageComponent ??= await loadLazy(() => import('./components/CollectionsPage.svelte'));
   }
 
   async function loadCollectionFormModal() {
-    CollectionFormModalComponent ??= (await import('./components/CollectionFormModal.svelte')).default as LazyComponent;
+    CollectionFormModalComponent ??= await loadLazy(
+      () => import('./components/CollectionFormModal.svelte'),
+      () => { showCollectionForm = false; },
+    );
   }
 
   async function loadGroupFormModal() {
-    GroupFormModalComponent ??= (await import('./components/GroupFormModal.svelte')).default as LazyComponent;
+    GroupFormModalComponent ??= await loadLazy(
+      () => import('./components/GroupFormModal.svelte'),
+      () => { showGroupForm = false; },
+    );
   }
 
   // ---- Route ↔ filter sync ----
@@ -166,8 +196,17 @@
     if (showGroupForm) void loadGroupFormModal();
   });
 
-  // Lock body scroll when any modal is open (including iOS Safari)
-  const anyModalOpen = $derived(!!viewingItem || !!activeModal || showCollectionForm || showGroupForm || captureSheetOpen);
+  // Lock body scroll when any modal is open (including iOS Safari). Each
+  // lazy-loaded modal counts only once its component is available — the same
+  // condition that renders it — so the lock can never engage for a modal that
+  // isn't on screen (e.g. its chunk failed to load).
+  const anyModalOpen = $derived(
+    !!(viewingItem && ViewCardModalComponent)
+    || !!(activeModal && AddEntryModalComponent)
+    || (showCollectionForm && !!CollectionFormModalComponent)
+    || (showGroupForm && !!GroupFormModalComponent)
+    || captureSheetOpen,
+  );
   let savedScrollY = 0;
   let wasModalOpen = false;
 

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -12,6 +12,7 @@
     isAccent,
   } from '../lib/theme';
   import { layout, setLayoutPersisted } from '../lib/layout';
+  import { showToast } from '../lib/toast';
 
   // Typed with the modal's exports so `bind:this` yields the handle we call
   // (startExport/promptImport) instead of an untyped instance.
@@ -32,8 +33,17 @@
   let importExportOpen = $state(false);
   let fileInputEl = $state<HTMLInputElement | null>(null);
 
+  // Catch failed chunk fetches (stale tab after a deploy, flaky network) so
+  // Export/Import doesn't fail silently — the callers' optional-chained calls
+  // then no-op. A deploy-invalidated chunk also triggers a one-shot reload via
+  // vite:preloadError (see main.ts).
   async function loadImportExportModal() {
-    ImportExportModalComponent ??= (await import('./ImportExportModal.svelte')).default as unknown as LazyComponent;
+    try {
+      ImportExportModalComponent ??= (await import('./ImportExportModal.svelte')).default as unknown as LazyComponent;
+    } catch (error) {
+      console.error('Failed to load import/export modal', error);
+      showToast("Couldn't load that view — reload the app and try again.");
+    }
   }
 
   // Theme: synced settings take priority, localStorage is the offline fallback

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -12,7 +12,7 @@
     isAccent,
   } from '../lib/theme';
   import { layout, setLayoutPersisted } from '../lib/layout';
-  import { showToast } from '../lib/toast';
+  import { loadLazy } from '../lib/lazy-load';
 
   // Typed with the modal's exports so `bind:this` yields the handle we call
   // (startExport/promptImport) instead of an untyped instance.
@@ -33,17 +33,10 @@
   let importExportOpen = $state(false);
   let fileInputEl = $state<HTMLInputElement | null>(null);
 
-  // Catch failed chunk fetches (stale tab after a deploy, flaky network) so
-  // Export/Import doesn't fail silently — the callers' optional-chained calls
-  // then no-op. A deploy-invalidated chunk also triggers a one-shot reload via
-  // vite:preloadError (see main.ts).
+  // On a failed chunk fetch, loadLazy toasts and the callers' optional-chained
+  // calls no-op — Export/Import doesn't fail silently or leave state dangling.
   async function loadImportExportModal() {
-    try {
-      ImportExportModalComponent ??= (await import('./ImportExportModal.svelte')).default as unknown as LazyComponent;
-    } catch (error) {
-      console.error('Failed to load import/export modal', error);
-      showToast("Couldn't load that view — reload the app and try again.");
-    }
+    ImportExportModalComponent ??= await loadLazy<LazyComponent>(() => import('./ImportExportModal.svelte'));
   }
 
   // Theme: synced settings take priority, localStorage is the offline fallback

--- a/packages/web/src/lib/lazy-load.ts
+++ b/packages/web/src/lib/lazy-load.ts
@@ -1,0 +1,26 @@
+import { showToast } from './toast';
+
+/**
+ * Load a lazy (dynamic-imported) component, tolerating a failed chunk fetch.
+ *
+ * A failure (stale tab after a deploy, flaky network) must never leave the
+ * summoning state dangling — e.g. a modal "open" with no UI — so callers pass
+ * `onerror` to undo that state; the user gets a toast either way. Callers
+ * assign with `??=`, so a `null` return leaves the cache empty and the next
+ * attempt retries the import. In production a deploy-invalidated chunk also
+ * triggers a one-shot reload via vite:preloadError (see main.ts); this catch
+ * covers the rest.
+ */
+export async function loadLazy<T>(
+  importer: () => Promise<{ default: unknown }>,
+  onerror?: () => void,
+): Promise<T | null> {
+  try {
+    return (await importer()).default as T;
+  } catch (error) {
+    console.error('Failed to load lazy component', error);
+    onerror?.();
+    showToast("Couldn't load that view — reload the app and try again.");
+    return null;
+  }
+}

--- a/packages/web/src/lib/preload-error.test.ts
+++ b/packages/web/src/lib/preload-error.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { installPreloadErrorReload } from './preload-error';
+
+function firePreloadError() {
+  window.dispatchEvent(new Event('vite:preloadError'));
+}
+
+describe('installPreloadErrorReload', () => {
+  let uninstall: (() => void) | undefined;
+
+  afterEach(() => {
+    uninstall?.();
+    uninstall = undefined;
+    sessionStorage.clear();
+  });
+
+  it('reloads on the first preload error, then guards against a loop', () => {
+    const reload = vi.fn();
+    let t = 1_000_000;
+    uninstall = installPreloadErrorReload(reload, () => t);
+
+    firePreloadError();
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    // Within the guard window: no second reload (would loop).
+    t += 30_000;
+    firePreloadError();
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    // Past the window a fresh failure may reload again.
+    t += 60_000;
+    firePreloadError();
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not reload again right after a guard-stamped reload (sessionStorage persists across reloads)', () => {
+    const reload = vi.fn();
+    const t = 2_000_000;
+    // Simulate the state just after a preload-error reload: the previous page
+    // load stamped the timestamp before reloading.
+    sessionStorage.setItem('inbox-rs:preload-error-reload', String(t - 1_000));
+    uninstall = installPreloadErrorReload(reload, () => t);
+
+    firePreloadError();
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/lib/preload-error.ts
+++ b/packages/web/src/lib/preload-error.ts
@@ -1,0 +1,44 @@
+/**
+ * Recover from deploy-invalidated lazy chunks.
+ *
+ * The app is a PWA registered with `autoUpdate`: a tab left open across a
+ * release keeps running the old shell, but the new service worker purges the
+ * old hashed chunks from the precache (and the deploy removes them from the
+ * server). The next dynamic import — e.g. clicking a card, which lazy-loads
+ * ViewCardModal — then 404s. Vite surfaces exactly that failure as a
+ * `vite:preloadError` event; reloading fetches the fresh shell whose chunks
+ * all exist.
+ *
+ * A reload is only attempted once per RELOAD_WINDOW_MS (tracked in
+ * sessionStorage so it survives the reload itself). If the failure persists —
+ * assets genuinely unreachable — the error propagates to the import() caller
+ * instead of reload-looping.
+ */
+
+const STORAGE_KEY = 'inbox-rs:preload-error-reload';
+const RELOAD_WINDOW_MS = 60_000;
+
+export function installPreloadErrorReload(
+  reload: () => void = () => window.location.reload(),
+  now: () => number = Date.now,
+): () => void {
+  const onPreloadError = () => {
+    let last = 0;
+    try {
+      last = Number(sessionStorage.getItem(STORAGE_KEY) ?? 0);
+    } catch {
+      // Storage blocked (private mode etc.) — we can't guard against a
+      // reload loop, so don't auto-reload; the caller's catch handles it.
+      return;
+    }
+    if (now() - last < RELOAD_WINDOW_MS) return;
+    try {
+      sessionStorage.setItem(STORAGE_KEY, String(now()));
+    } catch {
+      return;
+    }
+    reload();
+  };
+  window.addEventListener('vite:preloadError', onPreloadError);
+  return () => window.removeEventListener('vite:preloadError', onPreloadError);
+}

--- a/packages/web/src/main.ts
+++ b/packages/web/src/main.ts
@@ -1,6 +1,11 @@
 import { mount } from 'svelte';
+import { installPreloadErrorReload } from './lib/preload-error';
 import { type Accent, applyTheme, isAccent, type Mode } from './lib/theme';
 import Root from './Root.svelte';
+
+// A tab left open across a release can no longer fetch its lazy chunks —
+// reload once to pick up the fresh shell (see lib/preload-error.ts).
+installPreloadErrorReload();
 
 // Apply the stored theme (accent + light/dark) before mount to avoid a flash.
 // Mode is reconciled with synced UserSettings once connected (see UserMenu);


### PR DESCRIPTION
## Problem

The app would intermittently "lock up": clicking a card did nothing, scrolling died, and no card would open until a hard reload.

Root cause is a stale-tab-after-deploy failure chain:

1. The app is a PWA with `registerType: 'autoUpdate'` and `cleanupOutdatedCaches: true`. A tab left open across a release keeps running the old shell, but the new service worker purges the old hashed chunks — and the deploy removes them from the server.
2. Clicking a card sets `viewingItem` immediately, which engages the body scroll lock (`position: fixed; overflow: hidden`), while `ViewCardModal` is lazy-loaded.
3. When that dynamic import 404s, the rejection was discarded (`void loadViewCardModal()`): `viewingItem` stayed set, the body stayed frozen, and the Escape/backdrop handlers lived inside the modal that never mounted. The browser caches the failed module resolution, so every subsequent card click failed instantly too.

## Fix

- **`lib/preload-error.ts`** (new): listen for Vite's `vite:preloadError` and reload once to pick up the fresh shell. A sessionStorage timestamp allows at most one auto-reload per 60s so a persistent failure (assets genuinely unreachable) surfaces to the caller instead of reload-looping.
- **`App.svelte`**: all seven lazy loaders now go through a shared `loadLazy` that catches import failures, resets the state that summoned the view (`viewingItem`, `activeModal`, form flags), and shows a toast. The body scroll lock (`anyModalOpen`) additionally requires the modal's component to be loaded — the same condition that renders it — so the lock can never engage for a modal that isn't on screen.
- **`UserMenu.svelte`**: same catch for the lazy ImportExportModal so Export/Import fails with a toast rather than silently.

## Verification

- New unit tests for the reload guard; full web suite passes (426 tests).
- End-to-end simulation in headless Chrome against a production build with the `ViewCardModal` chunk deleted (as a deploy does): clicking a card now auto-reloads the tab once; with the chunk still missing inside the guard window, the next click shows the failure toast, the body is never frozen, and the page stays scrollable.
- Happy path re-verified the same way: modal opens, scroll lock engages while open and releases on Escape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now automatically recovers from failed lazy-loads by reloading once when needed, helping users return to a working version after a release.
  * If a page or modal can’t load, users now see a toast message with guidance to reload and try again.

* **Bug Fixes**
  * Improved modal behavior so failed loads no longer leave the interface in a blocked or scroll-locked state.
  * Added safer fallback handling for import/export and other on-demand screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->