### PR TITLE
feat(web): fetch link metadata for bookmarks via Sockethub

### DIFF
--- a/packages/rs-module/src/schemas.ts
+++ b/packages/rs-module/src/schemas.ts
@@ -155,6 +155,8 @@ export const userSettingsSchema = {
   properties: {
     abbreviation: { type: 'string' },
     theme: { type: 'string', enum: ['system', 'light', 'dark'] },
+    linkPreviews: { type: 'boolean' },
+    sockethubUrl: { type: 'string' },
   },
 };
 

--- a/packages/rs-module/src/types.ts
+++ b/packages/rs-module/src/types.ts
@@ -105,6 +105,12 @@ export type InboxItem =
 export interface UserSettings {
   abbreviation?: string;
   theme?: 'system' | 'light' | 'dark';
+  /** Fetch link metadata (title/description/preview image) for bookmarks.
+   *  Undefined means enabled. */
+  linkPreviews?: boolean;
+  /** Sockethub HTTP actions endpoint used for link-metadata fetching.
+   *  Undefined/empty means the app's default server. */
+  sockethubUrl?: string;
 }
 
 export interface AppConfig {

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -10,7 +10,7 @@
   import CaptureSheet from './components/CaptureSheet.svelte';
   import Toast from './components/Toast.svelte';
   import {
-    connected, deleteItem, openTodos, pendingMigrationCount, runAllMigrations,
+    connected, deleteItem, items, openTodos, pendingMigrationCount, runAllMigrations,
     createCollection, storeGroup,
     appConfig, setActiveGroupFilters,
   } from './lib/stores';
@@ -476,7 +476,14 @@
 
 {#if viewingItem}
   {#if ViewCardModalComponent}
-    <ViewCardModalComponent item={viewingItem} onclose={closeViewModal} onedit={openEditFromView} />
+    <!--
+      Prefer the live copy from the items store so background updates —
+      metadata enrichment, transcription, remote sync — appear in the open
+      modal instead of the stale snapshot taken when it was opened. The
+      snapshot fallback covers the moment an item is deleted elsewhere
+      while the modal is closing.
+    -->
+    <ViewCardModalComponent item={$items[viewingItem.id] ?? viewingItem} onclose={closeViewModal} onedit={openEditFromView} />
   {/if}
 {/if}
 

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -12,6 +12,7 @@
     shouldShowCollectionPicker,
     shouldSubmitAddEntryForm,
   } from '../lib/add-entry-modal';
+  import { enrichBookmark, needsEnrichment } from '../lib/enrich';
   import BookmarkForm from './add-entry/BookmarkForm.svelte';
   import NoteForm from './add-entry/NoteForm.svelte';
   import ImageForm from './add-entry/ImageForm.svelte';
@@ -221,6 +222,13 @@
       }
       if (selectedCollectionId && !isEdit) {
         await moveItemToCollection(item.id, selectedCollectionId);
+      }
+      // Fill blank bookmark fields (title, description, preview image) from
+      // the page's metadata in the background. New items only — an edit is
+      // the user deliberately setting fields, and the view card offers a
+      // manual fetch for older bookmarks.
+      if (!isEdit && item.type === 'bookmark' && needsEnrichment(item)) {
+        void enrichBookmark(item).catch(() => {});
       }
       onclose();
     } catch (e) {

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -2,7 +2,9 @@
   import type { Component } from 'svelte';
   import { tick } from 'svelte';
   import rs from '../lib/rs';
+  import { bulkEnrichProgress, enrichAllBookmarks } from '../lib/enrich';
   import { connected, syncing, userAddress, userSettings, updateUserSettings } from '../lib/stores';
+  import { showToast } from '../lib/toast';
   import {
     type Accent,
     ACCENT_LABELS,
@@ -175,6 +177,23 @@
     editingAbbrev = false;
   }
 
+  // Backfill metadata (title, description, preview image) for bookmarks
+  // saved before enrichment existed. Runs in the background — the menu can
+  // close, progress shows on the menu item, and a toast reports the result.
+  function handleFetchPreviews() {
+    void enrichAllBookmarks().then((summary) => {
+      if (!summary) return;
+      if (summary.total === 0) {
+        showToast('All bookmarks already have previews');
+      } else {
+        const failures = summary.failed ? ` (${summary.failed} failed)` : '';
+        showToast(
+          `Updated ${summary.updated} of ${summary.total} bookmark${summary.total === 1 ? '' : 's'}${failures}`,
+        );
+      }
+    });
+  }
+
   async function handleExport() {
     open = false;
     await loadImportExportModal();
@@ -325,6 +344,25 @@
           </svg>
           Import Data
           <span class="menu-hint">.zip</span>
+        </button>
+        <button
+          type="button"
+          class="menu-item"
+          role="menuitem"
+          onclick={handleFetchPreviews}
+          disabled={!!$bulkEnrichProgress}
+        >
+          <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+            <circle cx="8.5" cy="8.5" r="1.5"></circle>
+            <polyline points="21 15 16 10 5 21"></polyline>
+          </svg>
+          Fetch Link Previews
+          {#if $bulkEnrichProgress}
+            <span class="menu-hint"
+              >{$bulkEnrichProgress.done}/{$bulkEnrichProgress.total}</span
+            >
+          {/if}
         </button>
         <input
           bind:this={fileInputEl}

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -182,8 +182,15 @@
   // self-hosters point at their own Sockethub. Synced via user settings.
   const linkPreviewsOn = $derived($userSettings.linkPreviews !== false);
   let sockethubUrlInput = $state('');
+  let sockethubUrlEditing = $state(false);
+  // Re-sync from settings only while the field isn't focused — the store
+  // emits on every settings change (theme, abbreviation, remote sync from
+  // another device), and an unconditional sync would clobber keystrokes
+  // mid-edit. On blur, saveSockethubUrl runs before the flag flips back, so
+  // the re-sync lands on the value that was just saved.
   $effect(() => {
-    sockethubUrlInput = $userSettings.sockethubUrl ?? '';
+    const synced = $userSettings.sockethubUrl ?? '';
+    if (!sockethubUrlEditing) sockethubUrlInput = synced;
   });
 
   function setLinkPreviews(on: boolean) {
@@ -211,7 +218,10 @@
           `Updated ${summary.updated} of ${summary.total} bookmark${summary.total === 1 ? '' : 's'}${failures}`,
         );
       }
-    });
+      // enrichAllBookmarks swallows per-item failures, so this only guards
+      // against that contract changing — better a toast than an unhandled
+      // rejection.
+    }).catch(() => showToast('Failed to fetch link previews'));
   }
 
   async function handleExport() {
@@ -380,7 +390,7 @@
             </svg>
             Fetch Link Previews
             {#if $bulkEnrichProgress}
-              <span class="menu-hint"
+              <span class="menu-hint" aria-live="polite"
                 >{$bulkEnrichProgress.done}/{$bulkEnrichProgress.total}</span
               >
             {/if}
@@ -426,7 +436,11 @@
               bind:value={sockethubUrlInput}
               placeholder={DEFAULT_SOCKETHUB_ENDPOINT}
               aria-label="Sockethub endpoint"
-              onblur={saveSockethubUrl}
+              onfocus={() => (sockethubUrlEditing = true)}
+              onblur={() => {
+                saveSockethubUrl();
+                sockethubUrlEditing = false;
+              }}
             />
           </form>
         {/if}

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -3,6 +3,7 @@
   import { tick } from 'svelte';
   import rs from '../lib/rs';
   import { bulkEnrichProgress, enrichAllBookmarks } from '../lib/enrich';
+  import { DEFAULT_SOCKETHUB_ENDPOINT } from '../lib/link-metadata';
   import { connected, syncing, userAddress, userSettings, updateUserSettings } from '../lib/stores';
   import { showToast } from '../lib/toast';
   import {
@@ -177,6 +178,25 @@
     editingAbbrev = false;
   }
 
+  // Link previews: on unless explicitly disabled; the endpoint input lets
+  // self-hosters point at their own Sockethub. Synced via user settings.
+  const linkPreviewsOn = $derived($userSettings.linkPreviews !== false);
+  let sockethubUrlInput = $state('');
+  $effect(() => {
+    sockethubUrlInput = $userSettings.sockethubUrl ?? '';
+  });
+
+  function setLinkPreviews(on: boolean) {
+    // Store only the off state; undefined means the default (on).
+    void updateUserSettings({ linkPreviews: on ? undefined : false });
+  }
+
+  function saveSockethubUrl() {
+    const val = sockethubUrlInput.trim();
+    if (val === ($userSettings.sockethubUrl ?? '')) return;
+    void updateUserSettings({ sockethubUrl: val || undefined });
+  }
+
   // Backfill metadata (title, description, preview image) for bookmarks
   // saved before enrichment existed. Runs in the background — the menu can
   // close, progress shows on the menu item, and a toast reports the result.
@@ -345,25 +365,27 @@
           Import Data
           <span class="menu-hint">.zip</span>
         </button>
-        <button
-          type="button"
-          class="menu-item"
-          role="menuitem"
-          onclick={handleFetchPreviews}
-          disabled={!!$bulkEnrichProgress}
-        >
-          <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-            <circle cx="8.5" cy="8.5" r="1.5"></circle>
-            <polyline points="21 15 16 10 5 21"></polyline>
-          </svg>
-          Fetch Link Previews
-          {#if $bulkEnrichProgress}
-            <span class="menu-hint"
-              >{$bulkEnrichProgress.done}/{$bulkEnrichProgress.total}</span
-            >
-          {/if}
-        </button>
+        {#if linkPreviewsOn}
+          <button
+            type="button"
+            class="menu-item"
+            role="menuitem"
+            onclick={handleFetchPreviews}
+            disabled={!!$bulkEnrichProgress}
+          >
+            <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+              <circle cx="8.5" cy="8.5" r="1.5"></circle>
+              <polyline points="21 15 16 10 5 21"></polyline>
+            </svg>
+            Fetch Link Previews
+            {#if $bulkEnrichProgress}
+              <span class="menu-hint"
+                >{$bulkEnrichProgress.done}/{$bulkEnrichProgress.total}</span
+              >
+            {/if}
+          </button>
+        {/if}
         <input
           bind:this={fileInputEl}
           type="file"
@@ -371,6 +393,43 @@
           style="display: none"
           onchange={handleFileSelected}
         />
+
+        <div class="divider"></div>
+
+        <!-- Link previews — synced setting; endpoint is for self-hosters -->
+        <div class="section-label">Link previews</div>
+        <div class="theme-switcher" role="group" aria-label="Link previews">
+          <button type="button"
+            class="theme-option"
+            class:active={linkPreviewsOn}
+            aria-pressed={linkPreviewsOn}
+            onclick={() => setLinkPreviews(true)}
+          >
+            On
+          </button>
+          <button type="button"
+            class="theme-option"
+            class:active={!linkPreviewsOn}
+            aria-pressed={!linkPreviewsOn}
+            onclick={() => setLinkPreviews(false)}
+          >
+            Off
+          </button>
+        </div>
+        {#if linkPreviewsOn}
+          <form
+            class="connect-form"
+            onsubmit={(e) => { e.preventDefault(); saveSockethubUrl(); }}
+          >
+            <input
+              type="url"
+              bind:value={sockethubUrlInput}
+              placeholder={DEFAULT_SOCKETHUB_ENDPOINT}
+              aria-label="Sockethub endpoint"
+              onblur={saveSockethubUrl}
+            />
+          </form>
+        {/if}
       {/if}
 
       <div class="divider"></div>

--- a/packages/web/src/components/add-entry/BookmarkForm.svelte
+++ b/packages/web/src/components/add-entry/BookmarkForm.svelte
@@ -37,9 +37,8 @@
 </script>
 
 <p class="info-note">
-  Metadata fetching is not yet available in the web app. Use the browser
-  extension to auto-fill bookmark details. Sockethub integration is planned
-  for a future release.
+  Fields left blank are filled automatically from the page's metadata
+  (title, description, preview image) after saving.
 </p>
 <label class="field">
   <span>URL *</span>

--- a/packages/web/src/components/view-card/BookmarkView.svelte
+++ b/packages/web/src/components/view-card/BookmarkView.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import type { BookmarkItem } from '@inbox-rs/rs-module';
   import { enrichBookmark, needsEnrichment } from '../../lib/enrich';
-  import { blobUrls, connected, loadFileBlobUrl } from '../../lib/stores';
+  import {
+    blobUrls,
+    connected,
+    loadFileBlobUrl,
+    userSettings,
+  } from '../../lib/stores';
   import Lightbox from '../Lightbox.svelte';
 
   let { item, titleId }: { item: BookmarkItem; titleId: string } = $props();
@@ -104,7 +109,7 @@
     >
   {:else if previewStatus === 'none'}
     <span class="status-text">No preview available</span>
-  {:else if needsEnrichment(item)}
+  {:else if $userSettings.linkPreviews !== false && needsEnrichment(item)}
     <button type="button" class="btn-action" onclick={handleFetchPreview}
       >Fetch preview</button
     >

--- a/packages/web/src/components/view-card/BookmarkView.svelte
+++ b/packages/web/src/components/view-card/BookmarkView.svelte
@@ -1,11 +1,34 @@
 <script lang="ts">
   import type { BookmarkItem } from '@inbox-rs/rs-module';
+  import { enrichBookmark, needsEnrichment } from '../../lib/enrich';
   import { blobUrls, connected, loadFileBlobUrl } from '../../lib/stores';
   import Lightbox from '../Lightbox.svelte';
 
   let { item, titleId }: { item: BookmarkItem; titleId: string } = $props();
 
   let showLightbox = $state(false);
+  let fetchingPreview = $state(false);
+  let previewStatus = $state<'' | 'error' | 'none'>('');
+
+  // Fetch the page's metadata on demand for bookmarks saved before this
+  // feature (or whose auto-fetch failed). Mirrors AudioView's transcribe
+  // flow — the parent's `{#key item.id}` remount makes state resets and
+  // stale-promise guards unnecessary.
+  async function handleFetchPreview() {
+    fetchingPreview = true;
+    previewStatus = '';
+    try {
+      const result = await enrichBookmark(item);
+      // The enriched fields flow back reactively through the items store;
+      // only "nothing new" needs an explicit signal.
+      if (result === 'none') previewStatus = 'none';
+    } catch (e) {
+      console.warn('Metadata fetch failed:', e);
+      previewStatus = 'error';
+    } finally {
+      fetchingPreview = false;
+    }
+  }
 
   function getDomain(url: string): string {
     try {
@@ -72,6 +95,20 @@
     />
   {/if}
   <span class="domain">{item.siteName || getDomain(item.url)}</span>
+  {#if fetchingPreview}
+    <span class="status-text">Fetching preview…</span>
+  {:else if previewStatus === 'error'}
+    <span class="status-text">Couldn't fetch preview</span>
+    <button type="button" class="btn-action" onclick={handleFetchPreview}
+      >Retry</button
+    >
+  {:else if previewStatus === 'none'}
+    <span class="status-text">No preview available</span>
+  {:else if needsEnrichment(item)}
+    <button type="button" class="btn-action" onclick={handleFetchPreview}
+      >Fetch preview</button
+    >
+  {/if}
 </div>
 
 {#if imageSrc}

--- a/packages/web/src/lib/capture.test.ts
+++ b/packages/web/src/lib/capture.test.ts
@@ -19,6 +19,11 @@ const { storeItem, moveItemToCollection, collections } = vi.hoisted(() => {
 });
 vi.mock('./stores', () => ({ storeItem, moveItemToCollection, collections }));
 
+const { enrichBookmark } = vi.hoisted(() => ({
+  enrichBookmark: vi.fn().mockResolvedValue('updated'),
+}));
+vi.mock('./enrich', () => ({ enrichBookmark }));
+
 import { captureDetected, captureFile } from './capture';
 
 afterEach(() => vi.clearAllMocks());
@@ -31,6 +36,24 @@ describe('captureDetected', () => {
     expect((storeItem.mock.calls[0][0] as { url: string }).url).toBe(
       'https://example.com',
     );
+  });
+
+  it('kicks off background metadata enrichment for bookmarks', async () => {
+    const res = await captureDetected('https://example.com');
+    expect(enrichBookmark).toHaveBeenCalledOnce();
+    expect(enrichBookmark).toHaveBeenCalledWith(res?.item);
+  });
+
+  it('does not swallow the capture when enrichment fails', async () => {
+    enrichBookmark.mockRejectedValueOnce(new Error('metadata server down'));
+    const res = await captureDetected('https://example.com');
+    expect(res?.item.type).toBe('bookmark');
+    expect(storeItem).toHaveBeenCalledOnce();
+  });
+
+  it('does not attempt enrichment for notes', async () => {
+    await captureDetected('remember the milk');
+    expect(enrichBookmark).not.toHaveBeenCalled();
   });
 
   it('stores a note for text, preserving the body', async () => {

--- a/packages/web/src/lib/capture.ts
+++ b/packages/web/src/lib/capture.ts
@@ -7,6 +7,7 @@ import {
   buildNoteItem,
 } from './build-item';
 import { detectCaptureKind } from './capture-detect';
+import { enrichBookmark } from './enrich';
 import { collections, moveItemToCollection, storeItem } from './stores';
 
 /** Detect, build and store a quick capture. Returns the created item so the
@@ -42,6 +43,12 @@ export async function captureDetected(
   await storeItem(built.item);
   if (collectionId) {
     await moveItemToCollection(built.item.id, collectionId);
+  }
+  // Fill the bookmark's title/description/preview image from the page's
+  // metadata in the background — the capture itself must never wait on
+  // (or fail because of) the metadata server.
+  if (built.item.type === 'bookmark') {
+    void enrichBookmark(built.item).catch(() => {});
   }
   return { item: built.item };
 }

--- a/packages/web/src/lib/enrich.test.ts
+++ b/packages/web/src/lib/enrich.test.ts
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+import type { BookmarkItem } from '@inbox-rs/rs-module';
+import { get } from 'svelte/store';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { fetchLinkMetadata, storeItem, itemsMap } = vi.hoisted(() => {
+  const map: Record<string, unknown> = {};
+  return {
+    fetchLinkMetadata: vi.fn(),
+    storeItem: vi.fn().mockResolvedValue(undefined),
+    itemsMap: map,
+  };
+});
+vi.mock('./link-metadata', () => ({ fetchLinkMetadata }));
+vi.mock('./stores', () => ({
+  storeItem,
+  // Minimal readable-store stub so `get(items)` resolves synchronously.
+  items: {
+    subscribe: (run: (value: unknown) => void) => {
+      run(itemsMap);
+      return () => {};
+    },
+  },
+}));
+
+import {
+  applyLinkMetadata,
+  bulkEnrichProgress,
+  enrichAllBookmarks,
+  enrichBookmark,
+  needsEnrichment,
+} from './enrich';
+
+function bookmark(overrides: Partial<BookmarkItem> = {}): BookmarkItem {
+  return {
+    id: 'b1',
+    type: 'bookmark',
+    title: 'https://example.com',
+    url: 'https://example.com',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  for (const key of Object.keys(itemsMap)) delete itemsMap[key];
+});
+
+describe('needsEnrichment', () => {
+  it('is true while any preview field is missing', () => {
+    expect(needsEnrichment(bookmark())).toBe(true);
+    expect(needsEnrichment(bookmark({ title: 'Real title' }))).toBe(true);
+  });
+
+  it('is false once title, description, image and site name are set', () => {
+    expect(
+      needsEnrichment(
+        bookmark({
+          title: 'T',
+          description: 'D',
+          ogImage: 'https://x/i.png',
+          siteName: 'Example',
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('applyLinkMetadata', () => {
+  it('fills blank fields and replaces a URL-fallback title', () => {
+    const updated = applyLinkMetadata(bookmark(), {
+      title: 'Example Site',
+      description: 'A site',
+      image: 'https://x/og.png',
+      siteName: 'Example',
+      favicon: 'https://x/f.ico',
+    });
+    expect(updated).toMatchObject({
+      title: 'Example Site',
+      description: 'A site',
+      ogImage: 'https://x/og.png',
+      siteName: 'Example',
+      favicon: 'https://x/f.ico',
+    });
+  });
+
+  it('never overwrites user-provided fields', () => {
+    const item = bookmark({
+      title: 'My title',
+      description: 'my note',
+      ogImage: 'https://mine/i.png',
+      siteName: 'Mine',
+      favicon: '/mine.ico',
+    });
+    expect(
+      applyLinkMetadata(item, {
+        title: 'Fetched',
+        description: 'fetched',
+        image: 'https://theirs/i.png',
+        siteName: 'Theirs',
+        favicon: '/theirs.ico',
+      }),
+    ).toBeNull();
+  });
+
+  it('does not set ogImage when a local image copy exists', () => {
+    const item = bookmark({
+      title: 'T',
+      description: 'D',
+      siteName: 'S',
+      filePath: 'files/b1.png',
+    });
+    expect(applyLinkMetadata(item, { image: 'https://x/i.png' })).toBeNull();
+  });
+
+  it('returns null when the metadata adds nothing', () => {
+    expect(applyLinkMetadata(bookmark(), {})).toBeNull();
+  });
+});
+
+describe('enrichBookmark', () => {
+  it('stores the enriched item merged against the live copy', async () => {
+    const item = bookmark();
+    itemsMap[item.id] = item;
+    fetchLinkMetadata.mockResolvedValue({ title: 'Example', description: 'd' });
+
+    await expect(enrichBookmark(item)).resolves.toBe('updated');
+    expect(storeItem).toHaveBeenCalledOnce();
+    expect(storeItem.mock.calls[0][0]).toMatchObject({
+      id: 'b1',
+      title: 'Example',
+      description: 'd',
+    });
+  });
+
+  it('does not resurrect an item deleted during the fetch', async () => {
+    fetchLinkMetadata.mockResolvedValue({ title: 'Example' });
+    await expect(enrichBookmark(bookmark())).resolves.toBe('none');
+    expect(storeItem).not.toHaveBeenCalled();
+  });
+
+  it('respects edits made during the fetch', async () => {
+    const item = bookmark();
+    itemsMap[item.id] = { ...item, title: 'User renamed' };
+    fetchLinkMetadata.mockResolvedValue({ title: 'Fetched', description: 'd' });
+
+    await enrichBookmark(item);
+    expect(storeItem.mock.calls[0][0]).toMatchObject({
+      title: 'User renamed',
+      description: 'd',
+    });
+  });
+
+  it('skips stale items whose URL changed during the fetch', async () => {
+    const item = bookmark();
+    itemsMap[item.id] = { ...item, url: 'https://elsewhere.com' };
+    fetchLinkMetadata.mockResolvedValue({ title: 'Fetched' });
+
+    await expect(enrichBookmark(item)).resolves.toBe('none');
+    expect(storeItem).not.toHaveBeenCalled();
+  });
+
+  it('resolves "none" without storing when nothing was found', async () => {
+    const item = bookmark();
+    itemsMap[item.id] = item;
+    fetchLinkMetadata.mockResolvedValue(null);
+    await expect(enrichBookmark(item)).resolves.toBe('none');
+    expect(storeItem).not.toHaveBeenCalled();
+  });
+
+  it('propagates fetch failures so callers can offer a retry', async () => {
+    const item = bookmark();
+    itemsMap[item.id] = item;
+    fetchLinkMetadata.mockRejectedValue(new Error('boom'));
+    await expect(enrichBookmark(item)).rejects.toThrow('boom');
+  });
+});
+
+describe('enrichAllBookmarks', () => {
+  it('enriches only bookmarks that still need it and reports a summary', async () => {
+    itemsMap.b1 = bookmark({ id: 'b1' });
+    itemsMap.b2 = bookmark({
+      id: 'b2',
+      url: 'https://two.com',
+      title: 'Done',
+      description: 'D',
+      ogImage: 'https://x/i.png',
+      siteName: 'S',
+    });
+    itemsMap.n1 = { id: 'n1', type: 'note', title: 'n', createdAt: '' };
+    fetchLinkMetadata.mockResolvedValue({ title: 'Fetched' });
+
+    await expect(enrichAllBookmarks()).resolves.toEqual({
+      updated: 1,
+      failed: 0,
+      total: 1,
+    });
+    expect(fetchLinkMetadata).toHaveBeenCalledOnce();
+    expect(fetchLinkMetadata).toHaveBeenCalledWith('https://example.com');
+    // Progress is cleared when the pass finishes.
+    expect(get(bulkEnrichProgress)).toBeNull();
+  });
+
+  it('counts failures without aborting the rest', async () => {
+    itemsMap.b1 = bookmark({ id: 'b1' });
+    itemsMap.b2 = bookmark({ id: 'b2', url: 'https://two.com' });
+    fetchLinkMetadata
+      .mockRejectedValueOnce(new Error('dead link'))
+      .mockResolvedValueOnce({ title: 'Fetched', description: 'd' });
+
+    await expect(enrichAllBookmarks()).resolves.toEqual({
+      updated: 1,
+      failed: 1,
+      total: 2,
+    });
+  });
+});

--- a/packages/web/src/lib/enrich.test.ts
+++ b/packages/web/src/lib/enrich.test.ts
@@ -3,21 +3,33 @@ import type { BookmarkItem } from '@inbox-rs/rs-module';
 import { get } from 'svelte/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const { fetchLinkMetadata, storeItem, itemsMap } = vi.hoisted(() => {
+const { fetchLinkMetadata, storeItem, itemsMap, settings } = vi.hoisted(() => {
   const map: Record<string, unknown> = {};
   return {
     fetchLinkMetadata: vi.fn(),
     storeItem: vi.fn().mockResolvedValue(undefined),
     itemsMap: map,
+    settings: {} as Record<string, unknown>,
   };
 });
-vi.mock('./link-metadata', () => ({ fetchLinkMetadata }));
+vi.mock('./link-metadata', async (importOriginal) => ({
+  // Keep the real DEFAULT_SOCKETHUB_ENDPOINT so endpoint-resolution
+  // assertions run against the actual default.
+  ...(await importOriginal<typeof import('./link-metadata')>()),
+  fetchLinkMetadata,
+}));
+// Minimal readable-store stubs so `get(...)` resolves synchronously.
 vi.mock('./stores', () => ({
   storeItem,
-  // Minimal readable-store stub so `get(items)` resolves synchronously.
   items: {
     subscribe: (run: (value: unknown) => void) => {
       run(itemsMap);
+      return () => {};
+    },
+  },
+  userSettings: {
+    subscribe: (run: (value: unknown) => void) => {
+      run(settings);
       return () => {};
     },
   },
@@ -45,6 +57,7 @@ function bookmark(overrides: Partial<BookmarkItem> = {}): BookmarkItem {
 afterEach(() => {
   vi.clearAllMocks();
   for (const key of Object.keys(itemsMap)) delete itemsMap[key];
+  for (const key of Object.keys(settings)) delete settings[key];
 });
 
 describe('needsEnrichment', () => {
@@ -134,6 +147,33 @@ describe('enrichBookmark', () => {
     });
   });
 
+  it('is a no-op when the user disabled link previews', async () => {
+    settings.linkPreviews = false;
+    const item = bookmark();
+    itemsMap[item.id] = item;
+    await expect(enrichBookmark(item)).resolves.toBe('none');
+    expect(fetchLinkMetadata).not.toHaveBeenCalled();
+  });
+
+  it('uses the default endpoint unless the user configured their own', async () => {
+    const item = bookmark();
+    itemsMap[item.id] = item;
+    fetchLinkMetadata.mockResolvedValue(null);
+
+    await enrichBookmark(item);
+    expect(fetchLinkMetadata).toHaveBeenLastCalledWith(
+      item.url,
+      'https://sockethub.silverbucket.net/sockethub-http',
+    );
+
+    settings.sockethubUrl = 'https://my.sockethub/sockethub-http';
+    await enrichBookmark(item);
+    expect(fetchLinkMetadata).toHaveBeenLastCalledWith(
+      item.url,
+      'https://my.sockethub/sockethub-http',
+    );
+  });
+
   it('does not resurrect an item deleted during the fetch', async () => {
     fetchLinkMetadata.mockResolvedValue({ title: 'Example' });
     await expect(enrichBookmark(bookmark())).resolves.toBe('none');
@@ -197,7 +237,7 @@ describe('enrichAllBookmarks', () => {
       total: 1,
     });
     expect(fetchLinkMetadata).toHaveBeenCalledOnce();
-    expect(fetchLinkMetadata).toHaveBeenCalledWith('https://example.com');
+    expect(fetchLinkMetadata.mock.calls[0][0]).toBe('https://example.com');
     // Progress is cleared when the pass finishes.
     expect(get(bulkEnrichProgress)).toBeNull();
   });

--- a/packages/web/src/lib/enrich.ts
+++ b/packages/web/src/lib/enrich.ts
@@ -1,0 +1,145 @@
+/**
+ * Bookmark enrichment: fill a bookmark's blank title/description/preview
+ * image from the page's Open Graph metadata, fetched through Sockethub
+ * (see link-metadata.ts).
+ *
+ * Follows the transcription pattern (AudioView): an async, best-effort
+ * post-capture step that re-stores the item — the update flows to every
+ * card reactively through the `items` store. Runs automatically after a
+ * new link is captured, and on demand for existing bookmarks (per-card
+ * button in the bookmark view, bulk action in the user menu).
+ */
+
+import type { BookmarkItem, InboxItem } from '@inbox-rs/rs-module';
+import { get, writable } from 'svelte/store';
+import { fetchLinkMetadata, type LinkMetadata } from './link-metadata';
+import { items, storeItem } from './stores';
+
+/** True when a fetch could still add something to this bookmark. */
+export function needsEnrichment(item: BookmarkItem): boolean {
+  return (
+    !item.title ||
+    item.title === item.url ||
+    !item.description ||
+    !item.ogImage ||
+    !item.siteName
+  );
+}
+
+/**
+ * Merge fetched metadata into a bookmark, never clobbering what the user
+ * (or the extension's richer DOM scrape) already provided: the title is
+ * only replaced while it's still the URL fallback, and description/image/
+ * site name/favicon only fill empty fields. Returns the updated copy, or
+ * null when nothing new was learned.
+ */
+export function applyLinkMetadata(
+  item: BookmarkItem,
+  meta: LinkMetadata,
+): BookmarkItem | null {
+  const updated: BookmarkItem = { ...item };
+  let changed = false;
+  if (meta.title && (!item.title || item.title === item.url)) {
+    updated.title = meta.title;
+    changed = true;
+  }
+  if (meta.description && !item.description) {
+    updated.description = meta.description;
+    changed = true;
+  }
+  if (meta.image && !item.ogImage && !item.filePath) {
+    updated.ogImage = meta.image;
+    changed = true;
+  }
+  if (meta.siteName && !item.siteName) {
+    updated.siteName = meta.siteName;
+    changed = true;
+  }
+  if (meta.favicon && !item.favicon) {
+    updated.favicon = meta.favicon;
+    changed = true;
+  }
+  return changed ? updated : null;
+}
+
+/**
+ * Fetch metadata for a bookmark and store the enriched copy. Returns
+ * 'updated' when the item changed, 'none' when the page had nothing to add
+ * (or we're offline / the item vanished meanwhile); rejects when the fetch
+ * itself failed so interactive callers can offer a retry. Fire-and-forget
+ * callers should `.catch()` — a capture must never fail because its
+ * preview did.
+ */
+export async function enrichBookmark(
+  item: BookmarkItem,
+): Promise<'updated' | 'none'> {
+  if (!navigator.onLine) return 'none';
+  const meta = await fetchLinkMetadata(item.url);
+  if (!meta) return 'none';
+  // Re-read the live item: the user may have edited it during the fetch,
+  // and merging into the *current* fields keeps their changes protected.
+  // If it's gone (deleted or the capture was undone), storing again would
+  // resurrect it — bail instead.
+  const current = get(items)[item.id];
+  if (!current || current.type !== 'bookmark' || current.url !== item.url) {
+    return 'none';
+  }
+  const updated = applyLinkMetadata(current, meta);
+  if (!updated) return 'none';
+  await storeItem(updated);
+  return 'updated';
+}
+
+export interface BulkEnrichProgress {
+  done: number;
+  total: number;
+}
+
+/** Non-null while a bulk enrichment pass is running (drives the menu UI). */
+export const bulkEnrichProgress = writable<BulkEnrichProgress | null>(null);
+
+/** How many metadata fetches to keep in flight during a bulk pass. */
+const BULK_CONCURRENCY = 3;
+
+/**
+ * Enrich every existing bookmark that's still missing metadata. Returns a
+ * summary for the completion toast, or null when a pass is already running.
+ * Individual failures (dead links, pages Sockethub can't reach) are counted
+ * and skipped — one bad URL shouldn't abort the backlog.
+ */
+export async function enrichAllBookmarks(): Promise<{
+  updated: number;
+  failed: number;
+  total: number;
+} | null> {
+  if (get(bulkEnrichProgress)) return null;
+  const candidates = Object.values(get(items)).filter(
+    (item: InboxItem): item is BookmarkItem =>
+      item.type === 'bookmark' && needsEnrichment(item),
+  );
+  const total = candidates.length;
+  bulkEnrichProgress.set({ done: 0, total });
+  let updated = 0;
+  let failed = 0;
+  try {
+    const queue = [...candidates];
+    const worker = async () => {
+      for (let item = queue.shift(); item; item = queue.shift()) {
+        try {
+          if ((await enrichBookmark(item)) === 'updated') updated++;
+        } catch {
+          failed++;
+        }
+        bulkEnrichProgress.update((p) =>
+          p ? { ...p, done: p.done + 1 } : p,
+        );
+      }
+    };
+    await Promise.all(
+      Array.from({ length: Math.min(BULK_CONCURRENCY, total) }, worker),
+    );
+  } finally {
+    bulkEnrichProgress.set(null);
+  }
+  return { updated, failed, total };
+}

--- a/packages/web/src/lib/enrich.ts
+++ b/packages/web/src/lib/enrich.ts
@@ -12,8 +12,22 @@
 
 import type { BookmarkItem, InboxItem } from '@inbox-rs/rs-module';
 import { get, writable } from 'svelte/store';
-import { fetchLinkMetadata, type LinkMetadata } from './link-metadata';
-import { items, storeItem } from './stores';
+import {
+  DEFAULT_SOCKETHUB_ENDPOINT,
+  fetchLinkMetadata,
+  type LinkMetadata,
+} from './link-metadata';
+import { items, storeItem, userSettings } from './stores';
+
+/** Link previews are on unless the user turned them off. */
+export function linkPreviewsEnabled(): boolean {
+  return get(userSettings).linkPreviews !== false;
+}
+
+/** The user's own Sockethub endpoint when set, else the app default. */
+function resolveSockethubEndpoint(): string {
+  return get(userSettings).sockethubUrl?.trim() || DEFAULT_SOCKETHUB_ENDPOINT;
+}
 
 /** True when a fetch could still add something to this bookmark. */
 export function needsEnrichment(item: BookmarkItem): boolean {
@@ -73,8 +87,8 @@ export function applyLinkMetadata(
 export async function enrichBookmark(
   item: BookmarkItem,
 ): Promise<'updated' | 'none'> {
-  if (!navigator.onLine) return 'none';
-  const meta = await fetchLinkMetadata(item.url);
+  if (!linkPreviewsEnabled() || !navigator.onLine) return 'none';
+  const meta = await fetchLinkMetadata(item.url, resolveSockethubEndpoint());
   if (!meta) return 'none';
   // Re-read the live item: the user may have edited it during the fetch,
   // and merging into the *current* fields keeps their changes protected.
@@ -130,9 +144,7 @@ export async function enrichAllBookmarks(): Promise<{
         } catch {
           failed++;
         }
-        bulkEnrichProgress.update((p) =>
-          p ? { ...p, done: p.done + 1 } : p,
-        );
+        bulkEnrichProgress.update((p) => (p ? { ...p, done: p.done + 1 } : p));
       }
     };
     await Promise.all(

--- a/packages/web/src/lib/link-metadata.test.ts
+++ b/packages/web/src/lib/link-metadata.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchLinkMetadata,
+  normalizeMetadata,
+  SOCKETHUB_HTTP_ENDPOINT,
+} from './link-metadata';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('normalizeMetadata', () => {
+  it('extracts the documented title/description/image fields', () => {
+    expect(
+      normalizeMetadata({
+        type: 'message',
+        title: 'Page Title',
+        description: 'A description',
+        image: 'https://example.com/og.jpg',
+        url: 'https://example.com',
+      }),
+    ).toEqual({
+      title: 'Page Title',
+      description: 'A description',
+      image: 'https://example.com/og.jpg',
+      siteName: undefined,
+      favicon: undefined,
+    });
+  });
+
+  it('reads image descriptor objects and arrays', () => {
+    expect(
+      normalizeMetadata({ title: 't', image: { url: 'https://x/i.png' } })
+        ?.image,
+    ).toBe('https://x/i.png');
+    expect(
+      normalizeMetadata({ title: 't', image: [{ url: 'https://x/1.png' }] })
+        ?.image,
+    ).toBe('https://x/1.png');
+  });
+
+  it('reads alternate site-name/favicon spellings', () => {
+    expect(
+      normalizeMetadata({ title: 't', site_name: 'Example', icon: '/f.ico' }),
+    ).toMatchObject({ siteName: 'Example', favicon: '/f.ico' });
+  });
+
+  it('trims whitespace and drops empty strings', () => {
+    expect(normalizeMetadata({ title: '  Padded  ', description: '   ' })).toEqual(
+      {
+        title: 'Padded',
+        description: undefined,
+        image: undefined,
+        siteName: undefined,
+        favicon: undefined,
+      },
+    );
+  });
+
+  it('returns null when nothing usable is present', () => {
+    expect(normalizeMetadata(undefined)).toBeNull();
+    expect(normalizeMetadata('nope')).toBeNull();
+    expect(normalizeMetadata({})).toBeNull();
+    expect(normalizeMetadata({ type: 'message', url: 'https://x' })).toBeNull();
+    // A favicon alone isn't a preview.
+    expect(normalizeMetadata({ favicon: '/f.ico' })).toBeNull();
+  });
+});
+
+function ndjsonResponse(lines: unknown[], status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: () =>
+      Promise.resolve(lines.map((l) => JSON.stringify(l)).join('\n') + '\n'),
+  };
+}
+
+describe('fetchLinkMetadata', () => {
+  it('POSTs an ActivityStreams fetch and returns the normalized result', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      ndjsonResponse([
+        {
+          type: 'fetch',
+          actor: { id: 'https://example.com' },
+          object: { type: 'message', title: 'Example', image: 'https://x/i.png' },
+        },
+      ]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const meta = await fetchLinkMetadata('https://example.com');
+    expect(meta).toMatchObject({ title: 'Example', image: 'https://x/i.png' });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [endpoint, init] = fetchMock.mock.calls[0];
+    expect(endpoint).toBe(SOCKETHUB_HTTP_ENDPOINT);
+    expect(init.method).toBe('POST');
+    expect(init.headers['X-Request-Id']).toBeTruthy();
+    const body = JSON.parse(init.body);
+    expect(body.type).toBe('fetch');
+    expect(body.actor).toEqual({ id: 'https://example.com' });
+    expect(body['@context']).toContain(
+      'https://sockethub.org/ns/context/platform/metadata/v1.jsonld',
+    );
+  });
+
+  it('resolves null when the page has no usable metadata', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        ndjsonResponse([
+          { type: 'fetch', actor: { id: 'https://x' }, object: { type: 'message' } },
+        ]),
+      ),
+    );
+    await expect(fetchLinkMetadata('https://x')).resolves.toBeNull();
+  });
+
+  it('rejects when the result line carries a platform error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        ndjsonResponse([{ type: 'error', error: 'could not fetch page' }]),
+      ),
+    );
+    await expect(fetchLinkMetadata('https://x')).rejects.toThrow(
+      'could not fetch page',
+    );
+  });
+
+  it('rejects on a non-2xx response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(ndjsonResponse([], 404)));
+    await expect(fetchLinkMetadata('https://x')).rejects.toThrow('404');
+  });
+
+  it('resolves null on an empty response body', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(ndjsonResponse([])));
+    await expect(fetchLinkMetadata('https://x')).resolves.toBeNull();
+  });
+});

--- a/packages/web/src/lib/link-metadata.test.ts
+++ b/packages/web/src/lib/link-metadata.test.ts
@@ -128,12 +128,18 @@ describe('normalizeMetadata', () => {
     });
   });
 
+  it('keeps favicon-only metadata — pages without OG tags still have icons', () => {
+    expect(
+      normalizeMetadata({ favicon: '/favicon.ico' }, 'https://example.com'),
+    ).toMatchObject({ favicon: 'https://example.com/favicon.ico' });
+  });
+
   it('returns null when nothing usable is present', () => {
     expect(normalizeMetadata(undefined)).toBeNull();
     expect(normalizeMetadata('nope')).toBeNull();
     expect(normalizeMetadata({})).toBeNull();
     expect(normalizeMetadata({ type: 'message', url: 'https://x' })).toBeNull();
-    // A favicon alone isn't a preview.
+    // A relative favicon with no base URL can't be resolved — nothing left.
     expect(normalizeMetadata({ favicon: '/f.ico' })).toBeNull();
   });
 });

