### PR TITLE
feat(web): redesign card view and unify collection filing

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: verify
+description: How to build, launch, and drive the Inbox RS web app for runtime verification (Playwright against the Vite dev server, local-first — no RS server needed).
+---
+
+# Verifying the Inbox RS web app
+
+## Launch
+
+```bash
+NODE_OPTIONS= npm run dev        # from repo root; serves web app on http://localhost:5173
+```
+
+- Prefix node/npm/npx invocations with `NODE_OPTIONS=` — the harness env
+  sometimes carries a stale `--require` preload that crashes node.
+- No remoteStorage server needed: the app is local-first and fully usable
+  disconnected (data in IndexedDB). `docker-compose up` (Armadietto, port
+  8000) is only needed to exercise the sync path.
+- Checks: `npm run check` (svelte-check, packages/web), `npm test` (vitest).
+
+## Drive (Playwright)
+
+Playwright ~v1.59 + Chromium are installed at the repo root. Scripts outside
+the repo can't resolve the bare specifier — require by absolute path:
+
+```js
+const { chromium } = require('<repo>/node_modules/playwright');
+const ctx = await chromium.launchPersistentContext(dir, { viewport: {...} });
+```
+
+Use `launchPersistentContext` so seeded data (IndexedDB) survives across
+script runs; `rm -rf <profile-dir>` for a fresh start.
+
+### Gotchas that cost time
+
+- **Opening a card**: `article.card` ignores clicks that land on inner
+  links/buttons, and a bookmark card's title is an external link. Click the
+  card's `footer` (the date) — keyboard Enter is unreliable inside
+  collection views.
+- **Filed items** live on the Collections page inside `CollectionView`
+  sections; expand toggles are `aria-label="Expand {name}"` (already
+  expanded state persists in appConfig).
+- **Nav tabs**: the Todos tab label includes a count badge — match with
+  `{ name: /^Todos/ }`, not `exact: true`.
+- **Seeding**: capture bar (`Paste a link, jot a note, or drop a file…`) +
+  Enter creates a bookmark/note instantly. First group via "Create your
+  first group" (name field placeholder `e.g. Work, Bands, Research`);
+  collections via Collections page FAB "New collection" (placeholder
+  `e.g. Reading List`).
+- Offline enrichment fetches (sockethub) fail with console errors — noise,
+  not a defect.
+
+## Flows worth driving
+
+Open card modal → header icons / meta strip → "File into collection…" →
+CollectionPicker (suggestions, type-to-filter, inline create, Unfile/Inbox)
+→ Make a todo → Todos page. Mobile: 390×844 viewport renders the picker as
+a bottom sheet.

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -13,6 +13,8 @@
     shouldSubmitAddEntryForm,
   } from '../lib/add-entry-modal';
   import { enrichBookmark, needsEnrichment } from '../lib/enrich';
+  import type { FilingSubject } from '../lib/collection-suggest';
+  import CollectionPicker from './CollectionPicker.svelte';
   import BookmarkForm from './add-entry/BookmarkForm.svelte';
   import NoteForm from './add-entry/NoteForm.svelte';
   import ImageForm from './add-entry/ImageForm.svelte';
@@ -56,13 +58,6 @@
   // means Inbox.
   let selectedCollectionId = $state<string | undefined>(collectionId);
   let collectionPickerOpen = $state(false);
-  let collectionPickerEl = $state<HTMLDivElement>();
-  let collectionPickerTriggerEl = $state<HTMLButtonElement>();
-  // Collection dropdown menu position, computed when opened. Positioned
-  // with `position: fixed` so it escapes the modal's `overflow: hidden`
-  // (note modal) and the modal's rounded border clipping (other modals).
-  // Flips upward when there's no room below.
-  let pickerMenuStyle = $state('');
   // For refs, `undefined` means Inbox. For todos, `undefined` means unfiled:
   // no collectionId is written, and the todo stays available to organize
   // later without creating any synthetic group or collection.
@@ -119,73 +114,24 @@
     email: 'Edit Email',
   };
 
-  $effect(() => {
-    if (!collectionPickerOpen) return;
-    const onDoc = (e: MouseEvent) => {
-      if (collectionPickerEl && !collectionPickerEl.contains(e.target as Node))
-        collectionPickerOpen = false;
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') collectionPickerOpen = false;
-    };
-    // Re-position on resize/scroll so the fixed-position menu stays anchored
-    // to the trigger — the modal content can scroll behind it, and on mobile
-    // the viewport can change on orientation / keyboard appearance.
-    const reposition = () => positionPickerMenu();
-    document.addEventListener('mousedown', onDoc);
-    document.addEventListener('keydown', onKey);
-    window.addEventListener('resize', reposition);
-    window.addEventListener('scroll', reposition, true);
-    return () => {
-      document.removeEventListener('mousedown', onDoc);
-      document.removeEventListener('keydown', onKey);
-      window.removeEventListener('resize', reposition);
-      window.removeEventListener('scroll', reposition, true);
-    };
-  });
-
   function selectCollection(id: string | undefined) {
     selectedCollectionId = id;
     collectionPickerOpen = false;
   }
 
   /**
-   * Compute the dropdown menu position relative to the trigger using
-   * viewport coordinates. We render the menu with `position: fixed` so it
-   * escapes the modal's clipping contexts (overflow: hidden on the note
-   * modal, rounded border on others) and can always extend past the modal.
-   * If there's not enough room below the trigger for the menu (max 320px),
-   * flip it to open upward.
+   * What the CollectionPicker files. The item doesn't exist yet, so this is
+   * a lightweight subject: no title/url means content-based suggestions
+   * degrade gracefully to recency, and `collectionId` reflects the pending
+   * selection so the picker excludes it from the list and offers the
+   * Inbox/Unfiled row to clear it.
    */
