### PR TITLE
fix(web): open modals no longer die on same-page route churn

### DIFF
--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -145,9 +145,17 @@
     return () => window.removeEventListener('hashchange', syncRoute);
   });
 
-  // Close modals when navigating
+  // Close modals when navigating to a *different* page. `route` is
+  // reassigned wholesale on every hashchange — including same-page ones,
+  // like the async hashchange from a nav click landing after a modal was
+  // opened, or the filter-sync effect rewriting the hash. Keying this
+  // effect on the object would close modals on all of those (a real race:
+  // attach a file right after clicking Inbox and the modal dies as the
+  // stale hashchange arrives). The $derived memoizes on the page *value*,
+  // so this only fires when the user actually lands on another page.
+  const routePage = $derived(route.page);
   $effect(() => {
-    void route.page;
+    void routePage;
     activeModal = null;
     editingItem = undefined;
     viewingItem = null;

--- a/tests/e2e/desktop/modal-survives-same-page-navigation.spec.ts
+++ b/tests/e2e/desktop/modal-survives-same-page-navigation.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression: an open modal must survive same-page route churn.
+ *
+ * `route` is reassigned wholesale on every hashchange, including ones that
+ * land on the page the user is already on — most commonly the *async*
+ * hashchange event from a nav click being delivered a beat after the user
+ * opened a modal. The close-modals-on-navigation effect used to key on the
+ * route object, so that stale event instantly closed the just-opened
+ * modal. In practice: click Inbox, attach a file, and the Add Image modal
+ * flashed away (flaky, since it raced event delivery — the more the page
+ * had to render, the likelier the loss).
+ *
+ * The fix keys the effect on the page *value*. This spec pins both sides:
+ * a same-page hashchange keeps the modal open; navigating to a different
+ * page still closes it.
+ */
+
+import { expect, test } from '../helpers/fixtures';
+import { assertNoConsoleErrors, attachConsoleCapture } from '../helpers/pwa';
+
+const PNG_1PX = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+test('an open modal survives a same-page hashchange but closes on real navigation', async ({
+  connectedPage,
+  webOrigin,
+}) => {
+  const log = attachConsoleCapture(connectedPage);
+  await connectedPage.goto(webOrigin);
+  await connectedPage.waitForLoadState('networkidle');
+  await connectedPage.getByRole('button', { name: 'Inbox' }).first().click();
+
+  // Open the Add Image modal via the capture bar's hidden file input —
+  // the exact flow that raced the nav click's hashchange.
+  await connectedPage.locator('.file-input').setInputFiles({
+    name: 'regression.png',
+    mimeType: 'image/png',
+    buffer: PNG_1PX,
+  });
+  const dialog = connectedPage.getByRole('dialog');
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+  // A same-page hashchange — what the delayed nav-click event delivers.
+  await connectedPage.evaluate(() => {
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
+  });
+  // The modal must not flinch. A short settle keeps this assertion honest —
+  // the old bug closed it within one reactive flush.
+  await connectedPage.waitForTimeout(200);
+  await expect(dialog).toBeVisible();
+
+  // Navigating to a *different* page still closes it.
+  await connectedPage.evaluate(() => {
+    window.location.hash = '#/todos';
+  });
+  await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+
+  assertNoConsoleErrors(log);
+});


### PR DESCRIPTION
Fixes the pre-existing flakiness first documented in #181: `desktop/capture-file.spec.ts` failed whenever specs ran before it in the worker, and the ⊕ file-attach modal could vanish for real users.

## Root cause

The close-modals-on-navigation effect in `App.svelte` read `route.page`, but `route` is a `$state` object **reassigned wholesale on every hashchange** — so the effect re-ran on any reassignment, even when the page didn't change.

The user-visible race: click a nav button, then open a modal (e.g. attach a file from the capture bar) before the browser delivers the click's async `hashchange` event. `syncRoute` reassigns `route` for the page you're already on, and the just-opened modal is instantly closed. The busier the page (more cards to render, sync in flight), the likelier the event lands late enough to hit the modal — which is why this surfaced as environment- and ordering-dependent e2e flakiness rather than a hard failure. Confirmed by instrumenting the effect: the close fired with `activeModal='image'` immediately after a `syncRoute(#/)` for the page already being viewed.

## Fix

Key the effect on a `$derived` of the page value. Deriveds only propagate when their computed value changes, so modals now:

- **survive** same-page churn — late nav-click hashchange events, filter-sync hash rewrites, re-clicking the active nav button;
- **still close** when the user actually lands on a different page.

## Testing

- New deterministic regression spec (`modal-survives-same-page-navigation.spec.ts`) pinning both sides: an open Add Image modal survives a dispatched same-page `hashchange`, and closes when the hash navigates to `#/todos`.
- The previously failing ordering (`capture-editor.spec.ts` + `capture-file.spec.ts`) now passes, as does the full e2e suite (45/45 — it consistently had 1 failure locally before this).
- Unit tests, svelte-check, and biome all clean.