### PR TITLE
fix(web): Todos badge counts the in-view todos, with a greyed total

### DIFF
--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -10,7 +10,7 @@
   import CaptureSheet from './components/CaptureSheet.svelte';
   import Toast from './components/Toast.svelte';
   import {
-    connected, deleteItem, items, openTodos, pendingMigrationCount, runAllMigrations,
+    connected, deleteItem, items, visibleOpenTodos, pendingMigrationCount, runAllMigrations,
     createCollection, storeGroup,
     appConfig, setActiveGroupFilters,
   } from './lib/stores';
@@ -396,8 +396,9 @@
   }
 
   // Surface a small badge with open todo count next to the Todos nav item.
-  // Counts every open todo so the badge matches the flat Todos page.
-  const openTodoCount = $derived($openTodos.length);
+  // Counts open todos within the current group/collection focus, so the badge
+  // matches what the flat Todos page actually shows.
+  const openTodoCount = $derived($visibleOpenTodos.length);
 </script>
 
 {#snippet shellBody()}

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -10,7 +10,7 @@
   import CaptureSheet from './components/CaptureSheet.svelte';
   import Toast from './components/Toast.svelte';
   import {
-    connected, deleteItem, items, visibleOpenTodos, pendingMigrationCount, runAllMigrations,
+    connected, deleteItem, items, visibleOpenTodos, openTodos, pendingMigrationCount, runAllMigrations,
     createCollection, storeGroup,
     appConfig, setActiveGroupFilters,
   } from './lib/stores';
@@ -395,10 +395,12 @@
     void loadGroupFormModal();
   }
 