-  function positionPickerMenu() {
-    if (!collectionPickerTriggerEl) return;
-    const rect = collectionPickerTriggerEl.getBoundingClientRect();
-    const viewportHeight = window.innerHeight;
-    const menuMaxHeight = 320;
-    const gap = 4;
-    const spaceBelow = viewportHeight - rect.bottom - gap;
-    const spaceAbove = rect.top - gap;
-    const preferUp =
-      spaceBelow < Math.min(menuMaxHeight, 200) && spaceAbove > spaceBelow;
-    const maxHeight = Math.max(
-      120,
-      Math.min(menuMaxHeight, preferUp ? spaceAbove : spaceBelow),
-    );
-    const left = rect.left;
-    const width = rect.width;
-    if (preferUp) {
-      const bottom = viewportHeight - rect.top + gap;
-      pickerMenuStyle = `left: ${left}px; width: ${width}px; bottom: ${bottom}px; max-height: ${maxHeight}px;`;
-    } else {
-      const top = rect.bottom + gap;
-      pickerMenuStyle = `left: ${left}px; width: ${width}px; top: ${top}px; max-height: ${maxHeight}px;`;
-    }
-  }
-
-  function togglePicker() {
-    if (!collectionPickerOpen) positionPickerMenu();
-    collectionPickerOpen = !collectionPickerOpen;
-  }
+  const pickerSubject = $derived<FilingSubject>({
+    id: editItem?.id,
+    title: '',
+    collectionId: selectedCollectionId,
+    isTodo: isTodoType,
+  });
 
   async function handleSubmit() {
     if (!formBuildItem || !formCanSubmit) return;
@@ -339,102 +285,30 @@
       {#if showCollectionPicker}
         <div class="field">
           <span>{isTodoType ? 'File in' : 'Collection'}</span>
-          <div class="dest-wrapper" bind:this={collectionPickerEl}>
-            <button
-              type="button"
-              class="dest-trigger"
-              bind:this={collectionPickerTriggerEl}
-              onclick={togglePicker}
-              aria-haspopup="listbox"
-              aria-expanded={collectionPickerOpen}
+          <button
+            type="button"
+            class="dest-trigger"
+            onclick={() => (collectionPickerOpen = true)}
+            aria-haspopup="dialog"
+            aria-expanded={collectionPickerOpen}
+          >
+            <span class="dest-label">{collectionLabel}</span>
+            <svg
+              aria-hidden="true"
+              class="dest-chevron"
+              class:open={collectionPickerOpen}
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
             >
-              <span class="dest-label">{collectionLabel}</span>
-              <svg
-                aria-hidden="true"
-                class="dest-chevron"
-                class:open={collectionPickerOpen}
-                width="12"
-                height="12"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
-                <polyline points="6 9 12 15 18 9"></polyline>
-              </svg>
-            </button>
-            {#if collectionPickerOpen}
-              <div
-                class="dest-menu"
-                role="listbox"
-                aria-label="Destination"
-                style={pickerMenuStyle}
-              >
-                <!--
-                  Default non-collection destination. For refs this is Inbox;
-                  for todos this is unfiled so they can be organized later.
-                -->
-                {#if isTodoType}
-                  <button
-                    type="button"
-                    class="dest-item"
-                    class:selected={selectedCollectionId === undefined}
-                    onclick={() => selectCollection(undefined)}
-                  >
-                    <span
-                      class="dest-dot"
-                      style="background: #9ca3af"
-                      aria-hidden="true"
-                    ></span>
-                    Unfiled
-                  </button>
-                {:else if !isTodoType}
-                  <button
-                    type="button"
-                    class="dest-item"
-                    class:selected={selectedCollectionId === undefined}
-                    onclick={() => selectCollection(undefined)}
-                  >
-                    <span class="dest-dot inbox" aria-hidden="true"></span>
-                    {noCollectionLabel}
-                  </button>
-                {/if}
-                {#each $sortedGroups as group (group.id)}
-                  {@const cols = $groupCollections[group.id] ?? []}
-                  {#if cols.length > 0}
-                    <div
-                      class="dest-group-label"
-                      style="--group-color: {group.color || 'var(--accent)'}"
-                    >
-                      <span
-                        class="dest-dot"
-                        style="background: var(--group-color)"
-                        aria-hidden="true"
-                      ></span>
-                      {group.name}
-                    </div>
-                    {#each cols as col (col.id)}
-                      <button
-                        type="button"
-                        class="dest-item nested"
-                        class:selected={selectedCollectionId === col.id}
-                        onclick={() => selectCollection(col.id)}
-                      >
-                        <span
-                          class="dest-dot"
-                          style="background: {col.color || 'var(--accent)'}"
-                          aria-hidden="true"
-                        ></span>
-                        {col.name}
-                      </button>
-                    {/each}
-                  {/if}
-                {/each}
-              </div>
-            {/if}
-          </div>
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
         </div>
       {/if}
 
@@ -480,6 +354,15 @@
         </button>
       </div>
     </div>
+
+    {#if collectionPickerOpen}
+      <CollectionPicker
+        item={pickerSubject}
+        mode={isTodoType ? 'todo' : 'move'}
+        onpick={selectCollection}
+        onclose={() => (collectionPickerOpen = false)}
+      />
+    {/if}
   </div>
 </div>
 
@@ -955,10 +838,6 @@
     cursor: default;
   }
 
-  .dest-wrapper {
-    position: relative;
-  }
-
   .dest-trigger {
     display: inline-flex;
     align-items: center;
@@ -998,78 +877,5 @@
 
   .dest-chevron.open {
     transform: rotate(180deg);
-  }
-
-  /*
-   * Fixed positioning (set dynamically via inline style) lets the menu
-   * escape the modal's clipping contexts — the note modal sets
-   * `overflow: hidden` on the form, and the modal frame's rounded corners
-   * visually clip dropdowns that extend past the modal edge. A higher
-   * z-index than the overlay (200) keeps the menu on top of the modal.
-   */
-  .dest-menu {
-    position: fixed;
-    z-index: 250;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
-    padding: 0.3rem;
-    overflow-y: auto;
-  }
-
-  .dest-item {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    width: 100%;
-    background: none;
-    border: none;
-    padding: 0.4rem 0.55rem;
-    border-radius: var(--radius-sm);
-    color: var(--text);
-    font-size: 0.85rem;
-    font-family: inherit;
-    cursor: pointer;
-    text-align: left;
-    transition: background 0.12s;
-  }
-
-  .dest-item:hover {
-    background: var(--bg);
-  }
-
-  .dest-item.selected {
-    background: color-mix(in srgb, var(--accent) 14%, var(--surface) 86%);
-    color: var(--accent);
-    font-weight: 600;
-  }
-
-  .dest-item.nested {
-    padding-left: 1.5rem;
-  }
-
-  .dest-group-label {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.45rem 0.55rem 0.2rem;
-    color: var(--text-muted);
-    font-size: 0.7rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-  }
-
-  .dest-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
-    background: var(--accent);
-  }
-
-  .dest-dot.inbox {
-    background: var(--accent);
   }
 </style>

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -12,8 +12,14 @@
     shouldShowCollectionPicker,
     shouldSubmitAddEntryForm,
   } from '../lib/add-entry-modal';
+  import { get } from 'svelte/store';
+  import { collections } from '../lib/stores';
   import { enrichBookmark, needsEnrichment } from '../lib/enrich';
-  import type { FilingSubject } from '../lib/collection-suggest';
+  import {
+    getRecentCollectionIds,
+    recordCollectionUse,
+    type FilingSubject,
+  } from '../lib/collection-suggest';
   import CollectionPicker from './CollectionPicker.svelte';
   import BookmarkForm from './add-entry/BookmarkForm.svelte';
   import NoteForm from './add-entry/NoteForm.svelte';
@@ -51,12 +57,28 @@
   let formCanSubmit = $state(false);
   let formBuildItem = $state<BuildItemFn | undefined>(undefined);
 
-  // Initial destination for new items: honour the caller's explicit
-  // `collectionId` prop (e.g. a collection quick-add button), otherwise leave
-  // unset. For todos, unset means "unfiled" — we deliberately don't
-  // auto-select organization so capture stays frictionless. For refs, unset
-  // means Inbox.
-  let selectedCollectionId = $state<string | undefined>(collectionId);
+  /**
+   * Initial destination for new items, in priority order:
+   *   1. The caller's explicit `collectionId` prop (e.g. a collection
+   *      quick-add button) — that context is authoritative.
+   *   2. The most recent filing target that still exists — repeat captures
+   *      usually file to the same place, and the meta strip's Inbox/Unfiled
+   *      reset makes escaping the default one click.
+   *   3. Unset: Inbox for refs, unfiled for todos.
+   * Edit mode never shows the destination field, so it always starts unset.
+   */
+  function rememberedDestination(): string | undefined {
+    if (isEdit) return undefined;
+    const cols = get(collections);
+    for (const id of getRecentCollectionIds()) {
+      if (cols[id]) return id;
+    }
+    return undefined;
+  }
+
+  let selectedCollectionId = $state<string | undefined>(
+    collectionId ?? rememberedDestination(),
+  );
   let collectionPickerOpen = $state(false);
   // For refs, `undefined` means Inbox. For todos, `undefined` means unfiled:
   // no collectionId is written, and the todo stays available to organize
@@ -180,6 +202,9 @@
       }
       if (selectedCollectionId && !isEdit) {
         await moveItemToCollection(item.id, selectedCollectionId);
+        // Feed the recency signal so the next capture defaults here and the
+        // picker's Suggested block stays honest.
+        recordCollectionUse(selectedCollectionId);
       }
       // Fill blank bookmark fields (title, description, preview image) from
       // the page's metadata in the background. New items only — an edit is
@@ -313,6 +338,29 @@
             {/if}
             {selectedLocation.name}
           </span>
+          {#if selectedCollectionId !== undefined}
+            <button
+              type="button"
+              class="btn-reset"
+              onclick={() => (selectedCollectionId = undefined)}
+            >
+              <svg
+                aria-hidden="true"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polyline points="1 4 1 10 7 10"></polyline>
+                <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path>
+              </svg>
+              {isTodoType ? 'Unfiled' : 'Inbox'}
+            </button>
+          {/if}
         </div>
         <button
           type="button"
@@ -871,12 +919,35 @@
   .meta-strip {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
     gap: 0.9rem;
     margin-top: 0.25rem;
     padding-top: 0.75rem;
     border-top: 1px solid var(--border);
     font-size: 0.78rem;
     color: var(--text-muted);
+  }
+
+  /* One-click escape from the remembered destination. */
+  .btn-reset {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    font-family: inherit;
+    padding: 0.15rem 0.4rem;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+  }
+
+  .btn-reset:hover {
+    color: var(--text);
+    background: var(--surface-tint);
   }
 
   .meta-item {

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -65,17 +65,29 @@
   const noCollectionLabel = 'Inbox';
 
   // `undefined` is the non-collection sentinel: Inbox for refs, unfiled for
-  // todos.
-  const collectionLabel = $derived.by(() => {
-    if (selectedCollectionId === undefined) {
-      return isTodoType ? 'Unfiled' : noCollectionLabel;
+  // todos. Resolved to display parts so the trigger chip can mirror the card
+  // view's location styling (colored dot + group-colored prefix).
+  const selectedLocation = $derived.by(() => {
+    if (selectedCollectionId !== undefined) {
+      for (const group of $sortedGroups) {
+        const cols = $groupCollections[group.id] ?? [];
+        const found = cols.find((c) => c.id === selectedCollectionId);
+        if (found) {
+          return {
+            name: found.name,
+            color: found.color || '#6366f1',
+            groupName: group.name,
+            groupColor: group.color || 'var(--accent)',
+          };
+        }
+      }
     }
-    for (const group of $sortedGroups) {
-      const cols = $groupCollections[group.id] ?? [];
-      const found = cols.find((c) => c.id === selectedCollectionId);
-      if (found) return found.name;
-    }
-    return isTodoType ? 'Unfiled' : noCollectionLabel;
+    return {
+      name: isTodoType ? 'Unfiled' : noCollectionLabel,
+      color: '#9ca3af',
+      groupName: undefined,
+      groupColor: undefined,
+    };
   });
 
   // Whether the user has any real grouped collections at all. Todo capture
@@ -283,20 +295,30 @@
       {/if}
 
       {#if showCollectionPicker}
-        <div class="field">
-          <span>{isTodoType ? 'File in' : 'Collection'}</span>
+        <div class="field dest-field">
+          <span>File in</span>
           <button
             type="button"
-            class="dest-trigger"
+            class="loc-chip"
             onclick={() => (collectionPickerOpen = true)}
             aria-haspopup="dialog"
             aria-expanded={collectionPickerOpen}
           >
-            <span class="dest-label">{collectionLabel}</span>
+            <span
+              class="loc-dot"
+              style="background: {selectedLocation.color}"
+              aria-hidden="true"
+            ></span>
+            {#if selectedLocation.groupName}
+              <span class="loc-group" style="color: {selectedLocation.groupColor}"
+                >{selectedLocation.groupName}</span
+              >
+              <span class="loc-sep" aria-hidden="true">·</span>
+            {/if}
+            <span class="loc-name">{selectedLocation.name}</span>
             <svg
               aria-hidden="true"
-              class="dest-chevron"
-              class:open={collectionPickerOpen}
+              class="loc-chevron"
               width="12"
               height="12"
               viewBox="0 0 24 24"
@@ -838,44 +860,59 @@
     cursor: default;
   }
 
-  .dest-trigger {
+  /* Location chip — mirrors the card view's meta-strip location styling:
+     a pill with the collection's colored dot and group-colored prefix,
+     rather than a form select. Opens the CollectionPicker. */
+  .dest-field {
+    align-items: flex-start;
+  }
+
+  .loc-chip {
     display: inline-flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem;
-    width: 100%;
-    background: var(--bg);
+    gap: 0.45rem;
+    background: var(--surface-tint);
     border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    padding: 0.5rem 0.75rem;
+    border-radius: 999px;
+    padding: 0.35rem 0.85rem;
     color: var(--text);
     font-size: 0.85rem;
     font-family: inherit;
     cursor: pointer;
-    transition: border-color 0.15s;
-    white-space: nowrap;
+    transition: border-color 0.15s, background 0.15s;
+    max-width: 100%;
   }
 
-  .dest-trigger:hover {
+  .loc-chip:hover {
     border-color: var(--accent);
+    background: var(--accent-subtler);
   }
 
-  .dest-label {
+  .loc-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .loc-group {
+    font-weight: 600;
+    flex-shrink: 0;
+  }
+
+  .loc-sep {
+    color: var(--text-muted);
+  }
+
+  .loc-name {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-size: 0.85rem;
-    color: var(--text);
-    font-weight: 400;
   }
 
-  .dest-chevron {
-    transition: transform 150ms;
+  .loc-chevron {
     flex-shrink: 0;
-    opacity: 0.7;
-  }
-
-  .dest-chevron.open {
-    transform: rotate(180deg);
+    opacity: 0.6;
+    color: var(--text-muted);
   }
 </style>

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -295,43 +295,48 @@
       {/if}
 
       {#if showCollectionPicker}
-        <div class="field dest-field">
-          <span>File in</span>
-          <button
-            type="button"
-            class="loc-chip"
-            onclick={() => (collectionPickerOpen = true)}
-            aria-haspopup="dialog"
-            aria-expanded={collectionPickerOpen}
-          >
+        <!-- Mirrors the card view's filing zone exactly: meta-strip location
+             row + full-width filing primary. A new item's location is
+             Inbox/Unfiled until saved, so the same language applies. -->
+        <div class="meta-strip">
+          <span class="meta-item">
             <span
               class="loc-dot"
               style="background: {selectedLocation.color}"
               aria-hidden="true"
             ></span>
             {#if selectedLocation.groupName}
-              <span class="loc-group" style="color: {selectedLocation.groupColor}"
+              <span class="meta-group" style="color: {selectedLocation.groupColor}"
                 >{selectedLocation.groupName}</span
               >
-              <span class="loc-sep" aria-hidden="true">·</span>
+              <span aria-hidden="true">·</span>
             {/if}
-            <span class="loc-name">{selectedLocation.name}</span>
-            <svg
-              aria-hidden="true"
-              class="loc-chevron"
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <polyline points="6 9 12 15 18 9"></polyline>
-            </svg>
-          </button>
+            {selectedLocation.name}
+          </span>
         </div>
+        <button
+          type="button"
+          class="btn-file"
+          onclick={() => (collectionPickerOpen = true)}
+          aria-haspopup="dialog"
+          aria-expanded={collectionPickerOpen}
+        >
+          <svg
+            aria-hidden="true"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"
+            ></path>
+          </svg>
+          {selectedCollectionId ? 'Move to collection…' : 'File into collection…'}
+        </button>
       {/if}
 
       {#if error}
@@ -860,32 +865,24 @@
     cursor: default;
   }
 
-  /* Location chip — mirrors the card view's meta-strip location styling:
-     a pill with the collection's colored dot and group-colored prefix,
-     rather than a form select. Opens the CollectionPicker. */
-  .dest-field {
-    align-items: flex-start;
+  /* Filing zone — same visual language as ViewCardModal's meta strip +
+     filing primary, so filing looks identical whether the item exists yet
+     or not. */
+  .meta-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.9rem;
+    margin-top: 0.25rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.78rem;
+    color: var(--text-muted);
   }
 
-  .loc-chip {
-    display: inline-flex;
+  .meta-item {
+    display: flex;
     align-items: center;
-    gap: 0.45rem;
-    background: var(--surface-tint);
-    border: 1px solid var(--border);
-    border-radius: 999px;
-    padding: 0.35rem 0.85rem;
-    color: var(--text);
-    font-size: 0.85rem;
-    font-family: inherit;
-    cursor: pointer;
-    transition: border-color 0.15s, background 0.15s;
-    max-width: 100%;
-  }
-
-  .loc-chip:hover {
-    border-color: var(--accent);
-    background: var(--accent-subtler);
+    gap: 0.35rem;
   }
 
   .loc-dot {
@@ -895,24 +892,30 @@
     flex-shrink: 0;
   }
 
-  .loc-group {
+  .meta-group {
     font-weight: 600;
-    flex-shrink: 0;
   }
 
-  .loc-sep {
-    color: var(--text-muted);
+  .btn-file {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    width: 100%;
+    margin-top: 0.85rem;
+    background: var(--accent);
+    border: none;
+    color: white;
+    padding: 0.6rem 1rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.9rem;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    transition: opacity 0.15s;
   }
 
-  .loc-name {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .loc-chevron {
-    flex-shrink: 0;
-    opacity: 0.6;
-    color: var(--text-muted);
+  .btn-file:hover {
+    opacity: 0.9;
   }
 </style>

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -56,6 +56,10 @@
   // reads `formCanSubmit` to gate the action button.
   let formCanSubmit = $state(false);
   let formBuildItem = $state<BuildItemFn | undefined>(undefined);
+  // Live draft fields mirrored up from the per-type forms — they feed the
+  // filing picker's content-match suggestions before the item exists.
+  let draftTitle = $state('');
+  let draftUrl = $state('');
 
   /**
    * Initial destination for new items, in priority order:
@@ -155,14 +159,16 @@
 
   /**
    * What the CollectionPicker files. The item doesn't exist yet, so this is
-   * a lightweight subject: no title/url means content-based suggestions
-   * degrade gracefully to recency, and `collectionId` reflects the pending
+   * a lightweight subject built from the live draft fields — the typed
+   * title/URL feed name- and site-match suggestions; with nothing typed yet
+   * they degrade gracefully to recency. `collectionId` reflects the pending
    * selection so the picker excludes it from the list and offers the
    * Inbox/Unfiled row to clear it.
    */
   const pickerSubject = $derived<FilingSubject>({
     id: editItem?.id,
-    title: '',
+    title: draftTitle,
+    url: draftUrl || undefined,
     collectionId: selectedCollectionId,
     isTodo: isTodoType,
   });
@@ -276,6 +282,8 @@
           {editItem}
           bind:canSubmit={formCanSubmit}
           bind:buildItem={formBuildItem}
+          bind:draftTitle
+          bind:draftUrl
         />
       {:else if type === 'note'}
         <NoteForm
@@ -283,6 +291,7 @@
           {prefillTitle}
           bind:canSubmit={formCanSubmit}
           bind:buildItem={formBuildItem}
+          bind:draftTitle
         />
       {:else if type === 'image'}
         <ImageForm
@@ -290,12 +299,14 @@
           {prefillFile}
           bind:canSubmit={formCanSubmit}
           bind:buildItem={formBuildItem}
+          bind:draftTitle
         />
       {:else if type === 'audio'}
         <AudioForm
           {editItem}
           bind:canSubmit={formCanSubmit}
           bind:buildItem={formBuildItem}
+          bind:draftTitle
         />
       {:else if type === 'document'}
         <DocumentForm
@@ -303,12 +314,14 @@
           {prefillFile}
           bind:canSubmit={formCanSubmit}
           bind:buildItem={formBuildItem}
+          bind:draftTitle
         />
       {:else if type === 'email'}
         <EmailForm
           {editItem}
           bind:canSubmit={formCanSubmit}
           bind:buildItem={formBuildItem}
+          bind:draftTitle
         />
       {:else if type === 'todo'}
         <TodoForm
@@ -316,6 +329,7 @@
           {prefillTitle}
           bind:canSubmit={formCanSubmit}
           bind:buildItem={formBuildItem}
+          bind:draftTitle
         />
       {/if}
 

--- a/packages/web/src/components/CollectionPicker.svelte
+++ b/packages/web/src/components/CollectionPicker.svelte
@@ -7,6 +7,7 @@
     groupCollections,
     groups,
     items,
+    orphanCollections,
     sortedGroups,
     updateConfig,
   } from '../lib/stores';
@@ -47,6 +48,7 @@
   // touch devices — desktop-only.
   const isCoarse =
     typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
     window.matchMedia('(pointer: coarse)').matches;
 
   const isTodoish = $derived(item.isTodo || item.type === 'todo');
@@ -62,9 +64,10 @@
   );
   const showUnfiled = $derived(mode === 'todo' || !!item.collectionId);
 
-  const allCollections = $derived(
-    $sortedGroups.flatMap((g) => $groupCollections[g.id] ?? []),
-  );
+  const allCollections = $derived([
+    ...$sortedGroups.flatMap((g) => $groupCollections[g.id] ?? []),
+    ...$orphanCollections,
+  ]);
 
   // Suggestions only lead when the user isn't already narrowing by hand.
   const suggestions = $derived(
@@ -94,6 +97,16 @@
         ),
       }))
       .filter(({ cols }) => cols.length > 0);
+  });
+
+  /** Ungrouped collections, query-filtered — rendered under "Other". */
+  const filteredOrphans = $derived.by(() => {
+    const q = query.trim().toLowerCase();
+    return $orphanCollections.filter(
+      (col) =>
+        col.id !== item.collectionId &&
+        (!q || col.name.toLowerCase().includes(q)),
+    );
   });
 
   const hasAnyCollections = $derived(allCollections.length > 0);
@@ -151,7 +164,7 @@
 
   function handleSearchKeydown(e: KeyboardEvent) {
     if (e.key !== 'Enter') return;
-    const first = filteredGroups[0]?.cols[0];
+    const first = filteredGroups[0]?.cols[0] ?? filteredOrphans[0];
     if (query.trim() && first) {
       onpick(first.id);
     } else if (query.trim() && !queryHasExactMatch) {
@@ -337,7 +350,18 @@
           {/each}
         {/each}
 
-        {#if hasAnyCollections && query.trim() && filteredGroups.length === 0}
+        {#if filteredOrphans.length > 0}
+          <div class="group-label">Other</div>
+          {#each filteredOrphans as col (col.id)}
+            <button type="button" class="option" onclick={() => onpick(col.id)}>
+              <span class="dot" style="background: {col.color || '#6366f1'}"></span>
+              <span class="col-name">{col.name}</span>
+              <span class="count">{col.itemIds.length}</span>
+            </button>
+          {/each}
+        {/if}
+
+        {#if hasAnyCollections && query.trim() && filteredGroups.length === 0 && filteredOrphans.length === 0}
           <div class="empty">No matching collections</div>
         {/if}
 

--- a/packages/web/src/components/CollectionPicker.svelte
+++ b/packages/web/src/components/CollectionPicker.svelte
@@ -231,7 +231,11 @@
           }}
         />
         {#if $sortedGroups.length > 0}
-          <select class="create-select" bind:value={createGroupId}>
+          <select
+            class="create-select"
+            aria-label="Group"
+            bind:value={createGroupId}
+          >
             {#each $sortedGroups as g (g.id)}
               <option value={g.id}>{g.name}</option>
             {/each}
@@ -582,18 +586,6 @@
     flex-shrink: 0;
   }
 
-  @media (prefers-color-scheme: light) {
-    :global(:root:not([data-theme='dark'])) .reason,
-    :global(:root:not([data-theme='dark'])) .group-label.suggested {
-      color: #b45309;
-    }
-  }
-
-  :global(:root[data-theme='light']) .reason,
-  :global(:root[data-theme='light']) .group-label.suggested {
-    color: #b45309;
-  }
-
   .group-label {
     display: flex;
     align-items: center;
@@ -608,6 +600,18 @@
 
   .group-label.suggested {
     color: #f59e0b;
+  }
+
+  @media (prefers-color-scheme: light) {
+    :global(:root:not([data-theme='dark'])) .reason,
+    :global(:root:not([data-theme='dark'])) .group-label.suggested {
+      color: #b45309;
+    }
+  }
+
+  :global(:root[data-theme='light']) .reason,
+  :global(:root[data-theme='light']) .group-label.suggested {
+    color: #b45309;
   }
 
   .rule {

--- a/packages/web/src/components/CollectionPicker.svelte
+++ b/packages/web/src/components/CollectionPicker.svelte
@@ -1,0 +1,686 @@
+<script lang="ts">
+  import type { Collection, InboxItem } from '@inbox-rs/rs-module';
+  import { get } from 'svelte/store';
+  import {
+    appConfig,
+    createCollection,
+    groupCollections,
+    groups,
+    items,
+    sortedGroups,
+    updateConfig,
+  } from '../lib/stores';
+  import {
+    getRecentCollectionIds,
+    suggestCollections,
+    type SuggestionReason,
+  } from '../lib/collection-suggest';
+  import { autofocusIf } from '../lib/actions';
+  import { randomPresetColor } from '../lib/constants';
+
+  let {
+    item,
+    mode = 'move',
+    onpick,
+    onclose,
+  }: {
+    item: InboxItem;
+    /**
+     * 'move' — re-file the card; shows Inbox/Unfile when it's already filed.
+     * 'todo' — choosing where a converted todo lands; always offers Unfiled.
+     */
+    mode?: 'move' | 'todo';
+    /** `undefined` collectionId = Inbox / Unfiled. */
+    onpick: (collectionId: string | undefined) => void;
+    onclose: () => void;
+  } = $props();
+
+  let query = $state('');
+  let showCreate = $state(false);
+  let createName = $state('');
+  let creating = $state(false);
+  let createError = $state('');
+
+  // Autofocusing the search field pops the keyboard over half the sheet on
+  // touch devices — desktop-only.
+  const isCoarse =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(pointer: coarse)').matches;
+
+  const isTodoish = $derived(item.isTodo || item.type === 'todo');
+  const title = $derived(
+    mode === 'todo'
+      ? 'File todo'
+      : item.collectionId
+        ? 'Move to collection'
+        : 'File into collection',
+  );
+  const unfiledLabel = $derived(
+    mode === 'todo' || isTodoish ? 'Unfiled' : 'Inbox',
+  );
+  const showUnfiled = $derived(mode === 'todo' || !!item.collectionId);
+
+  const allCollections = $derived(
+    $sortedGroups.flatMap((g) => $groupCollections[g.id] ?? []),
+  );
+
+  // Suggestions only lead when the user isn't already narrowing by hand.
+  const suggestions = $derived(
+    query.trim()
+      ? []
+      : suggestCollections(item, allCollections, $items, getRecentCollectionIds()),
+  );
+
+  const REASON_LABEL: Record<SuggestionReason, string> = {
+    site: 'matches site',
+    name: 'matches name',
+    recent: 'recent',
+  };
+
+  /** Groups with their collections, filtered by the query, current home excluded. */
+  const filteredGroups = $derived.by(() => {
+    const q = query.trim().toLowerCase();
+    return $sortedGroups
+      .map((group) => ({
+        group,
+        cols: ($groupCollections[group.id] ?? []).filter(
+          (col) =>
+            col.id !== item.collectionId &&
+            (!q ||
+              col.name.toLowerCase().includes(q) ||
+              group.name.toLowerCase().includes(q)),
+        ),
+      }))
+      .filter(({ cols }) => cols.length > 0);
+  });
+
+  const hasAnyCollections = $derived(allCollections.length > 0);
+  const queryHasExactMatch = $derived(
+    allCollections.some(
+      (c) => c.name.toLowerCase() === query.trim().toLowerCase(),
+    ),
+  );
+
+  function pickInitialGroupId(): string {
+    const allGroups = get(groups);
+    const last = get(appConfig).lastSelectedGroupId;
+    if (last && allGroups[last]) return last;
+    return get(sortedGroups)[0]?.id ?? '';
+  }
+
+  let createGroupId = $state<string>(pickInitialGroupId());
+
+  function openCreate() {
+    createName = query.trim();
+    createGroupId = pickInitialGroupId();
+    createError = '';
+    showCreate = true;
+  }
+
+  async function handleCreate() {
+    const name = createName.trim();
+    if (!name || !createGroupId || creating) return;
+    creating = true;
+    createError = '';
+    try {
+      const col: Collection = {
+        id: crypto.randomUUID(),
+        name,
+        itemIds: [],
+        createdAt: new Date().toISOString(),
+        color: randomPresetColor(),
+        groupId: createGroupId,
+      };
+      await createCollection(col);
+      // Remember the group like CollectionFormModal does — best-effort.
+      try {
+        await updateConfig({ lastSelectedGroupId: createGroupId });
+      } catch (e) {
+        console.error('Failed to persist lastSelectedGroupId', e);
+      }
+      onpick(col.id);
+    } catch (e) {
+      console.error('Failed to create collection', e);
+      createError =
+        e instanceof Error ? e.message : 'Failed to create collection';
+      creating = false;
+    }
+  }
+
+  function handleSearchKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Enter') return;
+    const first = filteredGroups[0]?.cols[0];
+    if (query.trim() && first) {
+      onpick(first.id);
+    } else if (query.trim() && !queryHasExactMatch) {
+      openCreate();
+    }
+  }
+
+  function handleWindowKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Escape') return;
+    // Peel one layer: the inline create form first, then the picker.
+    if (showCreate) {
+      showCreate = false;
+      return;
+    }
+    onclose();
+  }
+</script>
+
+<svelte:window onkeydown={handleWindowKeydown} />
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onclick={onclose}>
+  <div
+    class="panel"
+    role="dialog"
+    aria-modal="true"
+    aria-label={title}
+    onclick={(e) => e.stopPropagation()}
+  >
+    <div class="sheet-handle" aria-hidden="true"></div>
+    <div class="head">
+      <span class="picker-title">{title}</span>
+      <button type="button" class="btn-close" aria-label="Close" onclick={onclose}>
+        <svg
+          aria-hidden="true"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <line x1="18" y1="6" x2="6" y2="18"></line>
+          <line x1="6" y1="6" x2="18" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+
+    {#if showCreate}
+      <div class="create-form">
+        <label class="create-label" for="picker-new-name">New collection</label>
+        <input
+          id="picker-new-name"
+          use:autofocusIf={!isCoarse}
+          type="text"
+          class="create-input"
+          bind:value={createName}
+          placeholder="Collection name"
+          onkeydown={(e) => {
+            if (e.key === 'Enter') handleCreate();
+          }}
+        />
+        {#if $sortedGroups.length > 0}
+          <select class="create-select" bind:value={createGroupId}>
+            {#each $sortedGroups as g (g.id)}
+              <option value={g.id}>{g.name}</option>
+            {/each}
+          </select>
+        {:else}
+          <p class="empty">No groups yet — create one in the filter bar first.</p>
+        {/if}
+        {#if createError}
+          <p class="error" role="status" aria-live="polite">{createError}</p>
+        {/if}
+        <div class="create-actions">
+          <button
+            type="button"
+            class="btn-cancel"
+            onclick={() => (showCreate = false)}>Back</button
+          >
+          <button
+            type="button"
+            class="btn-create"
+            disabled={!createName.trim() || !createGroupId || creating}
+            onclick={handleCreate}
+          >
+            {creating ? 'Creating…' : 'Create & file'}
+          </button>
+        </div>
+      </div>
+    {:else}
+      <div class="search-wrap">
+        <svg
+          aria-hidden="true"
+          class="search-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="11" cy="11" r="8"></circle>
+          <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+        </svg>
+        <input
+          use:autofocusIf={!isCoarse}
+          type="text"
+          class="search"
+          bind:value={query}
+          placeholder={hasAnyCollections
+            ? 'Search or create a collection…'
+            : 'Name your first collection…'}
+          onkeydown={handleSearchKeydown}
+        />
+      </div>
+
+      <div class="list">
+        {#if showUnfiled && !query.trim()}
+          <button
+            type="button"
+            class="option"
+            onclick={() => onpick(undefined)}
+          >
+            <span class="dot" style="background: #9ca3af"></span>
+            {unfiledLabel}
+          </button>
+          <div class="rule"></div>
+        {/if}
+
+        {#if suggestions.length > 0}
+          <div class="group-label suggested">
+            <svg
+              aria-hidden="true"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M12 3l1.6 4.8L18 9l-4.4 1.2L12 15l-1.6-4.8L6 9l4.4-1.2z"
+              ></path>
+            </svg>
+            Suggested
+          </div>
+          {#each suggestions as sugg (sugg.collection.id)}
+            <button
+              type="button"
+              class="option"
+              onclick={() => onpick(sugg.collection.id)}
+            >
+              <span
+                class="dot"
+                style="background: {sugg.collection.color || '#6366f1'}"
+              ></span>
+              <span class="col-name">{sugg.collection.name}</span>
+              <span class="reason">{REASON_LABEL[sugg.reason]}</span>
+            </button>
+          {/each}
+          {#if filteredGroups.length > 0}
+            <div class="group-label">All collections</div>
+          {/if}
+        {/if}
+
+        {#each filteredGroups as { group, cols } (group.id)}
+          <div class="group-label" style="color: {group.color || 'var(--text-muted)'}">
+            {group.name}
+          </div>
+          {#each cols as col (col.id)}
+            <button type="button" class="option" onclick={() => onpick(col.id)}>
+              <span class="dot" style="background: {col.color || '#6366f1'}"></span>
+              <span class="col-name">{col.name}</span>
+              <span class="count">{col.itemIds.length}</span>
+            </button>
+          {/each}
+        {/each}
+
+        {#if hasAnyCollections && query.trim() && filteredGroups.length === 0}
+          <div class="empty">No matching collections</div>
+        {/if}
+
+        <div class="rule"></div>
+        <button type="button" class="option create-option" onclick={openCreate}>
+          <svg
+            aria-hidden="true"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <line x1="12" y1="5" x2="12" y2="19"></line>
+            <line x1="5" y1="12" x2="19" y2="12"></line>
+          </svg>
+          {#if query.trim() && !queryHasExactMatch}
+            Create “{query.trim()}”
+          {:else}
+            New collection…
+          {/if}
+        </button>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 300;
+    background: var(--overlay);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 4rem 1rem 1rem;
+    overscroll-behavior: contain;
+  }
+
+  .panel {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: 0 12px 36px var(--shadow);
+    width: 100%;
+    max-width: 400px;
+    max-height: min(28rem, calc(100vh - 6rem));
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .sheet-handle {
+    display: none;
+  }
+
+  /* Bottom sheet on touch-sized screens and installed PWA. */
+  @media (max-width: 600px), (display-mode: standalone) {
+    .overlay {
+      align-items: flex-end;
+      padding: 0;
+    }
+
+    .panel {
+      max-width: none;
+      max-height: 78dvh;
+      border-left: none;
+      border-right: none;
+      border-bottom: none;
+      border-radius: 18px 18px 0 0;
+      padding-bottom: env(safe-area-inset-bottom);
+    }
+
+    .sheet-handle {
+      display: block;
+      width: 40px;
+      height: 5px;
+      border-radius: 3px;
+      background: var(--border);
+      margin: 0.5rem auto 0;
+      flex-shrink: 0;
+    }
+  }
+
+  .head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem 0.35rem;
+  }
+
+  .picker-title {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .btn-close {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    width: 28px;
+    height: 28px;
+    border-radius: var(--radius-sm);
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+  }
+
+  .btn-close:hover {
+    background: var(--surface-hover);
+    color: var(--text);
+  }
+
+  .search-wrap {
+    position: relative;
+    padding: 0 1rem 0.6rem;
+    flex-shrink: 0;
+  }
+
+  .search-icon {
+    position: absolute;
+    left: 1.65rem;
+    top: 50%;
+    transform: translateY(calc(-50% - 0.3rem));
+    color: var(--text-muted);
+    pointer-events: none;
+  }
+
+  .search {
+    width: 100%;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    padding: 0.5rem 0.65rem 0.5rem 2.1rem;
+    /* >=1rem avoids the iOS Safari focus-zoom on touch devices. */
+    font-size: 1rem;
+    font-family: inherit;
+  }
+
+  .search:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+
+  .list {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 0 0.5rem 0.6rem;
+  }
+
+  .option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.5rem 0.55rem;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-size: 0.85rem;
+    font-family: inherit;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    text-align: left;
+  }
+
+  @media (pointer: coarse) {
+    .option {
+      padding-top: 0.65rem;
+      padding-bottom: 0.65rem;
+    }
+  }
+
+  .option:hover {
+    background: var(--accent-subtler);
+  }
+
+  .dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .col-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .count {
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Amber "why" tag. Dark is the app default; light overrides mirror the
+     token pattern in global.css (media query + explicit data-theme). */
+  .reason {
+    font-size: 0.62rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    color: #f59e0b;
+    background: color-mix(in srgb, #f59e0b 16%, transparent);
+    padding: 0.12rem 0.4rem;
+    border-radius: 4px;
+    flex-shrink: 0;
+  }
+
+  @media (prefers-color-scheme: light) {
+    :global(:root:not([data-theme='dark'])) .reason,
+    :global(:root:not([data-theme='dark'])) .group-label.suggested {
+      color: #b45309;
+    }
+  }
+
+  :global(:root[data-theme='light']) .reason,
+  :global(:root[data-theme='light']) .group-label.suggested {
+    color: #b45309;
+  }
+
+  .group-label {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.55rem 0.55rem 0.25rem;
+    font-size: 0.62rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+  }
+
+  .group-label.suggested {
+    color: #f59e0b;
+  }
+
+  .rule {
+    height: 1px;
+    background: var(--border);
+    margin: 0.3rem 0.3rem;
+  }
+
+  .create-option {
+    color: var(--accent);
+    font-weight: 500;
+  }
+
+  .empty {
+    padding: 0.6rem 0.55rem;
+    font-size: 0.82rem;
+    color: var(--text-muted);
+  }
+
+  .error {
+    padding: 0.2rem 0.55rem 0.4rem;
+    font-size: 0.8rem;
+    color: var(--danger);
+  }
+
+  /* Inline create form */
+  .create-form {
+    padding: 0.35rem 1rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  .create-label {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .create-input,
+  .create-select {
+    width: 100%;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    padding: 0.5rem 0.65rem;
+    font-size: 1rem;
+    font-family: inherit;
+  }
+
+  .create-input:focus,
+  .create-select:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+
+  .create-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 0.2rem;
+  }
+
+  .btn-cancel {
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    padding: 0.45rem 0.9rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.85rem;
+    font-family: inherit;
+    cursor: pointer;
+  }
+
+  .btn-cancel:hover {
+    border-color: var(--text-muted);
+  }
+
+  .btn-create {
+    background: var(--accent);
+    border: none;
+    color: white;
+    padding: 0.45rem 1rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.85rem;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+  }
+
+  .btn-create:hover {
+    opacity: 0.9;
+  }
+
+  .btn-create:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+</style>

--- a/packages/web/src/components/CollectionPicker.svelte
+++ b/packages/web/src/components/CollectionPicker.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Collection, InboxItem } from '@inbox-rs/rs-module';
+  import type { Collection } from '@inbox-rs/rs-module';
   import { get } from 'svelte/store';
   import {
     appConfig,
@@ -13,6 +13,7 @@
   import {
     getRecentCollectionIds,
     suggestCollections,
+    type FilingSubject,
     type SuggestionReason,
   } from '../lib/collection-suggest';
   import { autofocusIf } from '../lib/actions';
@@ -24,7 +25,8 @@
     onpick,
     onclose,
   }: {
-    item: InboxItem;
+    /** Any InboxItem, or a lightweight subject for not-yet-saved items. */
+    item: FilingSubject;
     /**
      * 'move' — re-file the card; shows Inbox/Unfile when it's already filed.
      * 'todo' — choosing where a converted todo lands; always offers Unfiled.

--- a/packages/web/src/components/TodoQuickAdd.svelte
+++ b/packages/web/src/components/TodoQuickAdd.svelte
@@ -15,10 +15,11 @@
   import { autofocusIf } from '../lib/actions';
   import { modLabel } from '../lib/platform';
   import { showToast } from '../lib/toast';
+  import type { FilingSubject } from '../lib/collection-suggest';
+  import CollectionPicker from './CollectionPicker.svelte';
   import {
     activeGroupIds,
     collections,
-    groupCollections,
     moveItemToCollection,
     sortedGroups,
     storeItem,
@@ -62,11 +63,6 @@
     for (const g of $sortedGroups) out[g.id] = g;
     return out;
   });
-  const ungroupedCollections = $derived(
-    Object.values(collectionMap).filter(
-      (c) => !c.groupId || !groupMap()[c.groupId],
-    ),
-  );
 
   // Per-device quick-add destination (hidden when a fixed collection is given).
   // localStorage rather than synced config so a stale remote copy can't clobber
@@ -122,6 +118,32 @@
   }
 
   const targetCollectionId = $derived(fixedCollectionId ?? quickAddCollectionId);
+
+  // ── Destination picker (shared CollectionPicker, chip trigger) ─────────
+  let pickerOpen = $state(false);
+
+  /** Chip display parts for the current quick-add destination. */
+  const chip = $derived.by(() => {
+    const col = quickAddCollectionId
+      ? collectionMap[quickAddCollectionId]
+      : undefined;
+    if (!col) return { name: 'Unfiled', color: '#9ca3af' };
+    return { name: col.name, color: col.color || '#6366f1' };
+  });
+
+  /** What the picker files: the composed title feeds name-match suggestions. */
+  const pickerSubject = $derived<FilingSubject>({
+    title: quickTitle,
+    collectionId: quickAddCollectionId,
+    isTodo: true,
+  });
+
+  function handlePick(id: string | undefined) {
+    setQuickAddCollection(id);
+    pickerOpen = false;
+    // Hand focus back to the title so capture flow isn't interrupted.
+    quickInputEl?.focus();
+  }
 
   // Where plain Enter will file the todo, shown in the hint while composing so
   // the destination is predictable before submitting. Flags an out-of-view
@@ -236,36 +258,36 @@
     }}
   />
   {#if !fixedCollectionId}
-    <!-- Empty-string sentinel maps to undefined (Unfiled) on save. -->
-    <select
+    <button
+      type="button"
       class="quick-add__collection"
       aria-label="File into collection"
-      value={quickAddCollectionId ?? ''}
+      aria-haspopup="dialog"
+      aria-expanded={pickerOpen}
       disabled={quickSaving}
-      onchange={(e) => {
-        const v = (e.currentTarget as HTMLSelectElement).value;
-        setQuickAddCollection(v === '' ? undefined : v);
-      }}
+      onclick={() => (pickerOpen = true)}
     >
-      <option value="">Unfiled</option>
-      {#each $sortedGroups as group (group.id)}
-        {@const cols = $groupCollections[group.id] ?? []}
-        {#if cols.length > 0}
-          <optgroup label={group.name}>
-            {#each cols as col (col.id)}
-              <option value={col.id}>{col.name}</option>
-            {/each}
-          </optgroup>
-        {/if}
-      {/each}
-      {#if ungroupedCollections.length > 0}
-        <optgroup label="Other">
-          {#each ungroupedCollections as col (col.id)}
-            <option value={col.id}>{col.name}</option>
-          {/each}
-        </optgroup>
-      {/if}
-    </select>
+      <span
+        class="chip-dot"
+        style="background: {chip.color}"
+        aria-hidden="true"
+      ></span>
+      <span class="chip-name">{chip.name}</span>
+      <svg
+        aria-hidden="true"
+        class="chip-chevron"
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <polyline points="6 9 12 15 18 9"></polyline>
+      </svg>
+    </button>
   {/if}
   <button type="submit" disabled={!canCaptureTodo(quickTitle) || quickSaving}>
     {quickSaving ? 'Adding...' : 'Add'}
@@ -280,6 +302,15 @@
     <span>{mod}↵ Open editor</span>
   {/if}
 </div>
+
+{#if pickerOpen}
+  <CollectionPicker
+    item={pickerSubject}
+    mode="todo"
+    onpick={handlePick}
+    onclose={() => (pickerOpen = false)}
+  />
+{/if}
 
 <style>
   .quick-add {
@@ -359,28 +390,62 @@
     cursor: not-allowed;
   }
 
-  /* Capped width so long names truncate via the native control instead of
-     pushing the Add button off-screen. */
-  .quick-add__collection {
+  /* Chip-style trigger for the shared CollectionPicker — same box as the
+     old native select, but speaks the app's location language (colored dot
+     + name). Capped width so long names truncate instead of pushing the
+     Add button off-screen. Selector carries the `button` element so it
+     out-specifies the `.quick-add button` submit styling above (accent
+     fill, hover lift) that would otherwise swallow the chip. */
+  .quick-add button.quick-add__collection {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
     min-height: 2.75rem;
     max-width: 12rem;
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     background: var(--surface);
     color: var(--text);
-    padding: 0 0.6rem;
+    padding: 0 0.7rem;
     font: inherit;
+    font-weight: 400;
     cursor: pointer;
     box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
     transition: border-color 150ms, box-shadow 150ms;
   }
 
-  .quick-add__collection:focus-visible {
+  .quick-add button.quick-add__collection:hover:not(:disabled) {
+    border-color: var(--accent);
+    transform: none;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  }
+
+  .quick-add button.quick-add__collection:focus-visible {
     outline: none;
     border-color: var(--accent);
   }
 
-  .quick-add--compact .quick-add__collection {
+  .chip-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .chip-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .chip-chevron {
+    flex-shrink: 0;
+    opacity: 0.6;
+    color: var(--text-muted);
+  }
+
+  .quick-add--compact button.quick-add__collection {
     min-height: 2.25rem;
     /* Keep >=1rem (inherited) so iOS Safari doesn't auto-zoom on focus — the
        guideline forbids sub-1rem font-size on form controls. */

--- a/packages/web/src/components/TodoQuickAdd.svelte.test.ts
+++ b/packages/web/src/components/TodoQuickAdd.svelte.test.ts
@@ -12,6 +12,8 @@ const { storeItem, moveItemToCollection, toggleGroupFilter, showToast } =
 
 // Mock the data layer. The stores the component subscribes to are real
 // writables so `$`-auto-subscription works; the CRUD/toggle calls are spies.
+// The extra stores/functions beyond TodoQuickAdd's own imports are consumed
+// by the CollectionPicker it renders.
 vi.mock('../lib/stores', async () => {
   const { writable } = await import('svelte/store');
   return {
@@ -22,6 +24,12 @@ vi.mock('../lib/stores', async () => {
     groupCollections: writable({}),
     sortedGroups: writable([]),
     activeGroupIds: writable(new Set<string>()),
+    groups: writable({}),
+    items: writable({}),
+    appConfig: writable({}),
+    orphanCollections: writable([]),
+    createCollection: vi.fn().mockResolvedValue(undefined),
+    updateConfig: vi.fn().mockResolvedValue(undefined),
   };
 });
 vi.mock('../lib/toast', () => ({ showToast }));
@@ -88,11 +96,23 @@ describe('TodoQuickAdd', () => {
     flushSync();
   }
 
-  // Drive the native select the way a user picking a destination would.
-  function pickCollection(value: string) {
-    const sel = collectionSelect();
-    sel.value = value;
-    sel.dispatchEvent(new Event('change', { bubbles: true }));
+  // Drive the chip trigger + shared CollectionPicker the way a user picking
+  // a destination would: open the picker, click the named option.
+  function pickCollection(name: string) {
+    chipTrigger().click();
+    flushSync();
+    const options = [
+      ...host.querySelectorAll<HTMLButtonElement>('.panel .option'),
+    ];
+    const target = options.find((o) => o.textContent?.includes(name));
+    if (!target) {
+      throw new Error(
+        `picker option "${name}" not found among: ${options
+          .map((o) => o.textContent?.trim())
+          .join(', ')}`,
+      );
+    }
+    target.click();
     flushSync();
   }
 
@@ -221,14 +241,16 @@ describe('TodoQuickAdd', () => {
     );
   }
 
-  const collectionSelect = () =>
-    host.querySelector('.quick-add__collection') as HTMLSelectElement;
+  const chipTrigger = () =>
+    host.querySelector('.quick-add__collection') as HTMLButtonElement;
+  const chipText = () =>
+    host.querySelector('.chip-name')?.textContent?.trim() ?? '';
 
   it('ignores a persisted default whose group is filtered out of view', async () => {
     seedHiddenGroupDefault({ visible: false });
     render();
     // The default resolves to Unfiled so the just-added todo stays visible.
-    expect(collectionSelect().value).toBe('');
+    expect(chipText()).toBe('Unfiled');
     type('buy milk');
     submit();
     await vi.waitFor(() => {
@@ -241,7 +263,7 @@ describe('TodoQuickAdd', () => {
   it('honors a persisted default whose group is currently visible', async () => {
     seedHiddenGroupDefault({ visible: true });
     render();
-    expect(collectionSelect().value).toBe('col-h');
+    expect(chipText()).toBe('Hidden Col');
     type('buy milk');
     submit();
     await vi.waitFor(() => {
@@ -296,7 +318,7 @@ describe('TodoQuickAdd', () => {
     seedHiddenGroupDefault({ visible: false });
     render();
     // The default is guarded to Unfiled, so explicitly pick the hidden one.
-    pickCollection('col-h');
+    pickCollection('Hidden Col');
     focus();
     type('buy milk');
     expect(hintText()).toContain('Add to Hidden › Hidden Col (hidden)');
@@ -307,16 +329,16 @@ describe('TodoQuickAdd', () => {
   it('honors an explicit pick into a hidden group instead of bouncing to Unfiled', () => {
     seedHiddenGroupDefault({ visible: false });
     render();
-    expect(collectionSelect().value).toBe('');
-    pickCollection('col-h');
+    expect(chipText()).toBe('Unfiled');
+    pickCollection('Hidden Col');
     // The explicit choice sticks — it does NOT revert to Unfiled.
-    expect(collectionSelect().value).toBe('col-h');
+    expect(chipText()).toBe('Hidden Col');
   });
 
   it('files into the hidden group and shows a Show toast that reveals it', async () => {
     seedHiddenGroupDefault({ visible: false });
     render();
-    pickCollection('col-h');
+    pickCollection('Hidden Col');
     type('buy milk');
     submit();
     await vi.waitFor(() => {
@@ -341,7 +363,7 @@ describe('TodoQuickAdd', () => {
     toggleGroupFilter.mockRejectedValueOnce(new Error('config write failed'));
     seedHiddenGroupDefault({ visible: false });
     render();
-    pickCollection('col-h');
+    pickCollection('Hidden Col');
     type('buy milk');
     submit();
     await vi.waitFor(() => {

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -162,15 +162,18 @@
       return;
     }
     showPicker = false;
+    // Close only once the move settles — a failure leaves the card open (with
+    // a toast) so the user can retry, matching the todo-conversion branches.
+    // The write is a local-first IndexedDB store, so the await is cheap.
     moveItemToCollection(item.id, collectionId)
       .then(() => {
         if (collectionId) recordCollectionUse(collectionId);
+        onclose();
       })
       .catch((e) => {
         console.error('Move failed:', e);
         showToast('Move failed');
       });
-    onclose();
   }
 
   function formatDate(iso: string): string {

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
   import type { InboxItem } from '@inbox-rs/rs-module';
   import {
+    collections,
     deleteItem,
-    storeItem,
-    sortedGroups,
-    groupCollections,
+    groups,
     moveItemToCollection,
+    storeItem,
   } from '../lib/stores';
+  import { recordCollectionUse } from '../lib/collection-suggest';
+  import { showToast } from '../lib/toast';
   import ShareButton from './ShareButton.svelte';
+  import CollectionPicker from './CollectionPicker.svelte';
   import DeleteConfirm from './DeleteConfirm.svelte';
   import BookmarkView from './view-card/BookmarkView.svelte';
   import NoteView from './view-card/NoteView.svelte';
@@ -32,27 +34,14 @@
 
   let showDelete = $state(false);
   let deleting = $state(false);
-  let showMoveMenu = $state(false);
-  let moveButtonEl = $state<HTMLButtonElement | null>(null);
-  let dropdownStyle = $state('');
 
-  // "Make Todo" can file into a collection when one exists. Without a
-  // collection choice, converted todos stay unfiled and appear on the Todos
-  // page without creating any organization.
-  let showMakeTodoMenu = $state(false);
-  let makeTodoButtonEl = $state<HTMLButtonElement | null>(null);
-  let makeTodoDropdownStyle = $state('');
+  // One CollectionPicker serves both flows: re-filing the card ('move') and
+  // choosing where a converted todo lands ('todo').
+  let showPicker = $state(false);
+  let pickerMode = $state<'move' | 'todo'>('move');
 
   let convertingTodo = $state(false);
-  // Surface conversion failures inline. Both Make-Todo paths share this so
-  // either flow can announce its error in the same dropdown.
-  let convertError = $state('');
   let convertingRef = $state(false);
-
-  onDestroy(() => {
-    removeMoveMenuListeners();
-    removeMakeTodoMenuListeners();
-  });
 
   async function handleDelete() {
     deleting = true;
@@ -65,7 +54,6 @@
   /** Promote the current item to an unfiled todo. */
   async function convertToUnfiledTodo() {
     convertingTodo = true;
-    convertError = '';
     try {
       const { completedAt: _, ...rest } = item;
       await moveItemToCollection(item.id, undefined);
@@ -79,12 +67,11 @@
       };
       delete updated.collectionId;
       await storeItem(updated as unknown as InboxItem);
-      closeMakeTodoMenu();
+      showPicker = false;
       onclose();
     } catch (error) {
       console.error('Failed to convert to unfiled todo', error);
-      convertError =
-        error instanceof Error ? error.message : 'Failed to convert to todo';
+      showToast('Failed to convert to todo');
     } finally {
       convertingTodo = false;
     }
@@ -93,7 +80,6 @@
   /** Promote the current item to a todo and file it into the chosen collection. */
   async function convertToTodoInCollection(collectionId: string) {
     convertingTodo = true;
-    convertError = '';
     try {
       // Snapshot the rest of the item BEFORE we do any writes — once we move
       // the item, the store reflects the new collectionId and the prop might
@@ -117,12 +103,12 @@
         collectionId,
       };
       await storeItem(updated as InboxItem);
-      closeMakeTodoMenu();
+      recordCollectionUse(collectionId);
+      showPicker = false;
       onclose();
     } catch (error) {
       console.error('Failed to convert to todo', error);
-      convertError =
-        error instanceof Error ? error.message : 'Failed to convert to todo';
+      showToast('Failed to convert to todo');
     } finally {
       convertingTodo = false;
     }
@@ -153,143 +139,38 @@
   const canMakeTodo = $derived(item.type !== 'todo' && !item.isTodo);
   const canMakeRef = $derived(item.isTodo || item.type === 'todo');
 
-  function toggleMoveMenu() {
-    // Only one picker can be open at a time — close Make Todo if it's open
-    // so the overlays don't stack.
-    if (showMakeTodoMenu) closeMakeTodoMenu();
-    showMoveMenu = !showMoveMenu;
-    if (showMoveMenu) {
-      updateDropdownPosition();
-      window.addEventListener('scroll', handleMoveMenuScroll, true);
-      window.addEventListener('resize', closeMoveMenu);
-      window.addEventListener('keydown', handleMoveMenuKeydown);
-    } else {
-      removeMoveMenuListeners();
-    }
+  function openMovePicker() {
+    pickerMode = 'move';
+    showPicker = true;
   }
 
-  function handleMoveMenuScroll(event: Event) {
-    const target = event.target;
-    if (target instanceof Element && target.closest('.move-dropdown')) return;
-    closeMoveMenu();
+  function openMakeTodoPicker() {
+    pickerMode = 'todo';
+    showPicker = true;
   }
 
-  function handleMoveMenuKeydown(event: KeyboardEvent) {
-    if (event.key === 'Escape') closeMoveMenu();
-  }
-
-  function closeMoveMenu() {
-    showMoveMenu = false;
-    removeMoveMenuListeners();
-  }
-
-  function removeMoveMenuListeners() {
-    window.removeEventListener('scroll', handleMoveMenuScroll, true);
-    window.removeEventListener('resize', closeMoveMenu);
-    window.removeEventListener('keydown', handleMoveMenuKeydown);
-  }
-
-  // ── Make Todo menu ─────────────────────────────────────────────────────
-  // Mirrors the Move menu pattern so the two dropdowns feel identical.
-  // Kept as a parallel menu (rather than collapsed into a single generic
-  // picker) to keep the option list semantics crystal clear.
-
-  function toggleMakeTodoMenu() {
-    if (showMoveMenu) closeMoveMenu();
-    showMakeTodoMenu = !showMakeTodoMenu;
-    if (showMakeTodoMenu) {
-      updateMakeTodoDropdownPosition();
-      window.addEventListener('scroll', handleMakeTodoMenuScroll, true);
-      window.addEventListener('resize', closeMakeTodoMenu);
-      window.addEventListener('keydown', handleMakeTodoMenuKeydown);
-    } else {
-      removeMakeTodoMenuListeners();
-    }
-  }
-
-  function handleMakeTodoMenuScroll(event: Event) {
-    const target = event.target;
-    if (target instanceof Element && target.closest('.make-todo-dropdown'))
+  /** Route the picker's choice to the flow that opened it. */
+  function handlePick(collectionId: string | undefined) {
+    if (pickerMode === 'todo') {
+      // Conversion closes the picker + modal itself on success so a failure
+      // can leave both open for a retry.
+      if (collectionId) {
+        void convertToTodoInCollection(collectionId);
+      } else {
+        void convertToUnfiledTodo();
+      }
       return;
-    closeMakeTodoMenu();
-  }
-
-  function handleMakeTodoMenuKeydown(event: KeyboardEvent) {
-    if (event.key === 'Escape') closeMakeTodoMenu();
-  }
-
-  function closeMakeTodoMenu() {
-    showMakeTodoMenu = false;
-    removeMakeTodoMenuListeners();
-  }
-
-  function removeMakeTodoMenuListeners() {
-    window.removeEventListener('scroll', handleMakeTodoMenuScroll, true);
-    window.removeEventListener('resize', closeMakeTodoMenu);
-    window.removeEventListener('keydown', handleMakeTodoMenuKeydown);
-  }
-
-  function updateMakeTodoDropdownPosition() {
-    if (!makeTodoButtonEl) return;
-    const rect = makeTodoButtonEl.getBoundingClientRect();
-    const spaceAbove = rect.top;
-    const spaceBelow = window.innerHeight - rect.bottom;
-    const dropdownMaxHeight = 280;
-    const viewportPadding = 16;
-    const gap = 6;
-
-    const openUpward = spaceAbove > spaceBelow;
-    const available = openUpward ? spaceAbove : spaceBelow;
-    const maxHeight = Math.max(
-      0,
-      Math.min(available - viewportPadding, dropdownMaxHeight),
-    );
-
-    const dropdownWidth = Math.min(280, window.innerWidth - viewportPadding * 2);
-    // Anchor to the right edge of the button so the picker doesn't drift off
-    // the right side of the modal on tight layouts — Make Todo lives on the
-    // right side of the header.
-    const right = window.innerWidth - rect.right;
-    const clampedRight = Math.max(
-      viewportPadding,
-      Math.min(right, window.innerWidth - dropdownWidth - viewportPadding),
-    );
-
-    if (openUpward) {
-      makeTodoDropdownStyle = `bottom: ${window.innerHeight - rect.top + gap}px; right: ${clampedRight}px; max-height: ${maxHeight}px;`;
-    } else {
-      makeTodoDropdownStyle = `top: ${rect.bottom + gap}px; right: ${clampedRight}px; max-height: ${maxHeight}px;`;
     }
-  }
-
-  function updateDropdownPosition() {
-    if (!moveButtonEl) return;
-    const rect = moveButtonEl.getBoundingClientRect();
-    const spaceAbove = rect.top;
-    const spaceBelow = window.innerHeight - rect.bottom;
-    const dropdownMaxHeight = 240;
-    const viewportPadding = 16;
-    const gap = 4;
-
-    const openUpward = spaceAbove > spaceBelow;
-    const available = openUpward ? spaceAbove : spaceBelow;
-    const maxHeight = Math.max(
-      0,
-      Math.min(available - viewportPadding, dropdownMaxHeight),
-    );
-
-    // Clamp horizontal position using max possible rendered width
-    const dropdownWidth = Math.min(280, window.innerWidth - viewportPadding * 2);
-    const left = Math.max(
-      viewportPadding,
-      Math.min(rect.left, window.innerWidth - dropdownWidth - viewportPadding),
-    );
-
-    if (openUpward) {
-      dropdownStyle = `bottom: ${window.innerHeight - rect.top + gap}px; left: ${left}px; max-height: ${maxHeight}px;`;
-    } else {
-      dropdownStyle = `top: ${rect.bottom + gap}px; left: ${left}px; max-height: ${maxHeight}px;`;
-    }
+    showPicker = false;
+    moveItemToCollection(item.id, collectionId)
+      .then(() => {
+        if (collectionId) recordCollectionUse(collectionId);
+      })
+      .catch((e) => {
+        console.error('Move failed:', e);
+        showToast('Move failed');
+      });
+    onclose();
   }
 
   function formatDate(iso: string): string {
@@ -312,6 +193,45 @@
     'filePath' in item && !!(item as unknown as Record<string, unknown>).filePath,
   );
 
+  // ── Meta strip ─────────────────────────────────────────────────────────
+
+  const isTodoish = $derived(item.isTodo || item.type === 'todo');
+
+  /** Current home resolved to display parts (name, dot color, parent group). */
+  const location = $derived.by(() => {
+    const col = item.collectionId ? $collections[item.collectionId] : undefined;
+    if (!col) {
+      return {
+        label: isTodoish ? 'Unfiled' : 'Inbox',
+        color: '#9ca3af',
+        group: undefined,
+      };
+    }
+    return {
+      label: col.name,
+      color: col.color || '#6366f1',
+      group: col.groupId ? $groups[col.groupId] : undefined,
+    };
+  });
+
+  const wordCount = $derived.by(() => {
+    if (!('body' in item)) return 0;
+    const body = (item as unknown as Record<string, unknown>).body;
+    if (typeof body !== 'string') return 0;
+    const trimmed = body.trim();
+    return trimmed ? trimmed.split(/\s+/).length : 0;
+  });
+
+  /** "Open · 3d" for pending todos, "Done" once completed. */
+  const todoStatus = $derived.by(() => {
+    if (!isTodoish) return '';
+    if (item.completed) return 'Done';
+    const days = Math.floor(
+      (Date.now() - new Date(item.createdAt).getTime()) / 86_400_000,
+    );
+    return days < 1 ? 'Open · today' : `Open · ${days}d`;
+  });
+
   /**
    * Window-level Escape handler. Defers to nested overlays when any are open
    * so Escape peels one layer at a time instead of collapsing the stack:
@@ -319,9 +239,8 @@
    *   - DeleteConfirm, Lightbox: they register their own window handlers and
    *     will close themselves. We only need to keep *this* modal open so the
    *     user isn't unexpectedly dumped back to the card list.
-   *   - Move / Make-Todo menus: they already close themselves via their own
-   *     document-level escape listeners — we still early-return so both don't
-   *     close simultaneously.
+   *   - CollectionPicker: it closes itself via its own window escape
+   *     listener — we early-return so both layers don't close at once.
    *
    * Since `<svelte:window>` listeners fire in registration order, this outer
    * listener is registered first (parent mounts before children) and runs
@@ -330,7 +249,7 @@
    */
   function handleWindowEscape(e: KeyboardEvent) {
     if (e.key !== 'Escape') return;
-    if (showDelete || showMoveMenu || showMakeTodoMenu) return;
+    if (showDelete || showPicker) return;
     onclose();
   }
 </script>
@@ -350,21 +269,18 @@
     <div class="modal-header">
       <span class="type-badge">{item.type}</span>
       <time class="date">{formatDate(item.createdAt)}</time>
-      {#if canMakeTodo}
+      <div class="header-actions">
         <button
           type="button"
-          class="btn-todo btn-todo-top"
-          class:open={showMakeTodoMenu}
-          bind:this={makeTodoButtonEl}
-          disabled={convertingTodo}
-          onclick={toggleMakeTodoMenu}
-          aria-haspopup="listbox"
-          aria-expanded={showMakeTodoMenu}
+          class="icon-btn icon-btn-danger"
+          title="Delete"
+          aria-label="Delete"
+          onclick={() => (showDelete = true)}
         >
           <svg
             aria-hidden="true"
-            width="14"
-            height="14"
+            width="16"
+            height="16"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -372,39 +288,23 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           >
-            <polyline points="9 11 12 14 22 4"></polyline>
-            <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"
+            <polyline points="3 6 5 6 21 6"></polyline>
+            <path
+              d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
             ></path>
           </svg>
-          Make Todo
-          <svg
-            aria-hidden="true"
-            class="caret"
-            class:open={showMakeTodoMenu}
-            width="10"
-            height="10"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <polyline points="6 9 12 15 18 9"></polyline>
-          </svg>
         </button>
-      {/if}
-      {#if canMakeRef}
         <button
           type="button"
-          class="btn-todo btn-todo-top"
-          disabled={convertingRef}
-          onclick={convertToReference}
+          class="icon-btn"
+          title="Close"
+          aria-label="Close"
+          onclick={onclose}
         >
           <svg
             aria-hidden="true"
-            width="14"
-            height="14"
+            width="17"
+            height="17"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -412,13 +312,11 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           >
-            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path>
-            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"
-            ></path>
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
           </svg>
-          Make Reference
         </button>
-      {/if}
+      </div>
     </div>
 
     <!--
@@ -475,37 +373,25 @@
       </div>
     {/if}
 
-    <div class="actions">
-      <button type="button" class="btn-delete" onclick={() => (showDelete = true)}>
-        <svg
-          aria-hidden="true"
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <polyline points="3 6 5 6 21 6"></polyline>
-          <path
-            d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
-          ></path>
-        </svg>
-        Delete
-      </button>
-      <div class="move-container">
-        <button
-          type="button"
-          class="btn-move"
-          bind:this={moveButtonEl}
-          onclick={toggleMoveMenu}
-        >
+    <div class="meta-strip">
+      <span class="meta-item">
+        <span class="loc-dot" style="background: {location.color}"></span>
+        {#if location.group}
+          <span
+            class="meta-group"
+            style="color: {location.group.color || 'var(--accent)'}"
+            >{location.group.name}</span
+          >
+          <span aria-hidden="true">·</span>
+        {/if}
+        {location.label}
+      </span>
+      {#if wordCount > 0}
+        <span class="meta-item">
           <svg
             aria-hidden="true"
-            width="14"
-            height="14"
+            width="13"
+            height="13"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -513,16 +399,120 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           >
-            <rect x="3" y="3" width="7" height="7"></rect>
-            <rect x="14" y="3" width="7" height="7"></rect>
-            <rect x="3" y="14" width="7" height="7"></rect>
-            <rect x="14" y="14" width="7" height="7"></rect>
+            <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path>
+            <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path>
           </svg>
-          {item.collectionId ? 'Move' : 'Collect'}
+          {wordCount}
+          {wordCount === 1 ? 'word' : 'words'}
+        </span>
+      {/if}
+      {#if todoStatus}
+        <span class="meta-item">
+          <svg
+            aria-hidden="true"
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="12" cy="12" r="10"></circle>
+            <polyline points="12 6 12 12 16 14"></polyline>
+          </svg>
+          {todoStatus}
+        </span>
+      {/if}
+    </div>
+
+    <button type="button" class="btn-file" onclick={openMovePicker}>
+      <svg
+        aria-hidden="true"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"
+        ></path>
+      </svg>
+      {item.collectionId ? 'Move to collection…' : 'File into collection…'}
+    </button>
+
+    <div class="action-list">
+      {#if canMakeTodo}
+        <button
+          type="button"
+          class="action-row"
+          disabled={convertingTodo}
+          onclick={openMakeTodoPicker}
+        >
+          <svg
+            aria-hidden="true"
+            width="15"
+            height="15"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="9 11 12 14 22 4"></polyline>
+            <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"
+            ></path>
+          </svg>
+          Make a todo
         </button>
-      </div>
-      <button type="button" class="btn-cancel" onclick={onclose}>Close</button>
-      <button type="button" class="btn-edit" onclick={() => onedit(item)}>Edit</button>
+      {/if}
+      {#if canMakeRef}
+        <button
+          type="button"
+          class="action-row"
+          disabled={convertingRef}
+          onclick={convertToReference}
+        >
+          <svg
+            aria-hidden="true"
+            width="15"
+            height="15"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path>
+            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"
+            ></path>
+          </svg>
+          Make a reference
+        </button>
+      {/if}
+      <button type="button" class="action-row" onclick={() => onedit(item)}>
+        <svg
+          aria-hidden="true"
+          width="15"
+          height="15"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M12 20h9"></path>
+          <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"></path>
+        </svg>
+        Edit
+      </button>
     </div>
 
     {#if showDelete}
@@ -533,117 +523,13 @@
       />
     {/if}
 
-    {#if showMakeTodoMenu}
-      <button
-        type="button"
-        class="move-backdrop"
-        tabindex="-1"
-        aria-label="Close make todo menu"
-        onclick={() => closeMakeTodoMenu()}
-      ></button>
-      <div
-        class="move-dropdown make-todo-dropdown"
-        style={makeTodoDropdownStyle}
-        role="listbox"
-        aria-label="Choose a collection for this todo"
-      >
-        <div class="picker-title">File todo</div>
-        {#if convertError}
-          <p class="move-error" role="status" aria-live="polite">
-            {convertError}
-          </p>
-        {/if}
-        <button
-          type="button"
-          class="move-option"
-          onclick={convertToUnfiledTodo}
-          disabled={convertingTodo}
-        >
-          <span class="move-dot" style="background: #9ca3af"></span>
-          Unfiled
-        </button>
-        {#if $sortedGroups.some((g) => ($groupCollections[g.id] ?? []).length > 0)}
-          <div class="move-divider"></div>
-        {/if}
-        {#each $sortedGroups as group (group.id)}
-          {#each $groupCollections[group.id] ?? [] as col (col.id)}
-            <button
-              type="button"
-              class="move-option"
-              onclick={() => convertToTodoInCollection(col.id)}
-              disabled={convertingTodo}
-            >
-              <span
-                class="move-dot"
-                style="background: {col.color || '#6366f1'}"
-              ></span>
-              <span
-                class="move-group-prefix"
-                style="color: {group.color || 'var(--accent)'}">{group.name}</span
-              > : {col.name}
-            </button>
-          {/each}
-        {/each}
-      </div>
-    {/if}
-
-    {#if showMoveMenu}
-      <button
-        type="button"
-        class="move-backdrop"
-        tabindex="-1"
-        aria-label="Close move menu"
-        onclick={() => closeMoveMenu()}
-      ></button>
-      <div class="move-dropdown" style={dropdownStyle}>
-        {#if item.collectionId}
-          <button
-            type="button"
-            class="move-option"
-            onclick={() => {
-              moveItemToCollection(item.id, undefined).catch((e) =>
-                console.error('Move failed:', e),
-              );
-              closeMoveMenu();
-              onclose();
-            }}
-          >
-            <span class="move-dot" style="background: #9ca3af"></span>
-            {item.isTodo || item.type === 'todo' ? 'Unfile' : 'Inbox'}
-          </button>
-          <div class="move-divider"></div>
-        {/if}
-        {#each $sortedGroups as group (group.id)}
-          {#each $groupCollections[group.id] ?? [] as col (col.id)}
-            {#if col.id !== item.collectionId}
-              <button
-                type="button"
-                class="move-option"
-                onclick={() => {
-                  moveItemToCollection(item.id, col.id).catch((e) =>
-                    console.error('Move failed:', e),
-                  );
-                  closeMoveMenu();
-                  onclose();
-                }}
-              >
-                <span
-                  class="move-dot"
-                  style="background: {col.color || '#6366f1'}"
-                ></span>
-                <span
-                  class="move-group-prefix"
-                  style="color: {group.color || 'var(--accent)'}"
-                  >{group.name}</span
-                > : {col.name}
-              </button>
-            {/if}
-          {/each}
-        {/each}
-        {#if $sortedGroups.every((g) => ($groupCollections[g.id] ?? []).every((col) => col.id === item.collectionId))}
-          <div class="move-empty">No collections</div>
-        {/if}
-      </div>
+    {#if showPicker}
+      <CollectionPicker
+        {item}
+        mode={pickerMode}
+        onpick={handlePick}
+        onclose={() => (showPicker = false)}
+      />
     {/if}
   </div>
 </div>
@@ -984,220 +870,128 @@
     border-top: 1px solid var(--border);
   }
 
-  .actions {
+  /* ── Header icons ─────────────────────── */
+
+  .header-actions {
+    margin-left: auto;
     display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
+    gap: 0.25rem;
+  }
+
+  .icon-btn {
+    width: 32px;
+    height: 32px;
+    border-radius: var(--radius-sm);
+    display: grid;
+    place-items: center;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+  }
+
+  .icon-btn:hover {
+    background: var(--surface-hover);
+    color: var(--text);
+  }
+
+  .icon-btn-danger:hover {
+    color: var(--danger);
+    background: color-mix(in srgb, var(--danger) 10%, transparent);
+  }
+
+  /* ── Meta strip ───────────────────────── */
+
+  .meta-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.9rem;
     margin-top: 1rem;
     padding-top: 0.75rem;
     border-top: 1px solid var(--border);
+    font-size: 0.78rem;
+    color: var(--text-muted);
   }
 
-  .btn-delete {
-    margin-right: auto;
-    background: none;
-    border: 1px solid var(--border);
-    color: var(--danger, #ef4444);
-    padding: 0.45rem 0.75rem;
-    border-radius: var(--radius-sm);
-    font-size: 0.8rem;
-    cursor: pointer;
+  .meta-item {
     display: flex;
     align-items: center;
     gap: 0.35rem;
-    transition: background 0.15s, border-color 0.15s;
   }
 
-  .btn-delete:hover {
-    background: color-mix(in srgb, var(--danger) 10%, transparent 90%);
-    border-color: var(--danger, #ef4444);
-  }
-
-  .btn-todo {
-    background: none;
-    border: 1px solid var(--border);
-    color: var(--text-muted);
-    padding: 0.45rem 0.75rem;
-    border-radius: var(--radius-sm);
-    font-size: 0.8rem;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
-    transition: color 0.15s, border-color 0.15s;
-  }
-
-  .btn-todo:hover {
-    color: var(--accent);
-    border-color: var(--accent);
-  }
-
-  .btn-todo:disabled {
-    opacity: 0.4;
-    cursor: default;
-  }
-
-  .btn-todo.open {
-    color: var(--accent);
-    border-color: var(--accent);
-    background: color-mix(in srgb, var(--accent) 10%, transparent 90%);
-  }
-
-  .btn-todo .caret {
-    opacity: 0.7;
-    transition: transform 150ms ease;
-  }
-
-  .btn-todo .caret.open {
-    transform: rotate(180deg);
-  }
-
-  .btn-todo-top {
-    margin-left: auto;
-  }
-
-  .btn-cancel {
-    background: none;
-    border: 1px solid var(--border);
-    color: var(--text-muted);
-    padding: 0.45rem 1rem;
-    border-radius: var(--radius-sm);
-    font-size: 0.85rem;
-    cursor: pointer;
-  }
-
-  .btn-cancel:hover {
-    border-color: var(--text-muted);
-  }
-
-  .btn-edit {
-    background: var(--accent);
-    border: none;
-    color: white;
-    padding: 0.45rem 1rem;
-    border-radius: var(--radius-sm);
-    font-size: 0.85rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: opacity 0.15s;
-  }
-
-  .btn-edit:hover {
-    opacity: 0.9;
-  }
-
-  .move-container {
-    position: relative;
-  }
-
-  .btn-move {
-    background: none;
-    border: 1px solid var(--border);
-    color: var(--text-muted);
-    padding: 0.45rem 0.75rem;
-    border-radius: var(--radius-sm);
-    font-size: 0.8rem;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
-    transition: color 0.15s, border-color 0.15s;
-  }
-
-  .btn-move:hover {
-    color: var(--accent);
-    border-color: var(--accent);
-  }
-
-  .move-dropdown {
-    position: fixed;
-    min-width: 200px;
-    max-width: 280px;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    padding: 0.3rem;
-    z-index: 300;
-    box-shadow: 0 8px 24px var(--shadow);
-    overflow-y: auto;
-  }
-
-  /*
-   * Make Todo picker — sized a touch wider so the group : collection
-   * double label doesn't wrap awkwardly when users have long names.
-   */
-  .make-todo-dropdown {
-    min-width: 240px;
-  }
-
-  .picker-title {
-    padding: 0.35rem 0.55rem 0.4rem;
-    font-size: 0.7rem;
-    font-weight: 600;
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    border-bottom: 1px solid var(--border);
-    margin-bottom: 0.25rem;
-  }
-
-  .move-backdrop {
-    position: fixed;
-    inset: 0;
-    z-index: 250;
-    background: none;
-    border: none;
-    padding: 0;
-    cursor: default;
-  }
-
-  .move-option {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    width: 100%;
-    padding: 0.4rem 0.5rem;
-    border: none;
-    background: none;
-    color: var(--text);
-    font-size: 0.8rem;
-    cursor: pointer;
-    border-radius: 4px;
-    text-align: left;
-  }
-
-  .move-option:hover {
-    background: var(--accent-subtler);
-  }
-
-  .move-dot {
-    width: 8px;
-    height: 8px;
+  .loc-dot {
+    width: 9px;
+    height: 9px;
     border-radius: 50%;
     flex-shrink: 0;
   }
 
-  .move-group-prefix {
+  .meta-group {
     font-weight: 600;
-    font-size: 0.78rem;
   }
 
-  .move-divider {
-    height: 1px;
-    background: var(--border);
-    margin: 0.2rem 0;
+  /* ── Primary filing action ────────────── */
+
+  .btn-file {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    width: 100%;
+    margin-top: 0.85rem;
+    background: var(--accent);
+    border: none;
+    color: white;
+    padding: 0.6rem 1rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.9rem;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    transition: opacity 0.15s;
   }
 
-  .move-empty {
-    padding: 0.4rem 0.5rem;
-    font-size: 0.8rem;
+  .btn-file:hover {
+    opacity: 0.9;
+  }
+
+  /* ── Secondary action list ────────────── */
+
+  .action-list {
+    display: flex;
+    flex-direction: column;
+    margin-top: 0.5rem;
+  }
+
+  .action-row {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    width: 100%;
+    padding: 0.55rem 0.5rem;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-size: 0.85rem;
+    font-family: inherit;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    text-align: left;
+    transition: background 0.15s;
+  }
+
+  .action-row:hover {
+    background: var(--accent-subtler);
+  }
+
+  .action-row:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .action-row svg {
     color: var(--text-muted);
-  }
-
-  .move-error {
-    margin: 0 0.2rem 0.4rem;
-    padding: 0.4rem 0.5rem;
-    font-size: 0.8rem;
-    color: var(--danger);
+    flex-shrink: 0;
   }
 </style>

--- a/packages/web/src/components/add-entry/AudioForm.svelte
+++ b/packages/web/src/components/add-entry/AudioForm.svelte
@@ -13,10 +13,12 @@
   let {
     editItem,
     canSubmit = $bindable(false),
+    draftTitle = $bindable(''),
     buildItem = $bindable(),
   }: {
     editItem?: InboxItem;
     canSubmit?: boolean;
+    draftTitle?: string;
     buildItem?: BuildItemFn;
   } = $props();
 
@@ -28,6 +30,12 @@
   );
 
   let title = $state(editItem?.title ?? '');
+
+  // Mirror the draft title up to the shell so the filing picker can
+  // surface name-match suggestions for the not-yet-saved item.
+  $effect(() => {
+    draftTitle = title;
+  });
   let body = $state(editItem && 'body' in editItem ? (editItem.body ?? '') : '');
   let description = $state(editItem?.description ?? '');
   let file = $state<File | null>(null);

--- a/packages/web/src/components/add-entry/BookmarkForm.svelte
+++ b/packages/web/src/components/add-entry/BookmarkForm.svelte
@@ -7,15 +7,26 @@
   let {
     editItem,
     canSubmit = $bindable(false),
+    draftTitle = $bindable(''),
+    draftUrl = $bindable(''),
     buildItem = $bindable(),
   }: {
     editItem?: InboxItem;
     canSubmit?: boolean;
+    draftTitle?: string;
+    draftUrl?: string;
     buildItem?: BuildItemFn;
   } = $props();
 
   let url = $state(editItem && 'url' in editItem ? editItem.url : '');
   let title = $state(editItem?.title ?? '');
+
+  // Mirror the draft fields up to the shell so the filing picker can
+  // surface name/site-match suggestions for the not-yet-saved item.
+  $effect(() => {
+    draftTitle = title;
+    draftUrl = url;
+  });
   let description = $state(editItem?.description ?? '');
 
   // The URL field is the only required input — title falls back to the URL

--- a/packages/web/src/components/add-entry/DocumentForm.svelte
+++ b/packages/web/src/components/add-entry/DocumentForm.svelte
@@ -8,11 +8,13 @@
     editItem,
     prefillFile = undefined,
     canSubmit = $bindable(false),
+    draftTitle = $bindable(''),
     buildItem = $bindable(),
   }: {
     editItem?: InboxItem;
     prefillFile?: File;
     canSubmit?: boolean;
+    draftTitle?: string;
     buildItem?: BuildItemFn;
   } = $props();
 
@@ -23,6 +25,12 @@
   );
 
   let title = $state(editItem?.title ?? '');
+
+  // Mirror the draft title up to the shell so the filing picker can
+  // surface name-match suggestions for the not-yet-saved item.
+  $effect(() => {
+    draftTitle = title;
+  });
   let description = $state(editItem?.description ?? '');
   // Seed from a file already chosen in the capture bar's picker (the native
   // input can't be set programmatically — the name is shown below instead).

--- a/packages/web/src/components/add-entry/EmailForm.svelte
+++ b/packages/web/src/components/add-entry/EmailForm.svelte
@@ -7,14 +7,22 @@
   let {
     editItem,
     canSubmit = $bindable(false),
+    draftTitle = $bindable(''),
     buildItem = $bindable(),
   }: {
     editItem?: InboxItem;
     canSubmit?: boolean;
+    draftTitle?: string;
     buildItem?: BuildItemFn;
   } = $props();
 
   let title = $state(editItem?.title ?? '');
+
+  // Mirror the draft title up to the shell so the filing picker can
+  // surface name-match suggestions for the not-yet-saved item.
+  $effect(() => {
+    draftTitle = title;
+  });
   let body = $state(editItem && 'body' in editItem ? (editItem.body ?? '') : '');
   let from = $state(editItem && 'from' in editItem ? (editItem.from ?? '') : '');
   let notes = $state(editItem && 'notes' in editItem ? (editItem.notes ?? '') : '');

--- a/packages/web/src/components/add-entry/ImageForm.svelte
+++ b/packages/web/src/components/add-entry/ImageForm.svelte
@@ -8,11 +8,13 @@
     editItem,
     prefillFile = undefined,
     canSubmit = $bindable(false),
+    draftTitle = $bindable(''),
     buildItem = $bindable(),
   }: {
     editItem?: InboxItem;
     prefillFile?: File;
     canSubmit?: boolean;
+    draftTitle?: string;
     buildItem?: BuildItemFn;
   } = $props();
 
@@ -23,6 +25,12 @@
   );
 
   let title = $state(editItem?.title ?? '');
+
+  // Mirror the draft title up to the shell so the filing picker can
+  // surface name-match suggestions for the not-yet-saved item.
+  $effect(() => {
+    draftTitle = title;
+  });
   let description = $state(editItem?.description ?? '');
   // Seed from a file already chosen in the capture bar's picker, so the modal
   // opens with it attached (the native input can't be set programmatically —

--- a/packages/web/src/components/add-entry/NoteForm.svelte
+++ b/packages/web/src/components/add-entry/NoteForm.svelte
@@ -16,17 +16,25 @@
     editItem,
     prefillTitle = '',
     canSubmit = $bindable(false),
+    draftTitle = $bindable(''),
     buildItem = $bindable(),
   }: {
     editItem?: InboxItem;
     prefillTitle?: string;
     canSubmit?: boolean;
+    draftTitle?: string;
     buildItem?: BuildItemFn;
   } = $props();
 
   // When opened from quick-capture, the typed text seeds the title and the
   // body gets focus so the user keeps writing the content.
   let title = $state(editItem?.title ?? prefillTitle);
+
+  // Mirror the draft title up to the shell so the filing picker can
+  // surface name-match suggestions for the not-yet-saved item.
+  $effect(() => {
+    draftTitle = title;
+  });
   let body = $state(
     editItem && 'body' in editItem ? (editItem.body ?? '') : '',
   );

--- a/packages/web/src/components/add-entry/TodoForm.svelte
+++ b/packages/web/src/components/add-entry/TodoForm.svelte
@@ -12,11 +12,13 @@
     editItem,
     prefillTitle = '',
     canSubmit = $bindable(false),
+    draftTitle = $bindable(''),
     buildItem = $bindable(),
   }: {
     editItem?: InboxItem;
     prefillTitle?: string;
     canSubmit?: boolean;
+    draftTitle?: string;
     buildItem?: BuildItemFn;
   } = $props();
 
@@ -24,6 +26,12 @@
 
   // Seed from the Todos quick-add when opened via ⌘/Ctrl-Enter.
   let title = $state(editItem?.title ?? prefillTitle);
+
+  // Mirror the draft title up to the shell so the filing picker can
+  // surface name-match suggestions for the not-yet-saved item.
+  $effect(() => {
+    draftTitle = title;
+  });
   let body = $state(editItem && 'body' in editItem ? (editItem.body ?? '') : '');
   let description = $state(editItem?.description ?? '');
   let completed = $state(

--- a/packages/web/src/lib/collection-suggest.test.ts
+++ b/packages/web/src/lib/collection-suggest.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import type { Collection, InboxItem } from '@inbox-rs/rs-module';
+import { suggestCollections } from './collection-suggest';
+
+function col(id: string, name: string, itemIds: string[] = []): Collection {
+  return { id, name, itemIds, createdAt: '2026-01-01T00:00:00Z' };
+}
+
+function bookmark(
+  id: string,
+  url: string,
+  title = 'A bookmark',
+  collectionId?: string,
+): InboxItem {
+  return {
+    id,
+    type: 'bookmark',
+    title,
+    url,
+    createdAt: '2026-01-01T00:00:00Z',
+    ...(collectionId ? { collectionId } : {}),
+  } as InboxItem;
+}
+
+function note(id: string, title: string, description?: string): InboxItem {
+  return {
+    id,
+    type: 'note',
+    title,
+    body: '',
+    ...(description ? { description } : {}),
+    createdAt: '2026-01-01T00:00:00Z',
+  } as InboxItem;
+}
+
+describe('suggestCollections', () => {
+  it('suggests a collection already holding the same domain', () => {
+    const existing = bookmark('b1', 'https://blog.rust-lang.org/old-post');
+    const target = bookmark('b2', 'https://www.rust-lang.org/new');
+    const rust = col('c1', 'Rust', ['b1']);
+    const web = col('c2', 'Web');
+
+    const result = suggestCollections(
+      target,
+      [rust, web],
+      { b1: existing },
+      [],
+    );
+    // www. is stripped but subdomains are respected: blog.rust-lang.org and
+    // rust-lang.org are different sites, so only an exact domain repeat hits.
+    expect(result).toEqual([]);
+
+    const sameDomain = bookmark('b3', 'https://blog.rust-lang.org/another');
+    const result2 = suggestCollections(
+      sameDomain,
+      [rust, web],
+      { b1: existing },
+      [],
+    );
+    expect(result2).toEqual([{ collection: rust, reason: 'site' }]);
+  });
+
+  it('does not let the item match its own domain footprint', () => {
+    const self = bookmark('b1', 'https://example.com/a', 'Example', 'c1');
+    const other = col('c2', 'Other', ['b1']);
+    // b1 is in c2's itemIds but is the item being filed — no self-match.
+    expect(suggestCollections(self, [other], { b1: self }, [])).toEqual([]);
+  });
+
+  it('matches collection names as whole words in title/description', () => {
+    const recipes = col('c1', 'Recipes');
+    const rust = col('c2', 'Rust');
+    const item = note('n1', 'Weeknight recipes to try', 'crusty bread ideas');
+
+    const result = suggestCollections(item, [recipes, rust], {}, []);
+    // "crusty" must NOT match "Rust" — word boundaries are required.
+    expect(result).toEqual([{ collection: recipes, reason: 'name' }]);
+  });
+
+  it('fills remaining slots from recency, newest first, without duplicates', () => {
+    const a = col('a', 'Alpha');
+    const b = col('b', 'Beta');
+    const c = col('c', 'Gamma');
+    const item = note('n1', 'Beta test notes');
+
+    const result = suggestCollections(item, [a, b, c], {}, ['b', 'c', 'a']);
+    expect(result.map((s) => [s.collection.id, s.reason])).toEqual([
+      ['b', 'name'], // content match wins the top slot
+      ['c', 'recent'],
+      ['a', 'recent'],
+    ]);
+  });
+
+  it('never suggests the collection the item is already in', () => {
+    const home = col('c1', 'Reading');
+    const item = { ...note('n1', 'Reading list'), collectionId: 'c1' };
+    expect(suggestCollections(item, [home], {}, ['c1'])).toEqual([]);
+  });
+
+  it('caps results at max', () => {
+    const cols = ['a', 'b', 'c', 'd'].map((id) => col(id, id.toUpperCase()));
+    const item = note('n1', 'untitled');
+    const result = suggestCollections(item, cols, {}, ['a', 'b', 'c', 'd']);
+    expect(result).toHaveLength(3);
+  });
+});

--- a/packages/web/src/lib/collection-suggest.test.ts
+++ b/packages/web/src/lib/collection-suggest.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
 import type { Collection, InboxItem } from '@inbox-rs/rs-module';
+import { describe, expect, it } from 'vitest';
 import { suggestCollections } from './collection-suggest';
 
 function col(id: string, name: string, itemIds: string[] = []): Collection {

--- a/packages/web/src/lib/collection-suggest.ts
+++ b/packages/web/src/lib/collection-suggest.ts
@@ -22,6 +22,21 @@ export interface CollectionSuggestion {
   reason: SuggestionReason;
 }
 
+/**
+ * The thing being filed. Structurally satisfied by any InboxItem, but also
+ * by a lightweight stand-in for items that don't exist yet (AddEntryModal
+ * picks a destination before the item is built).
+ */
+export interface FilingSubject {
+  id?: string;
+  type?: string;
+  title: string;
+  description?: string;
+  url?: string;
+  collectionId?: string;
+  isTodo?: boolean;
+}
+
 const RECENT_KEY = 'inbox-rs:recent-collections';
 const RECENT_MAX = 12;
 export const SUGGESTION_MAX = 3;
@@ -62,10 +77,8 @@ function domainOf(url: string): string | null {
   }
 }
 
-function itemDomain(item: InboxItem): string | null {
-  return 'url' in item && typeof item.url === 'string'
-    ? domainOf(item.url)
-    : null;
+function itemDomain(item: FilingSubject): string | null {
+  return typeof item.url === 'string' ? domainOf(item.url) : null;
 }
 
 /**
@@ -94,7 +107,7 @@ function nameMatches(name: string, text: string): boolean {
  * it already lives is a no-op).
  */
 export function suggestCollections(
-  item: InboxItem,
+  item: FilingSubject,
   collections: Collection[],
   allItems: Record<string, InboxItem>,
   recentIds: string[],

--- a/packages/web/src/lib/collection-suggest.ts
+++ b/packages/web/src/lib/collection-suggest.ts
@@ -1,0 +1,138 @@
+import type { Collection, InboxItem } from '@inbox-rs/rs-module';
+
+/**
+ * Collection-filing suggestions for the card view's picker.
+ *
+ * Two signals, blended in a fixed priority order (no ML, no fuzziness — the
+ * picker shows a "why" tag per suggestion, so every entry must be explainable
+ * in two words):
+ *
+ *   1. Content match — the item's site domain already appears among a
+ *      collection's bookmarks ("matches site"), or the collection's name
+ *      occurs in the item's title/description ("matches name").
+ *   2. Recency — collections the user filed into recently on this device
+ *      ("recent"). Stored in localStorage: filing habits are per-device
+ *      ephemera, not user data worth syncing through remoteStorage.
+ */
+
+export type SuggestionReason = 'site' | 'name' | 'recent';
+
+export interface CollectionSuggestion {
+  collection: Collection;
+  reason: SuggestionReason;
+}
+
+const RECENT_KEY = 'inbox-rs:recent-collections';
+const RECENT_MAX = 12;
+export const SUGGESTION_MAX = 3;
+
+/** Most-recently-used collection ids, newest first. */
+export function getRecentCollectionIds(): string[] {
+  try {
+    const raw = localStorage.getItem(RECENT_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((v): v is string => typeof v === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Record a filing target so future pickers can suggest it. */
+export function recordCollectionUse(collectionId: string): void {
+  try {
+    const next = [
+      collectionId,
+      ...getRecentCollectionIds().filter((id) => id !== collectionId),
+    ].slice(0, RECENT_MAX);
+    localStorage.setItem(RECENT_KEY, JSON.stringify(next));
+  } catch {
+    // Storage unavailable (private mode, quota) — suggestions just lose the
+    // recency signal; filing itself is unaffected.
+  }
+}
+
+function domainOf(url: string): string | null {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return null;
+  }
+}
+
+function itemDomain(item: InboxItem): string | null {
+  return 'url' in item && typeof item.url === 'string'
+    ? domainOf(item.url)
+    : null;
+}
+
+/**
+ * Does `name` occur in `text` as a whole word/phrase? Guards against 1–2
+ * character collection names ("Go", "JS" are fine; "a" would match
+ * everything, so require length >= 2).
+ */
+function nameMatches(name: string, text: string): boolean {
+  const needle = name.trim().toLowerCase();
+  if (needle.length < 2) return false;
+  const haystack = text.toLowerCase();
+  const idx = haystack.indexOf(needle);
+  if (idx === -1) return false;
+  const before = haystack[idx - 1];
+  const after = haystack[idx + needle.length];
+  const isBoundary = (ch: string | undefined) =>
+    ch === undefined || !/[a-z0-9]/.test(ch);
+  return isBoundary(before) && isBoundary(after);
+}
+
+/**
+ * Rank collections worth surfacing for `item`.
+ *
+ * Pure — recency arrives as an argument so tests never touch localStorage.
+ * The item's current collection is never suggested (moving a card to where
+ * it already lives is a no-op).
+ */
+export function suggestCollections(
+  item: InboxItem,
+  collections: Collection[],
+  allItems: Record<string, InboxItem>,
+  recentIds: string[],
+  max: number = SUGGESTION_MAX,
+): CollectionSuggestion[] {
+  const out: CollectionSuggestion[] = [];
+  const seen = new Set<string>();
+  const add = (collection: Collection, reason: SuggestionReason) => {
+    if (collection.id === item.collectionId) return;
+    if (seen.has(collection.id)) return;
+    seen.add(collection.id);
+    out.push({ collection, reason });
+  };
+
+  // 1a. Site match — strongest signal: the user already files this domain here.
+  const domain = itemDomain(item);
+  if (domain) {
+    for (const col of collections) {
+      const hasDomain = col.itemIds.some((id) => {
+        const other = allItems[id];
+        return other && other.id !== item.id && itemDomain(other) === domain;
+      });
+      if (hasDomain) add(col, 'site');
+    }
+  }
+
+  // 1b. Name match against the item's own words.
+  const text = `${item.title} ${item.description ?? ''}`;
+  for (const col of collections) {
+    if (nameMatches(col.name, text)) add(col, 'name');
+  }
+
+  // 2. Recency fills the remaining slots, newest first.
+  const byId = new Map(collections.map((c) => [c.id, c]));
+  for (const id of recentIds) {
+    const col = byId.get(id);
+    if (col) add(col, 'recent');
+  }
+
+  return out.slice(0, max);
+}


### PR DESCRIPTION
## What

Implements the chosen direction from the card-view design exploration — the **C+ card layout** plus a **suggestions-first filing picker** — then rolls the same picker out to every surface that previously used a flat collection dropdown. There is now **one filing surface everywhere**: card view, make-todo, the add-entry form, and the quick-add todo row.

### Card view (`ViewCardModal`)
- **Delete + Close** are icon buttons in the top-right header, where hands expect them
- New **meta strip**: current location (`Group · Collection` in the group's color, or Inbox/Unfiled), word count when the item has a body, open-duration for todos
- **Filing is the primary action** — a full-width filled `File into collection…` / `Move to collection…` button
- *Make a todo · Make a reference · Edit* form a labelled action list
- Both fixed-position dropdowns and their scroll/resize/positioning bookkeeping are gone (**−200 lines**)

### The shared filing picker (new `CollectionPicker`)
- **Suggested block leads**, blending recency (localStorage, per-device) with content match — same site domain already filed there, or collection name appearing in the item's title — each with a *why* tag (`matches site` / `matches name` / `recent`)
- **Type-to-filter** across collection and group names; Enter picks the first match
- **Inline create**: an unmatched query offers `Create "…"`; a name + group mini-form creates the collection and files the card in one step
- Grouped list with per-collection counts, an **Other** section for ungrouped collections, and an `Inbox`/`Unfiled` row when applicable
- Centered panel on desktop, **bottom sheet** on ≤600px / installed PWA
- Serves four modes: re-filing a card, the make-todo conversion, the add-entry destination, and quick-add todos

### Add flow (`AddEntryModal`)
- The destination field is the **card view's exact filing zone** (meta-strip location row + full-width filing button) instead of a form select — filing looks identical whether the item exists yet or not
- **New items default to the last filing target** (skipping deleted collections; an explicit collection context still wins), with a one-click **↺ Inbox/Unfiled reset** in the meta strip
- Saving into a collection feeds the shared recency signal, so the add flow and the pickers learn from each other

### Quick-add todos (`TodoQuickAdd`)
- The native `<select>` — the last flat collection list in the app — becomes a **location chip** (colored dot + name) opening the shared picker in File-todo mode
- The composed title feeds the picker's name-match suggestions
- All existing semantics preserved: per-device destination memory, the hidden-group guard on passive defaults, explicit picks into hidden groups with the Show toast, and the `fixedCollectionId` variant

Also adds `.claude/skills/verify/SKILL.md` documenting how to drive the app with Playwright.

## Notes for review
- Edit mode never showed a collection field (`shouldShowCollectionPicker` gates on `!isEdit`) — unchanged; re-filing routes through the card view
- Todos previously always started Unfiled by design; they now inherit the remembered destination like other types (the reset keeps escape one click). Scoping the memory to non-todo types is a one-liner in `rememberedDestination()` if this proves wrong in practice

## Testing
- 6 new unit tests for suggestion ranking (word-boundary name match, domain match, recency fill, self-exclusion); `TodoQuickAdd` component tests rewired to drive the real picker UI — **482/482 vitest passing**
- `svelte-check`: 0 errors; production build clean
- Driven end-to-end with Playwright against the dev server (fresh profile, data seeded through the real UI): open card → picker → filter → file; suggested block after same-domain filing; inline create-and-file; unfile via Inbox; make-todo into a collection; Escape peels picker→card one layer at a time; garbage-query empty state; 390×844 bottom sheet; add-entry remembered default + reset; quick-add chip → pick → Enter files correctly. Visual verification also caught and fixed a CSS cascade bug (`.quick-add button` swallowing the chip styling)