--- a/packages/web/src/lib/link-metadata.test.ts
+++ b/packages/web/src/lib/link-metadata.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  DEFAULT_SOCKETHUB_ENDPOINT,
   fetchLinkMetadata,
   normalizeMetadata,
-  SOCKETHUB_HTTP_ENDPOINT,
 } from './link-metadata';
 
 afterEach(() => {
@@ -29,6 +29,41 @@ describe('normalizeMetadata', () => {
     });
   });
 
+  it('normalizes a real Sockethub metadata response', () => {
+    // Captured verbatim from sockethub.silverbucket.net (2026-07).
+    const object = {
+      type: 'page',
+      language: 'en',
+      title:
+        'GitHub - sockethub/sockethub: A multi-protocol gateway for the Web using ActivityStream messages.',
+      name: 'GitHub',
+      description:
+        'A multi-protocol gateway for the Web using ActivityStream messages. - sockethub/sockethub',
+      image: [
+        {
+          height: '600',
+          url: 'https://opengraph.githubassets.com/1abb/sockethub/sockethub',
+          width: '1200',
+          alt: 'A multi-protocol gateway…',
+        },
+      ],
+      url: 'https://github.com/sockethub/sockethub',
+      favicon: 'https://github.githubassets.com/favicons/favicon.svg',
+      charset: 'utf-8',
+    };
+    expect(
+      normalizeMetadata(object, 'https://github.com/sockethub/sockethub'),
+    ).toEqual({
+      title:
+        'GitHub - sockethub/sockethub: A multi-protocol gateway for the Web using ActivityStream messages.',
+      description:
+        'A multi-protocol gateway for the Web using ActivityStream messages. - sockethub/sockethub',
+      image: 'https://opengraph.githubassets.com/1abb/sockethub/sockethub',
+      siteName: 'GitHub',
+      favicon: 'https://github.githubassets.com/favicons/favicon.svg',
+    });
+  });
+
   it('reads image descriptor objects and arrays', () => {
     expect(
       normalizeMetadata({ title: 't', image: { url: 'https://x/i.png' } })
@@ -40,22 +75,57 @@ describe('normalizeMetadata', () => {
     ).toBe('https://x/1.png');
   });
 
+  it('resolves relative image/favicon URLs against the page URL', () => {
+    expect(
+      normalizeMetadata(
+        { title: 't', image: '/og.png', favicon: 'favicon.ico' },
+        'https://example.com/articles/1',
+      ),
+    ).toMatchObject({
+      image: 'https://example.com/og.png',
+      favicon: 'https://example.com/articles/favicon.ico',
+    });
+  });
+
+  it('drops non-http(s) and unresolvable media URLs', () => {
+    expect(
+      normalizeMetadata(
+        {
+          title: 't',
+          image: 'javascript:alert(1)',
+          favicon: 'data:image/png;base64,x',
+        },
+        'https://example.com',
+      ),
+    ).toMatchObject({ image: undefined, favicon: undefined });
+    // Relative values without a base can't be resolved — dropped.
+    expect(normalizeMetadata({ title: 't', image: '/og.png' })).toMatchObject({
+      image: undefined,
+    });
+  });
+
   it('reads alternate site-name/favicon spellings', () => {
     expect(
-      normalizeMetadata({ title: 't', site_name: 'Example', icon: '/f.ico' }),
-    ).toMatchObject({ siteName: 'Example', favicon: '/f.ico' });
+      normalizeMetadata(
+        { title: 't', site_name: 'Example', icon: '/f.ico' },
+        'https://example.com',
+      ),
+    ).toMatchObject({
+      siteName: 'Example',
+      favicon: 'https://example.com/f.ico',
+    });
   });
 
   it('trims whitespace and drops empty strings', () => {
-    expect(normalizeMetadata({ title: '  Padded  ', description: '   ' })).toEqual(
-      {
-        title: 'Padded',
-        description: undefined,
-        image: undefined,
-        siteName: undefined,
-        favicon: undefined,
-      },
-    );
+    expect(
+      normalizeMetadata({ title: '  Padded  ', description: '   ' }),
+    ).toEqual({
+      title: 'Padded',
+      description: undefined,
+      image: undefined,
+      siteName: undefined,
+      favicon: undefined,
+    });
   });
 
   it('returns null when nothing usable is present', () => {
@@ -73,7 +143,7 @@ function ndjsonResponse(lines: unknown[], status = 200) {
     ok: status >= 200 && status < 300,
     status,
     text: () =>
-      Promise.resolve(lines.map((l) => JSON.stringify(l)).join('\n') + '\n'),
+      Promise.resolve(`${lines.map((l) => JSON.stringify(l)).join('\n')}\n`),
   };
 }
 
@@ -84,7 +154,11 @@ describe('fetchLinkMetadata', () => {
         {
           type: 'fetch',
           actor: { id: 'https://example.com' },
-          object: { type: 'message', title: 'Example', image: 'https://x/i.png' },
+          object: {
+            type: 'message',
+            title: 'Example',
+            image: 'https://x/i.png',
+          },
         },
       ]),
     );
@@ -95,15 +169,23 @@ describe('fetchLinkMetadata', () => {
 
     expect(fetchMock).toHaveBeenCalledOnce();
     const [endpoint, init] = fetchMock.mock.calls[0];
-    expect(endpoint).toBe(SOCKETHUB_HTTP_ENDPOINT);
+    expect(endpoint).toBe(DEFAULT_SOCKETHUB_ENDPOINT);
     expect(init.method).toBe('POST');
     expect(init.headers['X-Request-Id']).toBeTruthy();
     const body = JSON.parse(init.body);
     expect(body.type).toBe('fetch');
-    expect(body.actor).toEqual({ id: 'https://example.com' });
+    // Schema validation on the server requires a typed actor.
+    expect(body.actor).toEqual({ id: 'https://example.com', type: 'website' });
     expect(body['@context']).toContain(
       'https://sockethub.org/ns/context/platform/metadata/v1.jsonld',
     );
+  });
+
+  it('POSTs to a caller-supplied endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ndjsonResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+    await fetchLinkMetadata('https://x', 'https://my.server/sockethub-http');
+    expect(fetchMock.mock.calls[0][0]).toBe('https://my.server/sockethub-http');
   });
 
   it('resolves null when the page has no usable metadata', async () => {
@@ -111,7 +193,11 @@ describe('fetchLinkMetadata', () => {
       'fetch',
       vi.fn().mockResolvedValue(
         ndjsonResponse([
-          { type: 'fetch', actor: { id: 'https://x' }, object: { type: 'message' } },
+          {
+            type: 'fetch',
+            actor: { id: 'https://x' },
+            object: { type: 'message' },
+          },
         ]),
       ),
     );
@@ -121,9 +207,11 @@ describe('fetchLinkMetadata', () => {
   it('rejects when the result line carries a platform error', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValue(
-        ndjsonResponse([{ type: 'error', error: 'could not fetch page' }]),
-      ),
+      vi
+        .fn()
+        .mockResolvedValue(
+          ndjsonResponse([{ type: 'error', error: 'could not fetch page' }]),
+        ),
     );
     await expect(fetchLinkMetadata('https://x')).rejects.toThrow(
       'could not fetch page',

--- a/packages/web/src/lib/link-metadata.ts
+++ b/packages/web/src/lib/link-metadata.ts
@@ -15,7 +15,13 @@
  * actions, with `httpActions: { enabled: true }` in its config.
  */
 
-export const SOCKETHUB_HTTP_ENDPOINT =
+/**
+ * Default Sockethub HTTP actions endpoint. Overridable per build via
+ * VITE_SOCKETHUB_URL and per user via the `sockethubUrl` user setting
+ * (see resolveSockethubEndpoint in enrich.ts).
+ */
+export const DEFAULT_SOCKETHUB_ENDPOINT: string =
+  import.meta.env?.VITE_SOCKETHUB_URL ||
   'https://sockethub.silverbucket.net/sockethub-http';
 
 /**
@@ -45,13 +51,42 @@ function asNonEmptyString(value: unknown): string | undefined {
 }
 
 /**
- * Shape a metadata-platform response object into LinkMetadata. The platform
- * documents `title`/`description`/`image`; site name and favicon are read
- * defensively under the names open-graph-scraper based servers use, since
- * Sockethub versions differ in what they pass through. Returns null when
- * the response carries nothing usable.
+ * Resolve a possibly-relative media URL against the fetched page and keep
+ * only http(s) results — servers echo whatever the page's tags contain
+ * (`/favicon.ico`, protocol-relative paths, or junk schemes), and these
+ * values end up in `<img src>` attributes.
  */
-export function normalizeMetadata(object: unknown): LinkMetadata | null {
+function asHttpUrl(
+  value: string | undefined,
+  baseUrl?: string,
+): string | undefined {
+  if (!value) return undefined;
+  try {
+    const resolved = new URL(value, baseUrl);
+    if (resolved.protocol === 'http:' || resolved.protocol === 'https:') {
+      return resolved.href;
+    }
+  } catch {
+    // Unparseable even against the base — drop it.
+  }
+  return undefined;
+}
+
+/**
+ * Shape a metadata-platform response object into LinkMetadata. Verified
+ * against a live server, the object looks like:
+ *
+ *   { type: 'page', title, name, description, favicon,
+ *     image: [{ url, width, height, alt }], url, ... }
+ *
+ * where `name` carries the og:site_name. `siteName`/`site_name`/`icon`
+ * are read as fallbacks for other server versions. Returns null when the
+ * response carries nothing usable.
+ */
+export function normalizeMetadata(
+  object: unknown,
+  baseUrl?: string,
+): LinkMetadata | null {
   if (!object || typeof object !== 'object') return null;
   const o = object as Record<string, unknown>;
   // `image` may arrive as a plain URL string or an object/array of
@@ -61,11 +96,17 @@ export function normalizeMetadata(object: unknown): LinkMetadata | null {
     asNonEmptyString(rawImage) ??
     asNonEmptyString((rawImage as Record<string, unknown> | undefined)?.url);
   const meta: LinkMetadata = {
-    title: asNonEmptyString(o.title) ?? asNonEmptyString(o.name),
+    title: asNonEmptyString(o.title),
     description: asNonEmptyString(o.description) ?? asNonEmptyString(o.summary),
-    image,
-    siteName: asNonEmptyString(o.siteName) ?? asNonEmptyString(o.site_name),
-    favicon: asNonEmptyString(o.favicon) ?? asNonEmptyString(o.icon),
+    image: asHttpUrl(image, baseUrl),
+    siteName:
+      asNonEmptyString(o.siteName) ??
+      asNonEmptyString(o.site_name) ??
+      asNonEmptyString(o.name),
+    favicon: asHttpUrl(
+      asNonEmptyString(o.favicon) ?? asNonEmptyString(o.icon),
+      baseUrl,
+    ),
   };
   return meta.title || meta.description || meta.image || meta.siteName
     ? meta
@@ -79,8 +120,9 @@ export function normalizeMetadata(object: unknown): LinkMetadata | null {
  */
 export async function fetchLinkMetadata(
   url: string,
+  endpoint: string = DEFAULT_SOCKETHUB_ENDPOINT,
 ): Promise<LinkMetadata | null> {
-  const res = await fetch(SOCKETHUB_HTTP_ENDPOINT, {
+  const res = await fetch(endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -90,7 +132,8 @@ export async function fetchLinkMetadata(
     body: JSON.stringify({
       '@context': METADATA_CONTEXT,
       type: 'fetch',
-      actor: { id: url },
+      // Schema validation requires a typed actor; URLs are `website`.
+      actor: { id: url, type: 'website' },
     }),
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
@@ -112,7 +155,7 @@ export async function fetchLinkMetadata(
     if (typeof p.error === 'string' && p.error) {
       throw new Error(p.error);
     }
-    return normalizeMetadata(p.object);
+    return normalizeMetadata(p.object, url);
   }
   return null;
 }

--- a/packages/web/src/lib/link-metadata.ts
+++ b/packages/web/src/lib/link-metadata.ts
@@ -1,0 +1,118 @@
+/**
+ * Link metadata fetching via a Sockethub server's stateless `metadata`
+ * platform (Open Graph extraction). The browser can't scrape arbitrary
+ * pages itself — CORS blocks cross-origin HTML fetches — so we relay
+ * through Sockethub's HTTP actions endpoint: POST an ActivityStreams
+ * `fetch` for a URL, get back an NDJSON line with the page's
+ * title/description/image.
+ *
+ * We use the one-shot HTTP endpoint rather than the socket.io client on
+ * purpose: the metadata platform is stateless (no credentials, no connect
+ * step), so each lookup is a pure request/response — no websocket
+ * lifecycle to manage and no client libraries to ship.
+ *
+ * NOTE: the server must run a Sockethub recent enough to have HTTP
+ * actions, with `httpActions: { enabled: true }` in its config.
+ */
+
+export const SOCKETHUB_HTTP_ENDPOINT =
+  'https://sockethub.silverbucket.net/sockethub-http';
+
+/**
+ * Canonical @context identifying the metadata platform. Sockethub resolves
+ * the target platform from the URL prefixed `.../ns/context/platform/`.
+ */
+const METADATA_CONTEXT = [
+  'https://www.w3.org/ns/activitystreams',
+  'https://sockethub.org/ns/context/v1.jsonld',
+  'https://sockethub.org/ns/context/platform/metadata/v1.jsonld',
+];
+
+/** Client-side cap; the server also enforces its own request timeout. */
+const FETCH_TIMEOUT_MS = 30_000;
+
+export interface LinkMetadata {
+  title?: string;
+  description?: string;
+  image?: string;
+  siteName?: string;
+  favicon?: string;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  return undefined;
+}
+
+/**
+ * Shape a metadata-platform response object into LinkMetadata. The platform
+ * documents `title`/`description`/`image`; site name and favicon are read
+ * defensively under the names open-graph-scraper based servers use, since
+ * Sockethub versions differ in what they pass through. Returns null when
+ * the response carries nothing usable.
+ */
+export function normalizeMetadata(object: unknown): LinkMetadata | null {
+  if (!object || typeof object !== 'object') return null;
+  const o = object as Record<string, unknown>;
+  // `image` may arrive as a plain URL string or an object/array of
+  // { url } media descriptors depending on the page's OG tags.
+  const rawImage = Array.isArray(o.image) ? o.image[0] : o.image;
+  const image =
+    asNonEmptyString(rawImage) ??
+    asNonEmptyString((rawImage as Record<string, unknown> | undefined)?.url);
+  const meta: LinkMetadata = {
+    title: asNonEmptyString(o.title) ?? asNonEmptyString(o.name),
+    description: asNonEmptyString(o.description) ?? asNonEmptyString(o.summary),
+    image,
+    siteName: asNonEmptyString(o.siteName) ?? asNonEmptyString(o.site_name),
+    favicon: asNonEmptyString(o.favicon) ?? asNonEmptyString(o.icon),
+  };
+  return meta.title || meta.description || meta.image || meta.siteName
+    ? meta
+    : null;
+}
+
+/**
+ * Fetch Open Graph metadata for a URL. Resolves null when the page has no
+ * usable metadata; rejects when the Sockethub server can't be reached, the
+ * page fetch fails server-side, or the request times out.
+ */
+export async function fetchLinkMetadata(
+  url: string,
+): Promise<LinkMetadata | null> {
+  const res = await fetch(SOCKETHUB_HTTP_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      // Required by the endpoint; also makes retries idempotent server-side.
+      'X-Request-Id': crypto.randomUUID(),
+    },
+    body: JSON.stringify({
+      '@context': METADATA_CONTEXT,
+      type: 'fetch',
+      actor: { id: url },
+    }),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`Metadata server responded with ${res.status}`);
+  }
+  // The endpoint streams NDJSON, one result line per submitted message —
+  // we send a single message, so the first parseable line settles it.
+  const text = await res.text();
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    let payload: unknown;
+    try {
+      payload = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const p = payload as Record<string, unknown>;
+    if (typeof p.error === 'string' && p.error) {
+      throw new Error(p.error);
+    }
+    return normalizeMetadata(p.object);
+  }
+  return null;
+}

--- a/packages/web/src/lib/link-metadata.ts
+++ b/packages/web/src/lib/link-metadata.ts
@@ -108,7 +108,13 @@ export function normalizeMetadata(
       baseUrl,
     ),
   };
-  return meta.title || meta.description || meta.image || meta.siteName
+  // A resolved favicon alone still counts — plenty of pages have no OG
+  // tags but a conventional /favicon.ico, and the card UI renders it.
+  return meta.title ||
+    meta.description ||
+    meta.image ||
+    meta.siteName ||
+    meta.favicon
     ? meta
     : null;
 }

--- a/tests/e2e/desktop/bookmark-enrichment.spec.ts
+++ b/tests/e2e/desktop/bookmark-enrichment.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * Bookmark metadata enrichment via the Sockethub HTTP actions endpoint.
+ *
+ * Capturing a URL stores the bookmark immediately, then fills its blank
+ * title/description/preview image from the page's Open Graph metadata in
+ * the background. The Sockethub endpoint is mocked with `page.route` so
+ * the suite stays hermetic — both the NDJSON happy path and the
+ * server-error path are exercised, plus the manual "Fetch preview"
+ * fallback in the view card.
+ *
+ * Service workers are blocked in this spec: Playwright route interception
+ * can't see requests once a service worker handles them, and enrichment
+ * behaviour doesn't depend on the SW.
+ *
+ * Each test runs as a per-test fresh user rather than the shared worker
+ * user, so the bookmarks it creates don't leak into the starting state of
+ * later specs in the worker.
+ */
+
+import type { Page } from '@playwright/test';
+import { expect, test } from '../helpers/fixtures';
+import {
+  assertNoConsoleErrors,
+  attachConsoleCapture,
+  seedRsSession,
+} from '../helpers/pwa';
+
+const SOCKETHUB_GLOB = 'https://sockethub.silverbucket.net/**';
+
+function ndjson(lines: unknown[]): {
+  status: number;
+  contentType: string;
+  body: string;
+} {
+  return {
+    status: 200,
+    contentType: 'application/x-ndjson',
+    body: lines.map((l) => JSON.stringify(l)).join('\n') + '\n',
+  };
+}
+
+function metadataResult(url: string, object: Record<string, unknown>) {
+  return ndjson([{ type: 'fetch', actor: { id: url }, object }]);
+}
+
+test.use({ serviceWorkers: 'block' });
+
+type FreshPageArgs = {
+  context: Parameters<typeof seedRsSession>[0];
+  freshRsUser: Parameters<typeof seedRsSession>[1];
+  freshRsToken: string;
+  webOrigin: string;
+};
+
+/** Open a page connected as this test's own empty user. */
+async function freshConnectedPage({
+  context,
+  freshRsUser,
+  freshRsToken,
+  webOrigin,
+}: FreshPageArgs): Promise<Page> {
+  await seedRsSession(context, freshRsUser, freshRsToken, {
+    clientOrigin: webOrigin,
+  });
+  return context.newPage();
+}
+
+test('a captured link is enriched with fetched title, description and image', async ({
+  context,
+  freshRsUser,
+  freshRsToken,
+  webOrigin,
+}) => {
+  const connectedPage = await freshConnectedPage({
+    context,
+    freshRsUser,
+    freshRsToken,
+    webOrigin,
+  });
+  const log = attachConsoleCapture(connectedPage);
+  const url = 'https://example.com';
+  await connectedPage.route(SOCKETHUB_GLOB, (route) =>
+    route.fulfill(
+      metadataResult(url, {
+        type: 'message',
+        title: 'Example Domain',
+        description: 'An illustrative example page',
+        image: 'https://example.com/og.png',
+        url,
+      }),
+    ),
+  );
+  // Serve real image bytes for the og:image URL — the card hides broken
+  // images via `onerror`, so the visibility assertion needs a loadable src.
+  await connectedPage.route('https://example.com/og.png', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'image/png',
+      body: Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+        'base64',
+      ),
+    }),
+  );
+
+  await connectedPage.goto(webOrigin);
+  await connectedPage.waitForLoadState('networkidle');
+  await connectedPage.getByRole('button', { name: 'Inbox' }).first().click();
+
+  const input = connectedPage.getByPlaceholder(
+    'Paste a link, jot a note, or drop a file…',
+  );
+  await input.click();
+  await input.fill(url);
+  await input.press('Enter');
+
+  // The card appears immediately (title falls back to the URL), then the
+  // background fetch fills the metadata and the card re-renders.
+  await expect(
+    connectedPage.getByRole('link', { name: 'Example Domain' }),
+  ).toBeVisible({ timeout: 10_000 });
+  await expect(
+    connectedPage.getByText('An illustrative example page'),
+  ).toBeVisible();
+  await expect(
+    connectedPage.locator('img[src="https://example.com/og.png"]'),
+  ).toBeVisible();
+
+  assertNoConsoleErrors(log);
+});
+
+test('a failed metadata fetch leaves the capture intact and the view card offers a manual fetch', async ({
+  context,
+  freshRsUser,
+  freshRsToken,
+  webOrigin,
+}) => {
+  const connectedPage = await freshConnectedPage({
+    context,
+    freshRsUser,
+    freshRsToken,
+    webOrigin,
+  });
+  const log = attachConsoleCapture(connectedPage);
+  const url = 'https://example.org';
+  // The server reports it couldn't fetch the page (an in-band NDJSON error,
+  // as Sockethub sends for dead links or scrape failures).
+  await connectedPage.route(SOCKETHUB_GLOB, (route) =>
+    route.fulfill(ndjson([{ type: 'error', error: 'could not fetch page' }])),
+  );
+
+  await connectedPage.goto(webOrigin);
+  await connectedPage.waitForLoadState('networkidle');
+  await connectedPage.getByRole('button', { name: 'Inbox' }).first().click();
+
+  const input = connectedPage.getByPlaceholder(
+    'Paste a link, jot a note, or drop a file…',
+  );
+  await input.click();
+  await input.fill(url);
+  const failedFetch = connectedPage.waitForResponse(SOCKETHUB_GLOB);
+  await input.press('Enter');
+
+  // The bookmark still saves, titled by its URL.
+  const cardLink = connectedPage.getByRole('link', { name: url });
+  await expect(cardLink).toBeVisible({ timeout: 10_000 });
+  // Let the doomed background fetch settle before swapping the mock.
+  await failedFetch;
+
+  // Now the server works again — recover through the view card's button.
+  await connectedPage.unroute(SOCKETHUB_GLOB);
+  await connectedPage.route(SOCKETHUB_GLOB, (route) =>
+    route.fulfill(
+      metadataResult(url, {
+        type: 'message',
+        title: 'Example Org',
+        description: 'Recovered metadata',
+        url,
+      }),
+    ),
+  );
+
+  // Click the card body (not the title link) to open the view modal.
+  await connectedPage
+    .getByRole('button', { name: new RegExp(url) })
+    .first()
+    .click();
+  const dialog = connectedPage.getByRole('dialog');
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+  await dialog.getByRole('button', { name: 'Fetch preview' }).click();
+  await expect(dialog.getByRole('link', { name: 'Example Org' })).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(dialog.getByText('Recovered metadata')).toBeVisible();
+
+  assertNoConsoleErrors(log);
+});

--- a/tests/e2e/desktop/bookmark-enrichment.spec.ts
+++ b/tests/e2e/desktop/bookmark-enrichment.spec.ts
@@ -35,12 +35,14 @@ function ndjson(lines: unknown[]): {
   return {
     status: 200,
     contentType: 'application/x-ndjson',
-    body: lines.map((l) => JSON.stringify(l)).join('\n') + '\n',
+    body: `${lines.map((l) => JSON.stringify(l)).join('\n')}\n`,
   };
 }
 
 function metadataResult(url: string, object: Record<string, unknown>) {
-  return ndjson([{ type: 'fetch', actor: { id: url }, object }]);
+  return ndjson([
+    { type: 'fetch', actor: { id: url, type: 'website' }, object },
+  ]);
 }
 
 test.use({ serviceWorkers: 'block' });
@@ -81,11 +83,15 @@ test('a captured link is enriched with fetched title, description and image', as
   const url = 'https://example.com';
   await connectedPage.route(SOCKETHUB_GLOB, (route) =>
     route.fulfill(
+      // Mirrors the live server's response shape: object type `page`,
+      // site name in `name`, image as an array of media descriptors.
       metadataResult(url, {
-        type: 'message',
+        type: 'page',
         title: 'Example Domain',
+        name: 'Example',
         description: 'An illustrative example page',
-        image: 'https://example.com/og.png',
+        image: [{ url: 'https://example.com/og.png', width: '1200' }],
+        favicon: 'https://example.com/favicon.ico',
         url,
       }),
     ),
@@ -172,7 +178,7 @@ test('a failed metadata fetch leaves the capture intact and the view card offers
   await connectedPage.route(SOCKETHUB_GLOB, (route) =>
     route.fulfill(
       metadataResult(url, {
-        type: 'message',
+        type: 'page',
         title: 'Example Org',
         description: 'Recovered metadata',
         url,
@@ -180,11 +186,14 @@ test('a failed metadata fetch leaves the capture intact and the view card offers
     ),
   );
 
-  // Click the card body (not the title link) to open the view modal.
+  // Open the view modal with keyboard activation. A mouse click aims at
+  // the card's centre, which can land on the inner title link (a click
+  // the card handler deliberately ignores) depending on font metrics —
+  // that's exactly what happened on CI. Enter always hits the handler.
   await connectedPage
     .getByRole('button', { name: new RegExp(url) })
     .first()
-    .click();
+    .press('Enter');
   const dialog = connectedPage.getByRole('dialog');
   await expect(dialog).toBeVisible({ timeout: 10_000 });
 

--- a/tests/e2e/desktop/bookmark-enrichment.spec.ts
+++ b/tests/e2e/desktop/bookmark-enrichment.spec.ts
@@ -190,10 +190,9 @@ test('a failed metadata fetch leaves the capture intact and the view card offers
   // the card's centre, which can land on the inner title link (a click
   // the card handler deliberately ignores) depending on font metrics —
   // that's exactly what happened on CI. Enter always hits the handler.
-  await connectedPage
-    .getByRole('button', { name: new RegExp(url) })
-    .first()
-    .press('Enter');
+  // A string name substring-matches, so the URL's dots stay literal
+  // (new RegExp(url) would treat them as metacharacters).
+  await connectedPage.getByRole('button', { name: url }).first().press('Enter');
   const dialog = connectedPage.getByRole('dialog');
   await expect(dialog).toBeVisible({ timeout: 10_000 });
 


### PR DESCRIPTION
Fulfills the note in BookmarkForm: *"Sockethub integration is planned for a future release."*

## What

**New links** — a bookmark captured from a URL (quick-capture bar, mobile capture sheet, or the add-entry form) is stored immediately, then enriched in the background with the page's Open Graph metadata: title, description, preview image, site name, favicon. All of these land in fields `BookmarkItem` already had (`ogImage`, `siteName`, `favicon`, `description`) and the cards already render — so no rs-module schema changes.

**Existing bookmarks** — two manual triggers:
- a **Fetch preview** button in the bookmark view card (shown while metadata is missing; error state with Retry),
- a **Fetch Link Previews** bulk action in the user menu that backfills every bookmark still missing metadata (3-way concurrency, per-item failures counted but non-fatal, completion toast).

## Transport: HTTP actions, not socket.io

The metadata platform is stateless, so each lookup is a pure request/response. This uses Sockethub's HTTP actions endpoint (`POST /sockethub-http` with an ActivityStreams `fetch`, NDJSON streamed back) instead of `@sockethub/client` + `socket.io-client`:

- **zero new dependencies** — a plain `fetch()` with an `AbortSignal` timeout, ~100 lines total,
- no websocket lifecycle, idle teardown, or response correlation,
- idempotent retries for free via `X-Request-Id`.

> ⚠️ **Server prerequisite:** `sockethub.silverbucket.net` currently 404s on `/sockethub-http` (the socket.io handshake on `/sockethub` works). The deployment needs a build recent enough to include `packages/server/src/http/actions.ts` and `httpActions: { enabled: true }` in its config. The web app degrades gracefully until then: captures work, enrichment silently no-ops, the manual button reports "Couldn't fetch preview".

## Merge safety

- Fill-only merge: title is replaced only while it's still the URL fallback; description/image/site name/favicon fill only when empty — user edits and the extension's richer DOM scrape are never clobbered.
- The live item is re-read from the store before saving, so an edit during the fetch wins and a deleted/undone capture is never resurrected.
- Enrichment is fire-and-forget; a capture never fails because its preview did. Offline captures skip enrichment (retryable later via the manual triggers).

## Also in this PR

The view-card modal now renders the **live item** from the items store rather than the snapshot taken when it was opened. Without this, enrichment (and the pre-existing audio transcription flow) updated the grid card but not the open modal.

## Testing

- 20 new unit tests: NDJSON client + response normalization, merge rules, undo/edit races, bulk pass (`link-metadata.test.ts`, `enrich.test.ts`, `capture.test.ts`).
- New e2e spec (`bookmark-enrichment.spec.ts`) with the Sockethub endpoint mocked via Playwright routes: auto-enrich on capture, and server-failure → manual Fetch preview recovery. Runs as a per-test fresh user so its items don't leak into later specs.
- Full unit suites green across all workspaces (682 tests); svelte-check 0 errors; production build clean.

## Known pre-existing issue (not addressed here)

`desktop/capture-file.spec.ts` fails when any spec runs before it in the worker — reproducible on `master` with `npx playwright test desktop/capture-editor.spec.ts desktop/capture-file.spec.ts`. The ⊕ file-attach modal never opens on a page whose session has prior state; a likely mechanism is the filter-sync effect reassigning `route`, which re-triggers the "close modals when navigating" effect (`App.svelte`) and clears `activeModal`. Worth a separate issue/fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically fetch and fill bookmark preview details after capture or when added manually (when enabled).
  * Added “Link previews” settings with an optional Sockethub endpoint override.
  * Added “Fetch Link Previews” to update previews across bookmarks, with progress feedback.
  * Bookmark views now include an on-demand “Fetch preview” action with status and retry.
* **Bug Fixes**
  * Bookmark details now show the latest saved content instead of an older snapshot.
  * Preview enrichment errors no longer block capture/saving; previews can be retried later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->