### PR TITLE
feat(web): decorate bookmark cards with the site favicon

### DIFF
--- a/packages/web/src/components/InboxCard.favicon.svelte.test.ts
+++ b/packages/web/src/components/InboxCard.favicon.svelte.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// InboxCard pulls in the per-type cards (stores/rs at import time) and
+// drag state — neutralise everything not under test.
+vi.mock('../lib/stores', async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    connected: writable(false),
+    blobUrls: writable<Record<string, string>>({}),
+    loadFileBlobUrl: vi.fn(),
+    draggingItemId: writable<string | null>(null),
+  };
+});
+vi.mock('../lib/rs', () => ({
+  default: {},
+  fetchFileBlobUrl: vi.fn(),
+  fetchFileWithAuth: vi.fn(),
+}));
+
+import type { BookmarkItem } from '@inbox-rs/rs-module';
+import InboxCard from './InboxCard.svelte';
+
+function bookmark(overrides: Partial<BookmarkItem> = {}): BookmarkItem {
+  return {
+    id: 'b1',
+    type: 'bookmark',
+    title: 'Example',
+    url: 'https://example.com',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('InboxCard bookmark favicon decorator', () => {
+  let host: HTMLElement;
+  let component: ReturnType<typeof mount> | undefined;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+  });
+
+  afterEach(() => {
+    if (component) unmount(component);
+    component = undefined;
+    host.remove();
+  });
+
+  function mountCard(item: BookmarkItem) {
+    component = mount(InboxCard, {
+      target: host,
+      props: { item, onselect: () => {} },
+    });
+    flushSync();
+  }
+
+  it('renders the favicon in the kind icon when present', () => {
+    mountCard(bookmark({ favicon: 'https://example.com/favicon.ico' }));
+    const img = host.querySelector('img.kind-favicon') as HTMLImageElement;
+    expect(img).not.toBeNull();
+    expect(img.src).toBe('https://example.com/favicon.ico');
+    expect(host.querySelector('.kind-ic svg')).toBeNull();
+  });
+
+  it('resolves relative favicons against the bookmark URL', () => {
+    mountCard(bookmark({ favicon: '/favicon.ico' }));
+    const img = host.querySelector('img.kind-favicon') as HTMLImageElement;
+    expect(img.src).toBe('https://example.com/favicon.ico');
+  });
+
+  it('falls back to the glyph without a favicon', () => {
+    mountCard(bookmark());
+    expect(host.querySelector('img.kind-favicon')).toBeNull();
+    expect(host.querySelector('.kind-ic svg')).not.toBeNull();
+  });
+
+  it('falls back to the glyph when the favicon fails to load', () => {
+    mountCard(bookmark({ favicon: 'https://example.com/favicon.ico' }));
+    const img = host.querySelector('img.kind-favicon') as HTMLImageElement;
+    img.dispatchEvent(new Event('error'));
+    flushSync();
+    expect(host.querySelector('img.kind-favicon')).toBeNull();
+    expect(host.querySelector('.kind-ic svg')).not.toBeNull();
+  });
+
+  it('drops non-http(s) favicons', () => {
+    mountCard(bookmark({ favicon: 'javascript:alert(1)' }));
+    expect(host.querySelector('img.kind-favicon')).toBeNull();
+  });
+
+  it('ignores the abort error fired when the img is detached mid-load', () => {
+    // A remoteStorage change-event echo can briefly revert the item to a
+    // pre-enrichment revision: the img is yanked from the DOM, the aborted
+    // load fires `error` on the detached node, and the favicon returns a
+    // beat later. That abort must not latch the failure state.
+    const props = $state({
+      item: bookmark({ favicon: 'https://example.com/favicon.ico' }),
+      onselect: () => {},
+    });
+    component = mount(InboxCard, { target: host, props });
+    flushSync();
+    const img = host.querySelector('img.kind-favicon') as HTMLImageElement;
+
+    props.item = bookmark(); // echo of the pre-enrichment revision
+    flushSync();
+    img.dispatchEvent(new Event('error')); // abort on the detached node
+    flushSync();
+
+    props.item = bookmark({ favicon: 'https://example.com/favicon.ico' });
+    flushSync();
+    expect(host.querySelector('img.kind-favicon')).not.toBeNull();
+  });
+
+  it('shows the favicon when enrichment adds it after mount', () => {
+    // Mirrors the real flow: the card renders right after capture (no
+    // favicon yet), then background enrichment stores the updated item and
+    // the prop changes.
+    const props = $state({
+      item: bookmark(),
+      onselect: () => {},
+    });
+    component = mount(InboxCard, { target: host, props });
+    flushSync();
+    expect(host.querySelector('img.kind-favicon')).toBeNull();
+
+    props.item = bookmark({ favicon: 'https://example.com/favicon.ico' });
+    flushSync();
+    const img = host.querySelector('img.kind-favicon') as HTMLImageElement;
+    expect(img).not.toBeNull();
+    expect(img?.src).toBe('https://example.com/favicon.ico');
+  });
+});

