### PR TITLE
ci: deploy main to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,75 @@
+name: Deploy to GitHub Pages
+
+# Builds the web app from `main` and publishes it to GitHub Pages. This is
+# separate from release.yml (which deploys the production site to 5apps on
+# a manual version bump) — Pages tracks `main` directly so it's always a
+# live preview of the latest commit.
+#
+# One-time setup required in the repo: Settings > Pages > Build and
+# deployment > Source: "GitHub Actions".
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one Pages deployment may run at a time; don't cancel one that's
+# already publishing so a slow run can't get replaced mid-upload by a
+# newer one and leave Pages half-updated.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+      - run: npm install @rollup/rollup-linux-x64-gnu --no-save
+
+      - name: Restore transcription asset cache
+        uses: actions/cache@v4
+        with:
+          path: packages/web/public/ml
+          key: ${{ runner.os }}-transcription-assets-${{ hashFiles('scripts/vendor-transcription-assets.mjs', 'package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-transcription-assets-
+
+      - name: Build web app
+        # Project Pages sites are served from /<repo>/, not the domain root,
+        # so asset/HTML references and the PWA precache manifest need that
+        # base baked in (see packages/web/vite.config.ts).
+        env:
+          GH_PAGES_BASE: /${{ github.event.repository.name }}/
+        run: npm run build
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: packages/web/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -15,7 +15,15 @@ const { version } = JSON.parse(
 // help. Production builds leave both off — nothing here changes for them.
 const isStaging = process.env.STAGING_BUILD === '1';
 
+// The 5apps deploys serve the app from the domain root, so `base` defaults
+// to '/'. The GitHub Pages workflow (.github/workflows/pages.yml) serves it
+// from a /<repo>/ project-page subpath instead, and sets GH_PAGES_BASE so
+// the built HTML/asset references (and the PWA precache manifest) resolve
+// correctly there.
+const base = process.env.GH_PAGES_BASE || '/';
+
 export default defineConfig({
+  base,
   plugins: [
     svelte(),
     VitePWA({
@@ -34,17 +42,19 @@ export default defineConfig({
       ],
       workbox: {
         additionalManifestEntries: [
-          { url: '/', revision: version },
-          { url: '/capture/', revision: version },
+          { url: base, revision: version },
+          { url: `${base}capture/`, revision: version },
         ],
         cleanupOutdatedCaches: true,
-        navigateFallback: '/index.html',
+        navigateFallback: `${base}index.html`,
         // The quick-capture app is its own shell (capture/index.html). Without
         // this, any /capture/ navigation that isn't an exact precache match
         // (query params from OAuth redirects or a future share_target, sub-
         // paths) falls through to the MAIN app's index.html and boots the
         // wrong app inside the capture PWA window.
-        navigateFallbackDenylist: [/^\/capture\//],
+        navigateFallbackDenylist: [
+          new RegExp(`^${base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}capture/`),
+        ],
         globPatterns: ['**/*.{js,css,html,png,svg,webmanifest,wasm}'],
         globIgnores: [
           'ml/**/*',


### PR DESCRIPTION
Adds a workflow that builds the web app on every push to main and publishes it via the official GitHub Pages actions. Project Pages sites are served from /<repo>/ rather than the domain root, so vite.config.ts now takes an optional GH_PAGES_BASE env var to rebase asset/HTML references and the PWA precache manifest accordingly — the 5apps release/staging deploys are unaffected since they leave it unset and keep serving from root.

Closes #1


Claude-Session: https://claude.ai/code/session_019iwWDJsEmqpq8WHWVrix9N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated deployment of the web application to GitHub Pages.
  * Added support for running the application from a repository subpath.
* **Bug Fixes**
  * Improved progressive web app navigation and route handling when hosted under a subpath.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->