### PR TITLE
feat: per-todo focus star + focus-count nav badge

### DIFF
--- a/packages/rs-module/src/schemas.ts
+++ b/packages/rs-module/src/schemas.ts
@@ -3,6 +3,7 @@ const todoFields = {
   isTodo: { type: 'boolean' },
   completed: { type: 'boolean' },
   completedAt: { type: 'string' },
+  focused: { type: 'boolean' },
 };
 
 // Shared collection field — any item can belong to a collection.
@@ -184,6 +185,7 @@ export const todoSchema = {
     body: { type: 'string' },
     completed: { type: 'boolean' },
     completedAt: { type: 'string' },
+    focused: { type: 'boolean' },
     createdAt: { type: 'string' },
     ...collectionFields,
     ...migrateFields,

--- a/packages/rs-module/src/types.ts
+++ b/packages/rs-module/src/types.ts
@@ -18,6 +18,7 @@ export interface InboxItemBase {
   isTodo?: boolean;
   completed?: boolean;
   completedAt?: string;
+  focused?: boolean; // starred as a "focus" todo — independent of completion
   collectionId?: string; // undefined = Inbox for refs, unfiled for todos
 }
 

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -10,7 +10,7 @@
   import CaptureSheet from './components/CaptureSheet.svelte';
   import Toast from './components/Toast.svelte';
   import {
-    connected, deleteItem, items, openTodos, pendingMigrationCount, runAllMigrations,
+    connected, deleteItem, items, focusedOpenTodos, pendingMigrationCount, runAllMigrations,
     createCollection, storeGroup,
     appConfig, setActiveGroupFilters,
   } from './lib/stores';
@@ -395,9 +395,10 @@
     void loadGroupFormModal();
   }
 