-  // Surface a small badge with open todo count next to the Todos nav item.
-  // Counts open todos within the current group/collection focus, so the badge
-  // matches what the flat Todos page actually shows.
-  const openTodoCount = $derived($visibleOpenTodos.length);
+  // Todos nav badge. Primary count = open todos within the current
+  // group/collection focus (matches the flat Todos page). Secondary =
+  // total incomplete todos everywhere, shown greyed when it exceeds the
+  // in-view count so a filtered view still hints at what's hidden.
+  const viewTodoCount = $derived($visibleOpenTodos.length);
+  const totalTodoCount = $derived($openTodos.length);
 </script>
 
 {#snippet shellBody()}
@@ -474,11 +476,11 @@
 {/snippet}
 
 {#if $layout === 'sidebar'}
-  <SidebarShell {route} {navTo} {openTodoCount} onaddgroup={openGroupForm} bind:userMenu>
+  <SidebarShell {route} {navTo} {viewTodoCount} {totalTodoCount} onaddgroup={openGroupForm} bind:userMenu>
     {#snippet children()}{@render shellBody()}{/snippet}
   </SidebarShell>
 {:else}
-  <ClassicShell {route} {navTo} {openTodoCount} onaddgroup={openGroupForm} bind:userMenu>
+  <ClassicShell {route} {navTo} {viewTodoCount} {totalTodoCount} onaddgroup={openGroupForm} bind:userMenu>
     {#snippet children()}{@render shellBody()}{/snippet}
   </ClassicShell>
 {/if}

--- a/packages/web/src/components/ClassicShell.svelte
+++ b/packages/web/src/components/ClassicShell.svelte
@@ -12,14 +12,18 @@
   let {
     route,
     navTo,
-    openTodoCount,
+    viewTodoCount,
+    totalTodoCount,
     onaddgroup,
     userMenu = $bindable(null),
     children,
   }: {
     route: Route;
     navTo: (page: Page) => void;
-    openTodoCount: number;
+    /** Open todos within the current group/collection focus (primary badge). */
+    viewTodoCount: number;
+    /** Total incomplete todos everywhere (greyed secondary badge). */
+    totalTodoCount: number;
     onaddgroup: () => void;
     userMenu?: UserMenuHandle | null;
     children: Snippet;
@@ -52,8 +56,11 @@
         onclick={() => navTo('todos')}
       >
         Todos
-        {#if openTodoCount > 0}
-          <span class="nav-badge">{openTodoCount}</span>
+        {#if viewTodoCount > 0}
+          <span class="nav-badge">{viewTodoCount}</span>
+        {/if}
+        {#if totalTodoCount > viewTodoCount}
+          <span class="nav-badge-total" title="{totalTodoCount} incomplete todos in total">{totalTodoCount}</span>
         {/if}
       </button>
       <button
@@ -215,6 +222,16 @@
     align-items: center;
     justify-content: center;
     padding: 0 5px;
+    line-height: 1;
+  }
+
+  /* Greyed total-incomplete count, shown after the accent pill when the
+     current view hides some todos. Muted so it reads as secondary. */
+  .nav-badge-total {
+    font-size: 0.62rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-left: 3px;
     line-height: 1;
   }
 

--- a/packages/web/src/components/SidebarShell.svelte
+++ b/packages/web/src/components/SidebarShell.svelte
@@ -30,14 +30,18 @@
   let {
     route,
     navTo,
-    openTodoCount,
+    viewTodoCount,
+    totalTodoCount,
     onaddgroup,
     userMenu = $bindable(null),
     children,
   }: {
     route: Route;
     navTo: (page: Page) => void;
-    openTodoCount: number;
+    /** Open todos within the current group/collection focus (primary badge). */
+    viewTodoCount: number;
+    /** Total incomplete todos everywhere (greyed secondary badge). */
+    totalTodoCount: number;
     onaddgroup: () => void;
     userMenu?: UserMenuHandle | null;
     children: Snippet;
@@ -294,8 +298,11 @@
         onclick={() => navTo('todos')}
       >
         Todos
-        {#if openTodoCount > 0}
-          <span class="nav-badge">{openTodoCount}</span>
+        {#if viewTodoCount > 0}
+          <span class="nav-badge">{viewTodoCount}</span>
+        {/if}
+        {#if totalTodoCount > viewTodoCount}
+          <span class="nav-badge-total" title="{totalTodoCount} incomplete todos in total">{totalTodoCount}</span>
         {/if}
       </button>
       <button
@@ -631,6 +638,16 @@
     align-items: center;
     justify-content: center;
     padding: 0 5px;
+    line-height: 1;
+  }
+
+  /* Greyed total-incomplete count, shown after the accent pill when the
+     current view hides some todos. Muted so it reads as secondary. */
+  .nav-badge-total {
+    font-size: 0.62rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-left: 3px;
     line-height: 1;
   }
 

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -93,6 +93,7 @@ import {
   toggleGroupFilter,
   userSettings,
   visibleGroupedCollections,
+  visibleOpenTodos,
   visibleTodos,
 } from './stores';
 
@@ -1842,6 +1843,52 @@ describe('visibleTodos', () => {
     appConfig.set({ todosGlobalOrder: ['t2'] });
 
     expect(get(visibleTodos).map((t) => t.id)).toEqual(['t2', 't3', 't1']);
+  });
+});
+
+describe('visibleOpenTodos (nav badge count)', () => {
+  beforeEach(() => {
+    items.set({});
+    collections.set({});
+    groups.set({});
+    appConfig.set({});
+  });
+
+  it('excludes completed todos from the visible set', () => {
+    items.set({
+      open: makeTodo('open'),
+      done: makeTodo('done', { completed: true }),
+    });
+
+    expect(get(visibleOpenTodos).map((t) => t.id)).toEqual(['open']);
+  });
+
+  it('counts only todos in the focused group, matching the Todos page', () => {
+    items.set({
+      c1: makeTodo('c1', { collectionId: 'col-active' }),
+      c2: makeTodo('c2', { collectionId: 'col-hidden' }),
+      done: makeTodo('done', {
+        collectionId: 'col-active',
+        completed: true,
+      }),
+      unfiled: makeTodo('unfiled'),
+    });
+    collections.set({
+      'col-active': makeCollection('col-active', 'g-active'),
+      'col-hidden': makeCollection('col-hidden', 'g-hidden'),
+    });
+    groups.set({
+      'g-active': makeGroup('g-active', ['col-active']),
+      'g-hidden': makeGroup('g-hidden', ['col-hidden']),
+    });
+    // Focus only g-active: the hidden group's open todo must not be counted.
+    appConfig.set({ activeGroupFilters: ['g-active'] });
+
+    const ids = get(visibleOpenTodos)
+      .map((t) => t.id)
+      .sort();
+    // c1 (focused) + unfiled (always visible); c2 hidden, done completed.
+    expect(ids).toEqual(['c1', 'unfiled']);
   });
 });
 

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -1684,6 +1684,16 @@ export const visibleTodos = derived(
 );
 
 /**
+ * Open todos within the current group/collection focus — exactly the set the
+ * Todos page shows as "open". This is what the nav badge counts, so the badge
+ * matches the list the user actually sees. Filtering to a group shrinks both
+ * together, instead of the badge stubbornly reporting a global total.
+ */
+export const visibleOpenTodos = derived(visibleTodos, ($visibleTodos) =>
+  $visibleTodos.filter((t) => !t.completed),
+);
+
+/**
  * Persist a new order for todos on the flat Todos page. Only stores the ids
  * the caller passed — any todos that appear later fall back to createdAt
  * ordering via `sortWithConfiguredOrder`.


### PR DESCRIPTION
## Problem

The Todos nav badge counted every incomplete todo everywhere, so filtering the view to a group left the badge reporting a global total that didn't match the Todos page — making it useless.

## Fix

The badge now shows **two numbers**:

- **Primary (accent pill)** — open todos within the current group/collection focus. Matches the flat Todos page exactly (via `visibleOpenTodos`).
- **Greyed secondary** — total incomplete todos everywhere (`openTodos`). Shown only when the current view hides some, so an unfiltered view stays a single number.

```
No filter (40 open, all in view):   Todos [40]
Filter to one group (8 in view):    Todos [8] 40    ← 40 greyed
Filter to an empty group:           Todos 40        ← greyed only
```

## Changes

- **`stores.ts`** — `visibleOpenTodos` derived store (`visibleTodos` minus completed) for the in-view count. `openTodos` already existed for the total.
- **`App.svelte`** — derives `viewTodoCount` (`visibleOpenTodos`) and `totalTodoCount` (`openTodos`); threads both to the shells.
- **`SidebarShell` / `ClassicShell`** — badge renders the accent pill plus a greyed `.nav-badge-total`, with a tooltip; prop `openTodoCount` → `viewTodoCount` + `totalTodoCount`.
- **`stores.test.ts`** — `visibleOpenTodos` excludes completed and honours the active group filter.

## Testing

- 124 web store tests pass; `svelte-check` clean on the changed components; production build clean.
- Not driven in a live browser (needs dev server + Docker remoteStorage) — happy to run it through and screenshot if you want eyes on the actual badge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Todos navigation badge to count only incomplete todos that match the current focus (excluding completed and hidden-group items).
  - Adjusted badge behavior to show a primary count for the current view and a secondary “total incomplete” count when applicable.

- **Tests**
  - Added/updated store tests to verify `visibleOpenTodos` excludes completed items and respects the active group filter.

- **New Features**
  - Introduced a `visibleOpenTodos` derived store to power the focused “open todos” badge logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->