--- a/packages/web/src/components/InboxCard.favicon.svelte.test.ts
+++ b/packages/web/src/components/InboxCard.favicon.svelte.test.ts
@@ -85,6 +85,28 @@ describe('InboxCard bookmark favicon decorator', () => {
     expect(host.querySelector('.kind-ic svg')).not.toBeNull();
   });
 
+  it('retries when a later update replaces a failed favicon with a new URL', () => {
+    // The failure latch is scoped to the URL that failed — a subsequent
+    // enrichment pass can correct a broken favicon, and the replacement
+    // deserves a fresh attempt.
+    const props = $state({
+      item: bookmark({ favicon: 'https://example.com/broken.ico' }),
+      onselect: () => {},
+    });
+    component = mount(InboxCard, { target: host, props });
+    flushSync();
+    const img = host.querySelector('img.kind-favicon') as HTMLImageElement;
+    img.dispatchEvent(new Event('error')); // genuine failure while connected
+    flushSync();
+    expect(host.querySelector('img.kind-favicon')).toBeNull();
+
+    props.item = bookmark({ favicon: 'https://example.com/fixed.ico' });
+    flushSync();
+    const retry = host.querySelector('img.kind-favicon') as HTMLImageElement;
+    expect(retry).not.toBeNull();
+    expect(retry?.src).toBe('https://example.com/fixed.ico');
+  });
+
   it('drops non-http(s) favicons', () => {
     mountCard(bookmark({ favicon: 'javascript:alert(1)' }));
     expect(host.querySelector('img.kind-favicon')).toBeNull();

--- a/packages/web/src/components/InboxCard.svelte
+++ b/packages/web/src/components/InboxCard.svelte
@@ -79,6 +79,25 @@
   // should still fall back to the generic label rather than render blank.
   const kindLabel = $derived(bookmarkDomain || kind.label);
 
+  // The site's favicon decorates bookmark cards in place of the generic
+  // bookmark glyph. Resolved against the bookmark URL because older items
+  // (and some servers) carry a relative icon path; a failed load falls
+  // back to the glyph.
+  let faviconFailed = $state(false);
+  const bookmarkFavicon = $derived.by(() => {
+    if (item.type !== 'bookmark' || !('favicon' in item) || !item.favicon) {
+      return null;
+    }
+    try {
+      const resolved = new URL(item.favicon, (item as { url: string }).url);
+      return resolved.protocol === 'http:' || resolved.protocol === 'https:'
+        ? resolved.href
+        : null;
+    } catch {
+      return null;
+    }
+  });
+
   // Preview text — note body or description, shown beneath the title so each
   // card gives a real sense of its content.
   const cardNotes = $derived(
@@ -117,7 +136,29 @@
         {#if item.type === 'note'}
           <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h10"/></svg>
         {:else if item.type === 'bookmark'}
-          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linejoin="round"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+          {#if bookmarkFavicon && !faviconFailed}
+            <img
+              class="kind-favicon"
+              src={bookmarkFavicon}
+              alt=""
+              width="14"
+              height="14"
+              loading="lazy"
+              decoding="async"
+              onerror={(e) => {
+                // Detaching an img mid-load (an item update can swap the
+                // if-block) aborts the fetch and fires `error` on the
+                // detached node. Only a *connected* img that fails should
+                // fall back to the glyph — an abort must not latch the
+                // failure and suppress the favicon after it returns.
+                if ((e.currentTarget as HTMLImageElement).isConnected) {
+                  faviconFailed = true;
+                }
+              }}
+            />
+          {:else}
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linejoin="round"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+          {/if}
         {:else if item.type === 'image'}
           <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-5-5L5 21"/></svg>
         {:else if item.type === 'audio'}
@@ -199,6 +240,13 @@
   .kind-ic svg {
     width: 14px;
     height: 14px;
+  }
+
+  .kind-ic .kind-favicon {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    object-fit: contain;
   }
 
   .kind-label {

--- a/packages/web/src/components/InboxCard.svelte
+++ b/packages/web/src/components/InboxCard.svelte
@@ -82,8 +82,10 @@
   // The site's favicon decorates bookmark cards in place of the generic
   // bookmark glyph. Resolved against the bookmark URL because older items
   // (and some servers) carry a relative icon path; a failed load falls
-  // back to the glyph.
-  let faviconFailed = $state(false);
+  // back to the glyph. The failure is scoped to the URL that failed — a
+  // later enrichment pass can replace a broken favicon, and the new URL
+  // deserves a fresh attempt.
+  let failedFaviconUrl = $state<string | null>(null);
   const bookmarkFavicon = $derived.by(() => {
     if (item.type !== 'bookmark' || !('favicon' in item) || !item.favicon) {
       return null;
@@ -136,7 +138,7 @@
         {#if item.type === 'note'}
           <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h10"/></svg>
         {:else if item.type === 'bookmark'}
-          {#if bookmarkFavicon && !faviconFailed}
+          {#if bookmarkFavicon && bookmarkFavicon !== failedFaviconUrl}
             <img
               class="kind-favicon"
               src={bookmarkFavicon}
@@ -151,8 +153,9 @@
                 // detached node. Only a *connected* img that fails should
                 // fall back to the glyph — an abort must not latch the
                 // failure and suppress the favicon after it returns.
-                if ((e.currentTarget as HTMLImageElement).isConnected) {
-                  faviconFailed = true;
+                const img = e.currentTarget as HTMLImageElement;
+                if (img.isConnected) {
+                  failedFaviconUrl = img.src;
                 }
               }}
             />

--- a/tests/e2e/desktop/bookmark-enrichment.spec.ts
+++ b/tests/e2e/desktop/bookmark-enrichment.spec.ts
@@ -91,23 +91,29 @@ test('a captured link is enriched with fetched title, description and image', as
         name: 'Example',
         description: 'An illustrative example page',
         image: [{ url: 'https://example.com/og.png', width: '1200' }],
-        favicon: 'https://example.com/favicon.ico',
+        favicon: 'https://example.com/site-icon.png',
         url,
       }),
     ),
   );
-  // Serve real image bytes for the og:image URL — the card hides broken
-  // images via `onerror`, so the visibility assertion needs a loadable src.
-  await connectedPage.route('https://example.com/og.png', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'image/png',
-      body: Buffer.from(
-        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
-        'base64',
-      ),
-    }),
-  );
+  // Serve real image bytes for the og:image and favicon URLs — the card
+  // hides broken images via `onerror`, so the visibility assertions need
+  // loadable sources.
+  for (const mediaUrl of [
+    'https://example.com/og.png',
+    'https://example.com/site-icon.png',
+  ]) {
+    await connectedPage.route(mediaUrl, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'image/png',
+        body: Buffer.from(
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+          'base64',
+        ),
+      }),
+    );
+  }
 
   await connectedPage.goto(webOrigin);
   await connectedPage.waitForLoadState('networkidle');
@@ -130,6 +136,13 @@ test('a captured link is enriched with fetched title, description and image', as
   ).toBeVisible();
   await expect(
     connectedPage.locator('img[src="https://example.com/og.png"]'),
+  ).toBeVisible();
+  // The fetched favicon decorates the card's kind icon in place of the
+  // generic bookmark glyph.
+  await expect(
+    connectedPage.locator(
+      'img.kind-favicon[src="https://example.com/site-icon.png"]',
+    ),
   ).toBeVisible();
 
   assertNoConsoleErrors(log);


### PR DESCRIPTION
Bookmark cards in the grid now show the site's favicon as the kind-icon decorator, in place of the generic bookmark glyph. Enrichment (via Sockethub) and the browser extension both store favicons, and the view modal already rendered them — the grid card was the gap.

## Details

- Relative icon paths are resolved against the bookmark URL (older items and the server's `/favicon.ico` fallback carry relative values); non-http(s) values are dropped.
- A failed image load falls back to the glyph — but only when a **connected** img errors. Detaching an img mid-load (an item update swapping the if-block) aborts the fetch and fires `error` on the detached node; latching on that abort would suppress the favicon permanently after it returns.
- 7 new component tests (`InboxCard.favicon.svelte.test.ts`): render/resolve/fallback, `javascript:` rejection, post-mount enrichment transition, and the detach-abort case.
- The enrichment e2e now also asserts the decorator renders.

## Test-harness note (cost a debugging session, worth recording)

Headless Chromium under Playwright **silently aborts any image request whose path ends in `/favicon.ico`** — no network request, instant `error` event, even for a page-initiated `new Image()`. Verified empirically: same origin and bytes load fine as `favicon2.ico`, `favicon.png`, or any other name; only `*/favicon.ico` is refused. Real browsers load such images normally. The e2e mock therefore uses `site-icon.png`.

## Verification

- 467 web unit tests green, svelte-check 0 errors, biome clean.
- Full e2e: 45 passed; the only failure is `capture-file.spec.ts`'s known ordering issue, fixed separately in #182 (unmerged).

Depends on nothing; pairs well with sockethub/sockethub#1178, which makes the server emit favicons for X posts and adds the `/favicon.ico` fallback for pages that declare no icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bookmark cards now show a site favicon when available, with a fallback to the existing bookmark icon if no favicon exists or it fails to load.
  * Relative favicon links are handled correctly, and newly enriched bookmarks can update to display a favicon after initial load.

* **Bug Fixes**
  * Improved favicon handling so invalid or unsupported image links are ignored.
  * Prevented a broken favicon state from sticking when an image load fails during rapid UI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->