### PR TITLE
feat(web): enable a collection directly by clicking it

### DIFF
--- a/packages/web/src/components/SidebarShell.svelte
+++ b/packages/web/src/components/SidebarShell.svelte
@@ -15,6 +15,7 @@
     inactiveCollectionIds,
     toggleGroupFilter,
     toggleCollectionFilter,
+    enableCollectionFilter,
     moveItemToCollection,
     createCollection,
     storeGroup,
@@ -123,9 +124,16 @@
     }
   }
 
-  async function onToggleCollection(col: Collection) {
+  async function onToggleCollection(group: CollectionGroup, col: Collection) {
     try {
-      await toggleCollectionFilter(col.id);
+      if (isCollectionActive(group, col)) {
+        // Currently visible → hide it (deny-list).
+        await toggleCollectionFilter(col.id);
+      } else {
+        // Hidden → reveal it, activating the parent group if needed. When the
+        // group was off, this shows only this collection (see the store fn).
+        await enableCollectionFilter(col.id);
+      }
     } catch (error) {
       console.error('Failed to toggle collection filter', error);
     }
@@ -426,7 +434,7 @@
                           style="--entity-color: {col.color || group.color || 'var(--accent)'}"
                           aria-pressed={colActive}
                           title={colActive ? `Hide ${col.name}` : `Show ${col.name}`}
-                          onclick={() => onToggleCollection(col)}
+                          onclick={() => onToggleCollection(group, col)}
                           ondragover={(e) => onColDragOver(e, col)}
                           ondragleave={() => onColDragLeave(col)}
                           ondrop={(e) => onColDrop(e, col)}

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -68,6 +68,7 @@ import {
   deleteCollection,
   deleteGroup,
   deleteItem,
+  enableCollectionFilter,
   groupCollections,
   groups,
   inactiveCollectionIds,
@@ -1588,6 +1589,112 @@ describe('toggleGroupFilter', () => {
     await toggleGroupFilter('g2');
 
     expect(get(appConfig).activeGroupFilters).toEqual(['g1', 'g2']);
+  });
+
+  it('clears the group’s collection hides when activating it', async () => {
+    collections.set({
+      c1: makeCollection('c1', 'g2'),
+      c2: makeCollection('c2', 'g2'),
+      c3: makeCollection('c3', 'g1'),
+    });
+    groups.set({
+      g1: makeGroup('g1', ['c3']),
+      g2: makeGroup('g2', ['c1', 'c2']),
+    });
+    // g2 is off; c1/c2 (its collections) and c3 (another group) are hidden.
+    appConfig.set({
+      activeGroupFilters: ['g1'],
+      inactiveCollectionFilters: ['c1', 'c2', 'c3'],
+    });
+
+    await toggleGroupFilter('g2');
+
+    expect(get(appConfig).activeGroupFilters).toEqual(['g1', 'g2']);
+    // c1/c2 revealed; c3 (belongs to another group) untouched.
+    expect(get(appConfig).inactiveCollectionFilters).toEqual(['c3']);
+  });
+
+  it('leaves the deny-list alone when deactivating a group', async () => {
+    collections.set({ c1: makeCollection('c1', 'g1') });
+    groups.set({ g1: makeGroup('g1', ['c1']) });
+    appConfig.set({
+      activeGroupFilters: ['g1'],
+      inactiveCollectionFilters: ['c1'],
+    });
+
+    await toggleGroupFilter('g1');
+
+    expect(get(appConfig).activeGroupFilters).toEqual([]);
+    expect(get(appConfig).inactiveCollectionFilters).toEqual(['c1']);
+  });
+});
+
+describe('enableCollectionFilter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+  });
+
+  it('activates the parent group and shows only the clicked collection', async () => {
+    collections.set({
+      c1: makeCollection('c1', 'g1'),
+      c2: makeCollection('c2', 'g1'),
+      c3: makeCollection('c3', 'g1'),
+    });
+    groups.set({ g1: makeGroup('g1', ['c1', 'c2', 'c3']) });
+    // g1 is off (only g2-less world here) → group inactive.
+    appConfig.set({ activeGroupFilters: [] });
+
+    await enableCollectionFilter('c2');
+
+    expect(get(appConfig).activeGroupFilters).toEqual(['g1']);
+    // Siblings hidden, c2 visible.
+    expect(get(appConfig).inactiveCollectionFilters?.sort()).toEqual([
+      'c1',
+      'c3',
+    ]);
+  });
+
+  it('additively reveals a collection when its group is already active', async () => {
+    collections.set({
+      c1: makeCollection('c1', 'g1'),
+      c2: makeCollection('c2', 'g1'),
+    });
+    groups.set({ g1: makeGroup('g1', ['c1', 'c2']) });
+    appConfig.set({
+      activeGroupFilters: ['g1'],
+      inactiveCollectionFilters: ['c2'],
+    });
+
+    await enableCollectionFilter('c2');
+
+    // Group unchanged; c2 un-hidden; siblings untouched.
+    expect(get(appConfig).activeGroupFilters).toEqual(['g1']);
+    expect(get(appConfig).inactiveCollectionFilters).toEqual([]);
+  });
+
+  it('reveals a collection under a default-all (undefined) group filter', async () => {
+    collections.set({ c1: makeCollection('c1', 'g1') });
+    groups.set({ g1: makeGroup('g1', ['c1']) });
+    appConfig.set({ inactiveCollectionFilters: ['c1'] });
+
+    await enableCollectionFilter('c1');
+
+    // Default-all means the group is already active — no materialization.
+    expect(get(appConfig).activeGroupFilters).toBeUndefined();
+    expect(get(appConfig).inactiveCollectionFilters).toEqual([]);
+  });
+
+  it('just un-hides an orphan collection (no group)', async () => {
+    collections.set({ c1: makeCollection('c1') });
+    appConfig.set({ inactiveCollectionFilters: ['c1'] });
+
+    await enableCollectionFilter('c1');
+
+    expect(get(appConfig).activeGroupFilters).toBeUndefined();
+    expect(get(appConfig).inactiveCollectionFilters).toEqual([]);
   });
 });
 

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -1586,15 +1586,40 @@ export const orphanCollections = derived(
  * Toggle a group's filter on/off. Persists to config.
  * If activeGroupFilters was undefined (default-all), this materializes the
  * current set first, then flips the requested id.
+ *
+ * When *activating* a group, any per-collection hides (the deny-list) for that
+ * group's collections are cleared, so "show this group" always reveals all of
+ * its collections. This keeps the two sidebar gestures coherent: the group
+ * toggle means "show everything in this group", while clicking an individual
+ * collection (`enableCollectionFilter`) means "show just this one". Without
+ * this, siblings hidden by an earlier exclusive collection-enable would stay
+ * hidden even after re-enabling the group.
  */
 export async function toggleGroupFilter(groupId: string): Promise<void> {
   const config = get(appConfig);
   const allGroupIds = get(sortedGroups).map((g) => g.id);
   const current = config.activeGroupFilters ?? allGroupIds;
-  const next = current.includes(groupId)
-    ? current.filter((id) => id !== groupId)
-    : [...current, groupId];
-  await updateConfig({ activeGroupFilters: next });
+  const activating = !current.includes(groupId);
+  const next = activating
+    ? [...current, groupId]
+    : current.filter((id) => id !== groupId);
+
+  const patch: Partial<AppConfig> = { activeGroupFilters: next };
+
+  if (activating) {
+    const deny = config.inactiveCollectionFilters;
+    if (deny && deny.length > 0) {
+      const groupColIds = new Set(
+        (get(groupCollections)[groupId] ?? []).map((c) => c.id),
+      );
+      const nextDeny = deny.filter((id) => !groupColIds.has(id));
+      if (nextDeny.length !== deny.length) {
+        patch.inactiveCollectionFilters = nextDeny;
+      }
+    }
+  }
+
+  await updateConfig(patch);
 }
 
 /** Set the active group filter list to exactly these IDs. Persists to config.
@@ -1633,6 +1658,48 @@ export async function toggleCollectionFilter(
     ? current.filter((id) => id !== collectionId)
     : [...current, collectionId];
   await updateConfig({ inactiveCollectionFilters: next });
+}
+
+/**
+ * Enable a single collection directly from the sidebar, making it visible even
+ * when its parent group is currently switched off.
+ *
+ * - If the parent group was already active, this is a plain additive reveal:
+ *   the collection is removed from the deny-list; siblings are untouched.
+ * - If the parent group was NOT active, this is an *exclusive* enable: the
+ *   group is activated and every other collection in it is deny-listed, so
+ *   only the clicked collection shows. This spares the user from enabling the
+ *   whole group and then hiding each sibling by hand — the point of the
+ *   gesture. `toggleGroupFilter` clears these hides again on the next group
+ *   activation, so "show the whole group" remains one click away.
+ *
+ * A collection with no `groupId` (orphan) is simply un-hidden.
+ */
+export async function enableCollectionFilter(
+  collectionId: string,
+): Promise<void> {
+  const config = get(appConfig);
+  const groupId = get(collections)[collectionId]?.groupId;
+  const allGroupIds = get(sortedGroups).map((g) => g.id);
+  const currentGroups = config.activeGroupFilters ?? allGroupIds;
+  const groupActive = groupId ? currentGroups.includes(groupId) : true;
+
+  const patch: Partial<AppConfig> = {};
+  const deny = new Set(config.inactiveCollectionFilters ?? []);
+
+  if (groupId && !groupActive) {
+    // Activate the group and show only this collection.
+    patch.activeGroupFilters = [...currentGroups, groupId];
+    for (const col of get(groupCollections)[groupId] ?? []) {
+      if (col.id !== collectionId) deny.add(col.id);
+    }
+  }
+  // Always reveal the clicked collection (covers the group-already-active and
+  // orphan cases, and guards against it being missing from the group list).
+  deny.delete(collectionId);
+
+  patch.inactiveCollectionFilters = Array.from(deny);
+  await updateConfig(patch);
 }
 
 // ---- Flat Todos page: all todos across all collections ----


### PR DESCRIPTION
## What

Clicking a collection in the sidebar now enables it **directly** — activating its parent group if needed — instead of forcing you to first enable the group and then hide every other collection you didn't want.

## The gesture model

The sidebar filter uses a group allow-list (`activeGroupFilters`) plus a collection deny-list (`inactiveCollectionFilters`): a collection shows when its group is active *and* it isn't deny-listed. Three coherent gestures now:

| Gesture | Result |
|---|---|
| Click a **group** name | Show *all* its collections (and clear that group's per-collection hides) |
| Click a **collection** whose group is **off** | Activate the group and show *only* this collection (siblings hidden) |
| Click a **collection** whose group is **on** | Plain toggle — reveal/hide just that one |

Group-activation clearing the group's collection hides is what keeps the two gestures from fighting: an exclusive collection-enable hides siblings, and "show the whole group" un-hides them again in one click.

## Changes

- **`stores.ts`**
  - `toggleGroupFilter` — clears a group's collections from the deny-list when the group is *activated*.
  - New `enableCollectionFilter(collectionId)` — reveals a collection, activating its parent group and (if the group was off) deny-listing siblings for an exclusive show. Handles default-all (`undefined`) filters and orphan collections.
- **`SidebarShell.svelte`** — `onToggleCollection` branches: active → hide, inactive → `enableCollectionFilter`.
- **`stores.test.ts`** — 7 new tests (deny-clearing on group activation, exclusive enable, additive reveal, default-all, orphan).

## Testing

- New + existing store tests pass (128 in `stores.test.ts`).
- Typecheck and production build clean for the changed files.
- Not yet driven in a live browser (needs dev server + Docker remoteStorage).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Collection filters can now be re-enabled directly from the sidebar.
  - Selecting a collection in an inactive group automatically reveals that collection while keeping other group collections hidden.
  - Orphaned collections can be shown independently.

- **Bug Fixes**
  - Re-enabling a group now correctly reveals its collections instead of leaving them hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->