-  // Surface a small badge with open todo count next to the Todos nav item.
-  // Counts every open todo so the badge matches the flat Todos page.
-  const openTodoCount = $derived($openTodos.length);
+  // Surface a small badge next to the Todos nav item counting the user's
+  // focused (starred) todos that are still open — an actionable short-list,
+  // not a global total.
+  const focusedTodoCount = $derived($focusedOpenTodos.length);
 </script>
 
 {#snippet shellBody()}
@@ -473,11 +474,11 @@
 {/snippet}
 
 {#if $layout === 'sidebar'}
-  <SidebarShell {route} {navTo} {openTodoCount} onaddgroup={openGroupForm} bind:userMenu>
+  <SidebarShell {route} {navTo} {focusedTodoCount} onaddgroup={openGroupForm} bind:userMenu>
     {#snippet children()}{@render shellBody()}{/snippet}
   </SidebarShell>
 {:else}
-  <ClassicShell {route} {navTo} {openTodoCount} onaddgroup={openGroupForm} bind:userMenu>
+  <ClassicShell {route} {navTo} {focusedTodoCount} onaddgroup={openGroupForm} bind:userMenu>
     {#snippet children()}{@render shellBody()}{/snippet}
   </ClassicShell>
 {/if}

--- a/packages/web/src/components/ClassicShell.svelte
+++ b/packages/web/src/components/ClassicShell.svelte
@@ -12,14 +12,14 @@
   let {
     route,
     navTo,
-    openTodoCount,
+    focusedTodoCount,
     onaddgroup,
     userMenu = $bindable(null),
     children,
   }: {
     route: Route;
     navTo: (page: Page) => void;
-    openTodoCount: number;
+    focusedTodoCount: number;
     onaddgroup: () => void;
     userMenu?: UserMenuHandle | null;
     children: Snippet;
@@ -52,8 +52,11 @@
         onclick={() => navTo('todos')}
       >
         Todos
-        {#if openTodoCount > 0}
-          <span class="nav-badge">{openTodoCount}</span>
+        {#if focusedTodoCount > 0}
+          <span
+            class="nav-badge"
+            title="{focusedTodoCount} focused {focusedTodoCount === 1 ? 'todo' : 'todos'}"
+          >{focusedTodoCount}</span>
         {/if}
       </button>
       <button

--- a/packages/web/src/components/SidebarShell.svelte
+++ b/packages/web/src/components/SidebarShell.svelte
@@ -30,14 +30,14 @@
   let {
     route,
     navTo,
-    openTodoCount,
+    focusedTodoCount,
     onaddgroup,
     userMenu = $bindable(null),
     children,
   }: {
     route: Route;
     navTo: (page: Page) => void;
-    openTodoCount: number;
+    focusedTodoCount: number;
     onaddgroup: () => void;
     userMenu?: UserMenuHandle | null;
     children: Snippet;
@@ -294,8 +294,11 @@
         onclick={() => navTo('todos')}
       >
         Todos
-        {#if openTodoCount > 0}
-          <span class="nav-badge">{openTodoCount}</span>
+        {#if focusedTodoCount > 0}
+          <span
+            class="nav-badge"
+            title="{focusedTodoCount} focused {focusedTodoCount === 1 ? 'todo' : 'todos'}"
+          >{focusedTodoCount}</span>
         {/if}
       </button>
       <button

--- a/packages/web/src/components/TodoRow.svelte
+++ b/packages/web/src/components/TodoRow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { InboxItem, Collection, CollectionGroup } from '@inbox-rs/rs-module';
-  import { storeItem } from '../lib/stores';
+  import { storeItem, toggleTodoFocus } from '../lib/stores';
   import { cleanForStorage } from '../lib/clean-for-storage';
   import { typeIconPath } from '../lib/item-utils';
   import { draggingItemId, DRAG_MIME } from '../lib/drag';
@@ -69,6 +69,16 @@
     } catch (err) {
       console.error('Failed to update todo:', err);
       // Checkbox reverts on next render because the `todo` prop is unchanged
+    }
+  }
+
+  async function toggleFocus(e: Event) {
+    e.stopPropagation();
+    try {
+      await toggleTodoFocus(todo.id);
+    } catch (err) {
+      console.error('Failed to toggle todo focus:', err);
+      // Star reverts on next render because the `todo` prop is unchanged
     }
   }
 
@@ -174,6 +184,22 @@
       <span class="date" title={createdTitle}>{createdLabel}</span>
     {/if}
   </div>
+
+  <!-- Focus star: mark a todo as part of your short-list. Filled when focused
+       (always visible so the state is scannable); a faint outline otherwise,
+       revealed on row hover/focus so unfocused rows stay uncluttered. -->
+  <button type="button"
+    class="btn-focus"
+    class:is-focused={todo.focused}
+    onclick={toggleFocus}
+    aria-pressed={!!todo.focused}
+    aria-label="{todo.focused ? 'Unfocus' : 'Focus'} {todo.title}"
+    title={todo.focused ? 'Focused — click to unfocus' : 'Focus this todo'}
+  >
+    <svg width="16" height="16" viewBox="0 0 24 24" fill={todo.focused ? 'currentColor' : 'none'} stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
+    </svg>
+  </button>
 
   {#if onaddincollection}
     <!-- Hover/focus-reveal quick-add: creates a new todo in this row's
@@ -329,6 +355,58 @@
     white-space: nowrap;
   }
 
+  /* Focus star. Unfocused: faint and hover-revealed like the quick-add, so
+     rows stay clean. Focused: always visible in the accent colour so the
+     short-list is scannable at rest. */
+  .btn-focus {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    flex-shrink: 0;
+    padding: 0;
+    border: none;
+    background: none;
+    border-radius: 999px;
+    color: var(--text-muted);
+    opacity: 0;
+    cursor: pointer;
+    transition: opacity 150ms, color 150ms, transform 150ms;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .todo-row:hover .btn-focus,
+  .todo-row:focus-within .btn-focus {
+    opacity: 0.55;
+  }
+
+  .btn-focus:hover {
+    opacity: 1;
+    transform: scale(1.1);
+  }
+
+  .btn-focus:focus-visible {
+    opacity: 1;
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  /* Focused rows always show a filled accent star, regardless of hover. */
+  .btn-focus.is-focused,
+  .todo-row:hover .btn-focus.is-focused,
+  .todo-row:focus-within .btn-focus.is-focused {
+    color: var(--accent);
+    opacity: 1;
+  }
+
+  /* Touch devices have no hover: keep the star visible so it's reachable. */
+  @media (hover: none) {
+    .btn-focus {
+      opacity: 0.55;
+    }
+  }
+
   /* Quick-add button: revealed on hover or keyboard focus anywhere in the row
      (mirrors the pattern in GroupSection / CollectionView). Tinted with the
      collection colour to reinforce the "this adds here" mental model. */
@@ -381,7 +459,7 @@
   @media (max-width: 600px) {
     .todo-row {
       display: grid;
-      grid-template-columns: auto 1fr;
+      grid-template-columns: auto 1fr auto;
       grid-template-rows: auto auto;
       column-gap: 0.6rem;
       row-gap: 0.25rem;
@@ -399,6 +477,15 @@
       grid-column: 2;
       grid-row: 1;
       font-size: 0.9rem;
+    }
+
+    /* Star sits top-right of the 2-line row; kept visible since narrow is
+       typically touch. */
+    .btn-focus {
+      grid-column: 3;
+      grid-row: 1 / span 2;
+      align-self: center;
+      opacity: 0.55;
     }
 
     .meta {

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -68,6 +68,8 @@ import {
   deleteCollection,
   deleteGroup,
   deleteItem,
+  focusedOpenTodos,
+  focusedTodos,
   groupCollections,
   groups,
   inactiveCollectionIds,
@@ -91,6 +93,7 @@ import {
   todoItems,
   toggleCollectionFilter,
   toggleGroupFilter,
+  toggleTodoFocus,
   userSettings,
   visibleGroupedCollections,
   visibleTodos,
@@ -1767,6 +1770,58 @@ describe('allTodos / openTodos', () => {
     });
 
     expect(get(openTodos).map((t) => t.id)).toEqual(['open']);
+  });
+});
+
+describe('focus (star) todos', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    items.set({});
+    appConfig.set({});
+  });
+
+  it('focusedTodos returns only starred todos', () => {
+    items.set({
+      a: makeTodo('a', { focused: true }),
+      b: makeTodo('b'),
+      c: makeTodo('c', { focused: true, completed: true }),
+    });
+
+    expect(
+      get(focusedTodos)
+        .map((t) => t.id)
+        .sort(),
+    ).toEqual(['a', 'c']);
+  });
+
+  it('focusedOpenTodos excludes completed starred todos (the nav badge set)', () => {
+    items.set({
+      a: makeTodo('a', { focused: true }),
+      b: makeTodo('b'), // not focused
+      c: makeTodo('c', { focused: true, completed: true }), // focused but done
+    });
+
+    expect(get(focusedOpenTodos).map((t) => t.id)).toEqual(['a']);
+  });
+
+  it('toggleTodoFocus flips the flag and persists', async () => {
+    items.set({ t1: makeTodo('t1') });
+
+    await toggleTodoFocus('t1');
+    expect(get(items).t1.focused).toBe(true);
+    expect(get(items).t1.isTodo).toBe(true);
+    expect(mockInbox.store).toHaveBeenCalledTimes(1);
+    const stored = mockInbox.store.mock.calls[0][0] as InboxItem;
+    expect(stored.focused).toBe(true);
+
+    await toggleTodoFocus('t1');
+    expect(get(items).t1.focused).toBe(false);
+  });
+
+  it('toggleTodoFocus is a no-op for an unknown id', async () => {
+    items.set({});
+    await toggleTodoFocus('missing');
+    expect(mockInbox.store).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -1650,6 +1650,33 @@ export const openTodos = derived(allTodos, ($allTodos) =>
   $allTodos.filter((t) => !t.completed),
 );
 
+/** Todos the user has starred as "focused" (independent of completion). */
+export const focusedTodos = derived(allTodos, ($allTodos) =>
+  $allTodos.filter((t) => t.focused),
+);
+
+/**
+ * Focused, still-open todos — what the nav badge counts. A badge over the
+ * user's own short-list of starred todos is actionable; a global open-todo
+ * total is not (it can't be driven to zero and ignores the current view).
+ */
+export const focusedOpenTodos = derived(focusedTodos, ($focusedTodos) =>
+  $focusedTodos.filter((t) => !t.completed),
+);
+
+/**
+ * Toggle a todo's "focus" star and persist. Focus is a lightweight per-todo
+ * flag, orthogonal to completion. Mirrors the complete-toggle pattern: build a
+ * rewritten item and hand it to `storeItem` (which updates the `items` store);
+ * on failure the row reverts because its prop is unchanged.
+ */
+export async function toggleTodoFocus(id: string): Promise<void> {
+  const item = get(items)[id];
+  if (!item) return;
+  const updated = { ...item, isTodo: true, focused: !item.focused };
+  await storeItem(cleanForStorage(updated) as InboxItem);
+}
+
 /**
  * Todos visible on the flat Todos page. Unfiled todos are always visible;
  * filed todos honour the group-filter row. Sorted by `todosGlobalOrder`; ids


### PR DESCRIPTION
## Why

The Todos nav badge counted every incomplete todo everywhere — a number you can't act on and can't drive to zero. This adds a real **focus** concept: star the todos that matter now, and the badge counts your focused, still-open todos.

> Chosen over PR #185's "badge follows the group filter" — that one is now superseded for the badge. This PR branches off `master`.

## What it does

- **Star a todo** from any todo row (Todos page + collection views). Filled accent star when focused (always visible so your short-list is scannable); a faint outline star, hover-revealed, otherwise.
- **Nav badge** counts focused-and-incomplete todos. Zero focused ⇒ no badge.

```
[★] Ship the release      ← focused, counts toward the badge
[☆] Read that article     ← not focused
Todos ②                    ← badge = # of ★ that are still open
```

## Changes

| Area | Change |
|---|---|
| `rs-module/types.ts` | `focused?: boolean` on `InboxItemBase` (any todo-capable item). Optional → existing data untouched. |
| `rs-module/schemas.ts` | `focused` added to shared `todoFields` + `todoSchema` (passthrough; kept out of `required`). |
| `stores.ts` | `toggleTodoFocus` (mirrors the complete-toggle pattern) + `focusedTodos` / `focusedOpenTodos` derived stores. |
| `App.svelte` + both shells | Badge now counts `focusedOpenTodos`; prop `openTodoCount` → `focusedTodoCount`, with a descriptive title. |
| `TodoRow.svelte` | Star toggle button + styles, incl. narrow 2-line grid placement. |

Persistence uses the existing `cleanForStorage` + `storeItem` path; `focused` survives the storage round-trip. `CollectionTodoTile.svelte` was left alone — it has no importers (dead code).

## Testing

- New store tests: `focusedTodos` / `focusedOpenTodos` filtering, `toggleTodoFocus` flip+persist and unknown-id no-op. All 126 web store tests + 67 rs-module tests pass.
- `svelte-check` clean on changed components; production build clean.
- Not yet driven in a live browser (needs dev server + Docker remoteStorage) — happy to run it through and screenshot if you want.

## Follow-up (not in scope)

A "Focused" filter/view on the Todos page so clicking the badge jumps to just your starred todos. Say the word and I'll add it.