### PR TITLE
feat: schedule cards as calendar events/tasks — .ics export + CalDAV posting

### DIFF
--- a/packages/rs-module/src/schemas.ts
+++ b/packages/rs-module/src/schemas.ts
@@ -19,6 +19,8 @@ const scheduleFields = {
   scheduleKind: { type: 'string', enum: ['event', 'task'] },
   eventUrl: { type: 'string' },
   eventEtag: { type: 'string' },
+  archived: { type: 'boolean' },
+  archivedAt: { type: 'string' },
 };
 
 // rs-migrate version stamp — must be in every item schema so remoteStorage persists it

--- a/packages/rs-module/src/schemas.ts
+++ b/packages/rs-module/src/schemas.ts
@@ -10,6 +10,17 @@ const collectionFields = {
   collectionId: { type: 'string' },
 };
 
+// Shared scheduling fields — any item can carry a calendar time.
+// See InboxItemBase in types.ts for semantics.
+const scheduleFields = {
+  startsAt: { type: 'string' },
+  endsAt: { type: 'string' },
+  allDay: { type: 'boolean' },
+  scheduleKind: { type: 'string', enum: ['event', 'task'] },
+  eventUrl: { type: 'string' },
+  eventEtag: { type: 'string' },
+};
+
 // rs-migrate version stamp — must be in every item schema so remoteStorage persists it
 const migrateFields = {
   _migrateVersion: { type: 'number' },
@@ -31,6 +42,7 @@ export const bookmarkSchema = {
     mimeType: { type: 'string' },
     createdAt: { type: 'string' },
     ...todoFields,
+    ...scheduleFields,
     ...collectionFields,
     ...migrateFields,
   },
@@ -47,6 +59,7 @@ export const noteSchema = {
     body: { type: 'string' },
     createdAt: { type: 'string' },
     ...todoFields,
+    ...scheduleFields,
     ...collectionFields,
     ...migrateFields,
   },
@@ -67,6 +80,7 @@ export const imageMetaSchema = {
     thumbMimeType: { type: 'string' },
     createdAt: { type: 'string' },
     ...todoFields,
+    ...scheduleFields,
     ...collectionFields,
     ...migrateFields,
   },
@@ -87,6 +101,7 @@ export const audioMetaSchema = {
     transcribed: { type: 'boolean' },
     createdAt: { type: 'string' },
     ...todoFields,
+    ...scheduleFields,
     ...collectionFields,
     ...migrateFields,
   },
@@ -106,6 +121,7 @@ export const videoMetaSchema = {
     body: { type: 'string' },
     createdAt: { type: 'string' },
     ...todoFields,
+    ...scheduleFields,
     ...collectionFields,
     ...migrateFields,
   },
@@ -125,6 +141,7 @@ export const documentMetaSchema = {
     fileName: { type: 'string' },
     createdAt: { type: 'string' },
     ...todoFields,
+    ...scheduleFields,
     ...collectionFields,
     ...migrateFields,
   },
@@ -144,6 +161,7 @@ export const emailSchema = {
     messageUrl: { type: 'string' },
     createdAt: { type: 'string' },
     ...todoFields,
+    ...scheduleFields,
     ...collectionFields,
     ...migrateFields,
   },
@@ -185,6 +203,7 @@ export const todoSchema = {
     completed: { type: 'boolean' },
     completedAt: { type: 'string' },
     createdAt: { type: 'string' },
+    ...scheduleFields,
     ...collectionFields,
     ...migrateFields,
   },

--- a/packages/rs-module/src/types.ts
+++ b/packages/rs-module/src/types.ts
@@ -33,6 +33,14 @@ export interface InboxItemBase {
   /** CalDAV object href + etag once posted to a calendar; absent until then. */
   eventUrl?: string;
   eventEtag?: string;
+  /**
+   * Set when adding an Inbox reference card to a calendar: the calendar now
+   * owns it, so it leaves the Inbox triage queue (collapsed "archived"
+   * section). Never set on todos — they complete instead — and removing the
+   * calendar entry clears it.
+   */
+  archived?: boolean;
+  archivedAt?: string;
 }
 
 export interface BookmarkItem extends InboxItemBase {

--- a/packages/rs-module/src/types.ts
+++ b/packages/rs-module/src/types.ts
@@ -19,6 +19,20 @@ export interface InboxItemBase {
   completed?: boolean;
   completedAt?: string;
   collectionId?: string; // undefined = Inbox for refs, unfiled for todos
+  /**
+   * Scheduling. The card is the editor — a calendar entry (once posted) is
+   * a projection of these fields, never the other way around.
+   * `startsAt` is the event start, or the due time when scheduleKind is
+   * 'task'. ISO 8601. `endsAt` only applies to events. For all-day entries
+   * both carry date-only semantics (time portion ignored).
+   */
+  startsAt?: string;
+  endsAt?: string;
+  allDay?: boolean;
+  scheduleKind?: 'event' | 'task';
+  /** CalDAV object href + etag once posted to a calendar; absent until then. */
+  eventUrl?: string;
+  eventEtag?: string;
 }
 
 export interface BookmarkItem extends InboxItemBase {

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -20,7 +20,10 @@
     recordCollectionUse,
     type FilingSubject,
   } from '../lib/collection-suggest';
+  import { formatScheduled, type PendingSchedule } from '../lib/schedule';
+  import { applyPendingSchedule } from '../lib/schedule-sync';
   import CollectionPicker from './CollectionPicker.svelte';
+  import ScheduleSheet from './ScheduleSheet.svelte';
   import BookmarkForm from './add-entry/BookmarkForm.svelte';
   import NoteForm from './add-entry/NoteForm.svelte';
   import ImageForm from './add-entry/ImageForm.svelte';
@@ -157,6 +160,26 @@
     collectionPickerOpen = false;
   }
 
+  // ── Optional capture-time schedule ("When?" chip → ScheduleSheet in pick
+  // mode). New items only: editing a schedule lives in the card view's
+  // sheet, and edits preserve existing schedule fields via build-item.
+  let pendingSchedule = $state<PendingSchedule | null>(null);
+  let scheduleSheetOpen = $state(false);
+
+  const whenLabel = $derived(
+    pendingSchedule
+      ? formatScheduled({
+          startsAt: pendingSchedule.start.toISOString(),
+          allDay: pendingSchedule.allDay,
+        })
+      : 'When?',
+  );
+
+  function handleSchedulePick(schedule: PendingSchedule | null) {
+    pendingSchedule = schedule;
+    scheduleSheetOpen = false;
+  }
+
   /**
    * What the CollectionPicker files. The item doesn't exist yet, so this is
    * a lightweight subject built from the live draft fields — the typed
@@ -212,6 +235,16 @@
         // picker's Suggested block stays honest.
         recordCollectionUse(selectedCollectionId);
       }
+      if (pendingSchedule && !isEdit) {
+        // Apply after the move so the stored item keeps its collectionId.
+        // Posts to the picked calendar best-effort — see applyPendingSchedule.
+        await applyPendingSchedule(
+          selectedCollectionId
+            ? { ...item, collectionId: selectedCollectionId }
+            : item,
+          pendingSchedule,
+        );
+      }
       // Fill blank bookmark fields (title, description, preview image) from
       // the page's metadata in the background. New items only — an edit is
       // the user deliberately setting fields, and the view card offers a
@@ -248,6 +281,8 @@
       collectionPickerOpen = false;
       return;
     }
+    // The schedule sheet closes itself via its own Escape listener.
+    if (scheduleSheetOpen) return;
     onclose();
   }}
 />
@@ -401,6 +436,52 @@
         </button>
       {/if}
 
+      {#if !isEdit}
+        <!-- Capture-time schedule: optional, one chip. Untouched it does
+             nothing — scheduling never adds friction to plain capture. -->
+        <div class="schedule-row">
+          <button
+            type="button"
+            class="btn-when"
+            class:has-time={!!pendingSchedule}
+            aria-haspopup="dialog"
+            aria-expanded={scheduleSheetOpen}
+            onclick={() => (scheduleSheetOpen = true)}
+          >
+            <svg
+              aria-hidden="true"
+              width="13"
+              height="13"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="3" y="4" width="18" height="18" rx="2"></rect>
+              <line x1="16" y1="2" x2="16" y2="6"></line>
+              <line x1="8" y1="2" x2="8" y2="6"></line>
+              <line x1="3" y1="10" x2="21" y2="10"></line>
+            </svg>
+            {whenLabel}
+          </button>
+          {#if pendingSchedule}
+            <button
+              type="button"
+              class="btn-when-clear"
+              aria-label="Clear time"
+              onclick={() => (pendingSchedule = null)}
+            >
+              <svg aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+              </svg>
+            </button>
+          {/if}
+        </div>
+      {/if}
+
       {#if error}
         <p class="error">{error}</p>
       {/if}
@@ -450,6 +531,15 @@
         mode={isTodoType ? 'todo' : 'move'}
         onpick={selectCollection}
         onclose={() => (collectionPickerOpen = false)}
+      />
+    {/if}
+
+    {#if scheduleSheetOpen}
+      <ScheduleSheet
+        subject={{ title: draftTitle, isTodo: isTodoType }}
+        initial={pendingSchedule}
+        onpick={handleSchedulePick}
+        onclose={() => (scheduleSheetOpen = false)}
       />
     {/if}
   </div>
@@ -979,6 +1069,59 @@
 
   .meta-group {
     font-weight: 600;
+  }
+
+  /* Capture-time schedule chip row, under the filing zone. */
+  .schedule-row {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-top: 0.6rem;
+  }
+
+  .btn-when {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: none;
+    color: var(--text-muted);
+    padding: 0.28rem 0.75rem;
+    font-size: 0.78rem;
+    font-family: inherit;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s, background 0.15s;
+  }
+
+  .btn-when:hover {
+    border-color: var(--accent);
+    color: var(--text);
+  }
+
+  .btn-when.has-time {
+    border-color: var(--accent-subtle-strong);
+    background: var(--accent-subtler);
+    color: var(--accent);
+  }
+
+  .btn-when-clear {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border: none;
+    border-radius: 50%;
+    background: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+  }
+
+  .btn-when-clear:hover {
+    color: var(--danger);
+    background: color-mix(in srgb, var(--danger) 10%, transparent);
   }
 
   .btn-file {

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -22,6 +22,7 @@
   } from '../lib/collection-suggest';
   import { formatScheduled, type PendingSchedule } from '../lib/schedule';
   import { applyPendingSchedule } from '../lib/schedule-sync';
+  import { showToast } from '../lib/toast';
   import CollectionPicker from './CollectionPicker.svelte';
   import ScheduleSheet from './ScheduleSheet.svelte';
   import BookmarkForm from './add-entry/BookmarkForm.svelte';
@@ -224,26 +225,36 @@
       //                              collection/group written)
       //   real id                 → assign via moveItemToCollection after storage
       await storeItem(item, fileData, thumbData);
-      // Clean up files this edit orphaned (e.g. a previous thumbnail that the
-      // replacement image no longer produces). Best-effort; never blocks save.
-      if (removePaths) {
-        for (const path of removePaths) await removeFile(path);
-      }
-      if (selectedCollectionId && !isEdit) {
-        await moveItemToCollection(item.id, selectedCollectionId);
-        // Feed the recency signal so the next capture defaults here and the
-        // picker's Suggested block stays honest.
-        recordCollectionUse(selectedCollectionId);
-      }
-      if (pendingSchedule && !isEdit) {
-        // Apply after the move so the stored item keeps its collectionId.
-        // Posts to the picked calendar best-effort — see applyPendingSchedule.
-        await applyPendingSchedule(
-          selectedCollectionId
-            ? { ...item, collectionId: selectedCollectionId }
-            : item,
-          pendingSchedule,
-        );
+      // From here the item exists. A follow-up failure (filing, schedule)
+      // must NOT bounce back into the outer catch: that leaves the modal
+      // open, and pressing Save again re-runs the whole submit with a fresh
+      // crypto.randomUUID() — storing a duplicate. Report the partial
+      // failure and close; the item itself is safe.
+      try {
+        // Clean up files this edit orphaned (e.g. a previous thumbnail that
+        // the replacement image no longer produces).
+        if (removePaths) {
+          for (const path of removePaths) await removeFile(path);
+        }
+        if (selectedCollectionId && !isEdit) {
+          await moveItemToCollection(item.id, selectedCollectionId);
+          // Feed the recency signal so the next capture defaults here and
+          // the picker's Suggested block stays honest.
+          recordCollectionUse(selectedCollectionId);
+        }
+        if (pendingSchedule && !isEdit) {
+          // Apply after the move so the stored item keeps its collectionId.
+          // Posts to the picked calendar best-effort — see applyPendingSchedule.
+          await applyPendingSchedule(
+            selectedCollectionId
+              ? { ...item, collectionId: selectedCollectionId }
+              : item,
+            pendingSchedule,
+          );
+        }
+      } catch (postSaveError) {
+        console.error('Post-save step failed:', postSaveError);
+        showToast('Saved — but filing or scheduling failed. Open the item to finish up.');
       }
       // Fill blank bookmark fields (title, description, preview image) from
       // the page's metadata in the background. New items only — an edit is

--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -444,6 +444,9 @@
             type="button"
             class="btn-when"
             class:has-time={!!pendingSchedule}
+            aria-label={pendingSchedule
+              ? `Scheduled ${whenLabel} — change time`
+              : 'Set a time'}
             aria-haspopup="dialog"
             aria-expanded={scheduleSheetOpen}
             onclick={() => (scheduleSheetOpen = true)}

--- a/packages/web/src/components/AddToCalendarSheet.svelte
+++ b/packages/web/src/components/AddToCalendarSheet.svelte
@@ -1,0 +1,397 @@
+<script lang="ts">
+  import type { InboxItem } from '@inbox-rs/rs-module';
+  import { trapFocus } from '../lib/actions';
+  import { CaldavError } from '../lib/caldav';
+  import {
+    calendarAccounts,
+    type CalendarChoice,
+    choiceForEventUrl,
+    findCalendarChoice,
+    pickPreferredCalendar,
+  } from '../lib/calendar-accounts';
+  import { downloadIcs } from '../lib/ics';
+  import { formatScheduled } from '../lib/schedule';
+  import {
+    addItemToCalendar,
+    recordCalendarUse,
+    removeItemFromCalendar,
+  } from '../lib/schedule-sync';
+  import { showToast } from '../lib/toast';
+  import CalendarPicker from './CalendarPicker.svelte';
+
+  /**
+   * Publishing a timed card to a calendar — the counterpart to the
+   * calendar-free time sheet. Only reachable once a time is set. Posting an
+   * Inbox reference card archives it (the calendar owns it now); removing
+   * the entry brings it back. Todos are never archived — they complete.
+   */
+  let {
+    item,
+    onclose,
+  }: {
+    item: InboxItem;
+    onclose: () => void;
+  } = $props();
+
+  const isTodoish = item.isTodo || item.type === 'todo';
+  const kind = item.scheduleKind ?? (isTodoish ? 'task' : 'event');
+  const timeLabel = formatScheduled(item);
+  const isPosted = !!item.eventUrl;
+  const willArchive = !isPosted && !isTodoish && !item.collectionId;
+
+  const eventHome = choiceForEventUrl(item.eventUrl);
+  let selectedCalendarId = $state<string | undefined>(
+    eventHome?.calendar.id ?? pickPreferredCalendar(kind)?.calendar.id,
+  );
+  let showPicker = $state(false);
+  let saving = $state(false);
+
+  const hasAccounts = $derived($calendarAccounts.length > 0);
+  const selectedChoice = $derived<CalendarChoice | undefined>(
+    findCalendarChoice(selectedCalendarId) ??
+      (eventHome?.calendar.id === selectedCalendarId ? eventHome : undefined),
+  );
+  const calendarSupportsKind = $derived(
+    !!selectedChoice?.calendar.components.includes(kind),
+  );
+  const canPost = $derived(
+    !saving && !!selectedChoice && calendarSupportsKind,
+  );
+  /** Selected a different calendar than the entry's current home. */
+  const isMove = $derived(
+    isPosted && !!selectedChoice && selectedChoice.calendar.id !== eventHome?.calendar.id,
+  );
+
+  function handlePick(choice: CalendarChoice) {
+    selectedCalendarId = choice.calendar.id;
+    showPicker = false;
+  }
+
+  function friendly(err: unknown): string {
+    return err instanceof CaldavError
+      ? err.message
+      : 'the calendar relay is unreachable';
+  }
+
+  async function post() {
+    if (!canPost || !selectedChoice) return;
+    saving = true;
+    try {
+      const posted = await addItemToCalendar(item, selectedChoice.calendar.id);
+      recordCalendarUse(kind, selectedChoice.calendar.id);
+      if (posted.archived) {
+        showToast('Added to calendar — card archived from the Inbox');
+      }
+      onclose();
+    } catch (err) {
+      console.error('Calendar post failed', err);
+      showToast(`Couldn't add to calendar — ${friendly(err)}`);
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function remove() {
+    saving = true;
+    try {
+      await removeItemFromCalendar(item);
+      onclose();
+    } catch (err) {
+      console.error('Calendar delete failed', err);
+      showToast(`Still on your calendar — ${friendly(err)}`);
+    } finally {
+      saving = false;
+    }
+  }
+
+  function handleDownload() {
+    downloadIcs(item);
+    onclose();
+  }
+
+  function handleEscape(e: KeyboardEvent) {
+    if (e.key !== 'Escape' || saving) return;
+    if (showPicker) return; // picker closes itself first
+    onclose();
+  }
+</script>
+
+<svelte:window onkeydown={handleEscape} />
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" role="dialog" aria-modal="true" aria-label="Add to calendar" onclick={() => { if (!saving) onclose(); }}>
+  <div class="sheet" use:trapFocus onclick={(e) => e.stopPropagation()}>
+    <h3 class="title">{isPosted ? 'On calendar' : 'Add to calendar'}</h3>
+    <p class="ctx">{item.title || 'Untitled'}</p>
+
+    <div class="time-row">
+      <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="10"></circle>
+        <polyline points="12 6 12 12 16 14"></polyline>
+      </svg>
+      {timeLabel}
+      <span class="kind-tag">{kind}</span>
+    </div>
+
+    {#if hasAccounts}
+      <button type="button" class="zone" onclick={() => (showPicker = true)}>
+        {#if selectedChoice}
+          <span
+            class="dot"
+            style="background: {selectedChoice.calendar.color || 'var(--accent)'}"
+          ></span>
+          <span class="zone-name">{selectedChoice.calendar.name}</span>
+          <span class="zone-sub">· {selectedChoice.account.label}</span>
+        {:else}
+          <span class="zone-name muted">Choose calendar…</span>
+        {/if}
+        <svg class="chev" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="6 9 12 15 18 9"></polyline>
+        </svg>
+      </button>
+      {#if selectedChoice && !calendarSupportsKind}
+        <p class="note">
+          {selectedChoice.calendar.name} doesn't support {kind}s — pick
+          another calendar.
+        </p>
+      {/if}
+      {#if willArchive}
+        <p class="note">
+          The card moves to the Inbox's archived section once it's on your
+          calendar. Removing the entry brings it back.
+        </p>
+      {/if}
+
+      {#if !isPosted || isMove}
+        <button type="button" class="btn-primary" disabled={!canPost} onclick={post}>
+          {isMove
+            ? 'Move to this calendar'
+            : kind === 'task'
+              ? 'Add task'
+              : 'Add to calendar'}
+        </button>
+      {/if}
+      <button type="button" class="btn-ghost" disabled={saving} onclick={handleDownload}>
+        Download .ics
+      </button>
+      {#if isPosted}
+        <button type="button" class="btn-remove" disabled={saving} onclick={remove}>
+          Remove from calendar
+        </button>
+      {/if}
+    {:else}
+      <button type="button" class="btn-primary" disabled={saving} onclick={handleDownload}>
+        Download .ics
+      </button>
+      <p class="hint">
+        Post events straight to your calendar by connecting an account:
+        user&nbsp;menu → Calendar accounts.
+      </p>
+    {/if}
+  </div>
+</div>
+
+{#if showPicker}
+  <CalendarPicker
+    {kind}
+    selectedId={selectedCalendarId}
+    onpick={handlePick}
+    onclose={() => (showPicker = false)}
+  />
+{/if}
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--overlay);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    z-index: 200;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+  }
+
+  .sheet {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.25rem;
+    max-width: 380px;
+    width: 100%;
+    box-shadow: 0 12px 40px var(--shadow);
+  }
+
+  .title {
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  .ctx {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    margin-bottom: 0.85rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* The time being published — read-only here; edited via the time sheet. */
+  .time-row {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.85rem;
+    color: var(--text);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.5rem 0.65rem;
+  }
+
+  .time-row svg {
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .kind-tag {
+    margin-left: auto;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.02rem 0.5rem;
+    font-size: 0.64rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .zone {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    margin-top: 0.7rem;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 10px;
+    padding: 0.5rem 0.65rem;
+    font-family: inherit;
+    font-size: 0.82rem;
+    color: var(--text);
+    cursor: pointer;
+    transition: border-color 0.15s;
+    text-align: left;
+  }
+
+  .zone:hover {
+    border-color: var(--accent);
+  }
+
+  .zone .dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .zone-name {
+    font-weight: 550;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .zone-name.muted {
+    color: var(--text-muted);
+    font-weight: 400;
+  }
+
+  .zone-sub {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .zone .chev {
+    margin-left: auto;
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .note {
+    margin-top: 0.5rem;
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    line-height: 1.45;
+  }
+
+  .btn-primary {
+    display: block;
+    width: 100%;
+    margin-top: 0.9rem;
+    background: var(--accent);
+    border: none;
+    color: white;
+    padding: 0.55rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.88rem;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  .btn-primary:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .btn-ghost,
+  .btn-remove {
+    display: block;
+    width: 100%;
+    margin-top: 0.35rem;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    padding: 0.4rem;
+    font-size: 0.78rem;
+    font-family: inherit;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+  }
+
+  .btn-ghost:hover:not(:disabled) {
+    color: var(--text);
+    background: var(--surface-hover);
+  }
+
+  .btn-remove {
+    color: var(--danger);
+  }
+
+  .btn-remove:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--danger) 10%, transparent);
+  }
+
+  .btn-ghost:disabled,
+  .btn-remove:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .hint {
+    margin-top: 0.6rem;
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+</style>

--- a/packages/web/src/components/CalendarPicker.svelte
+++ b/packages/web/src/components/CalendarPicker.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+  import {
+    calendarAccounts,
+    type CalendarChoice,
+  } from '../lib/calendar-accounts';
+  import type { ScheduleKind } from '../lib/schedule';
+
+  let {
+    kind,
+    selectedId,
+    onpick,
+    onclose,
+  }: {
+    /** Entry kind being scheduled — task-incapable calendars are disabled. */
+    kind: ScheduleKind;
+    selectedId?: string;
+    onpick: (choice: CalendarChoice) => void;
+    onclose: () => void;
+  } = $props();
+
+  /** Accounts with their visible calendars — same hierarchy as the settings list. */
+  const groups = $derived(
+    $calendarAccounts
+      .map((account) => ({
+        account,
+        calendars: account.calendars.filter(
+          (c) => !account.hiddenCalendarIds?.includes(c.id),
+        ),
+      }))
+      .filter((g) => g.calendars.length > 0),
+  );
+
+  function supports(components: Array<'event' | 'task'>): boolean {
+    return components.includes(kind);
+  }
+
+  function handleEscape(e: KeyboardEvent) {
+    if (e.key !== 'Escape') return;
+    onclose();
+  }
+</script>
+
+<svelte:window onkeydown={handleEscape} />
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" role="dialog" aria-modal="true" aria-label="Choose calendar" onclick={onclose}>
+  <div class="sheet" onclick={(e) => e.stopPropagation()}>
+    <h3 class="title">Choose calendar</h3>
+    {#each groups as group (group.account.id)}
+      <div class="grp">{group.account.label} · {group.account.username}</div>
+      {#each group.calendars as cal (cal.id)}
+        <button
+          type="button"
+          class="cal-row"
+          class:sel={cal.id === selectedId}
+          disabled={!supports(cal.components)}
+          title={supports(cal.components)
+            ? cal.name
+            : `${cal.name} doesn't support ${kind}s`}
+          onclick={() => onpick({ account: group.account, calendar: cal })}
+        >
+          <span class="dot" style="background: {cal.color || 'var(--accent)'}"></span>
+          <span class="name">{cal.name}</span>
+          <span class="tags">
+            {#if cal.components.includes('task')}
+              <span class="tag">tasks</span>
+            {/if}
+            {#if cal.id === group.account.defaultCalendarId}
+              <span class="tag star" title="Default calendar">★</span>
+            {/if}
+          </span>
+        </button>
+      {/each}
+    {:else}
+      <p class="empty">
+        No calendar accounts yet. Add one from the user menu → Calendar
+        accounts, then events post straight to your calendar.
+      </p>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--overlay);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    z-index: 210;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+  }
+
+  .sheet {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.1rem;
+    max-width: 360px;
+    width: 100%;
+    box-shadow: 0 12px 40px var(--shadow);
+  }
+
+  .title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+
+  .grp {
+    font-size: 0.64rem;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    font-weight: 650;
+    margin: 0.7rem 0 0.25rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .cal-row {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    width: 100%;
+    padding: 0.45rem 0.45rem;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-size: 0.85rem;
+    font-family: inherit;
+    text-align: left;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  .cal-row:hover:not(:disabled) {
+    background: var(--accent-subtler);
+  }
+
+  .cal-row.sel {
+    background: var(--accent-subtle);
+    outline: 1.5px solid var(--accent);
+    outline-offset: -1.5px;
+  }
+
+  .cal-row:disabled {
+    opacity: 0.45;
+    cursor: default;
+  }
+
+  .dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .tags {
+    display: inline-flex;
+    gap: 0.35rem;
+    flex-shrink: 0;
+    align-items: center;
+  }
+
+  .tag {
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.02rem 0.4rem;
+    font-size: 0.62rem;
+    color: var(--text-muted);
+  }
+
+  .tag.star {
+    border: none;
+    color: #eab308;
+    padding: 0;
+  }
+
+  .empty {
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+    padding: 0.5rem 0.25rem;
+  }
+</style>

--- a/packages/web/src/components/CalendarPicker.svelte
+++ b/packages/web/src/components/CalendarPicker.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { trapFocus } from '../lib/actions';
   import {
     calendarAccounts,
     type CalendarChoice,
@@ -45,7 +46,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="overlay" role="dialog" aria-modal="true" aria-label="Choose calendar" onclick={onclose}>
-  <div class="sheet" onclick={(e) => e.stopPropagation()}>
+  <div class="sheet" use:trapFocus onclick={(e) => e.stopPropagation()}>
     <h3 class="title">Choose calendar</h3>
     {#each groups as group (group.account.id)}
       <div class="grp">{group.account.label} · {group.account.username}</div>

--- a/packages/web/src/components/CalendarSettingsModal.svelte
+++ b/packages/web/src/components/CalendarSettingsModal.svelte
@@ -14,6 +14,7 @@
   } from '../lib/calendar-accounts';
   import { trapFocus } from '../lib/actions';
   import { resolveSockethubEndpoint } from '../lib/enrich';
+  import { DEFAULT_SOCKETHUB_ENDPOINT } from '../lib/link-metadata';
   import { showToast } from '../lib/toast';
 
   let { onclose }: { onclose: () => void } = $props();
@@ -30,6 +31,22 @@
   const canConnect = $derived(
     !!serverUrl.trim() && !!username.trim() && !!password && !connecting,
   );
+
+  // The relay that will receive the credentials, surfaced BEFORE the user
+  // presses Connect. The synced `sockethubUrl` setting decides it, and a
+  // compromised linked device could have rewritten that setting — showing
+  // the destination (and flagging a non-default relay) makes a redirected
+  // connect visible at the moment it matters. Recomputed when the add form
+  // opens; the chosen value is pinned on the account afterwards.
+  let connectEndpoint = $state(resolveSockethubEndpoint());
+  const endpointHost = $derived.by(() => {
+    try {
+      return new URL(connectEndpoint).host;
+    } catch {
+      return connectEndpoint;
+    }
+  });
+  const isCustomRelay = $derived(connectEndpoint !== DEFAULT_SOCKETHUB_ENDPOINT);
 
   /** Accept a bare host ("caldav.fastmail.com") — discovery wants a URL. */
   function normalizeUrl(raw: string): string {
@@ -51,10 +68,10 @@
       username: username.trim(),
       password,
     };
-    // Resolved once, at this explicit local action, and pinned on the
+    // The endpoint shown in the form is the one used and then pinned on the
     // account — later credential-bearing requests never re-resolve the
     // synced setting (see CalendarAccount.endpoint).
-    const endpoint = resolveSockethubEndpoint();
+    const endpoint = connectEndpoint;
     try {
       const calendars = await fetchCalendars(creds, endpoint);
       if (calendars.length === 0) {
@@ -243,6 +260,21 @@
           bind:value={password}
           autocomplete="current-password"
         />
+        <p class="relay-line" class:custom={isCustomRelay}>
+          {#if isCustomRelay}
+            <svg aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+              <line x1="12" y1="9" x2="12" y2="13"></line>
+              <line x1="12" y1="17" x2="12.01" y2="17"></line>
+            </svg>
+            Credentials will be relayed via <strong>{endpointHost}</strong> —
+            a custom Sockethub server, not the app default. Make sure you
+            trust it.
+          {:else}
+            Credentials are relayed via <strong>{endpointHost}</strong> and
+            never stored there.
+          {/if}
+        </p>
         {#if connectError}
           <p class="error">{connectError}</p>
         {/if}
@@ -255,7 +287,15 @@
         </p>
       </form>
     {:else}
-      <button type="button" class="btn-add" onclick={() => { showAdd = true; connectError = ''; }}>
+      <button
+        type="button"
+        class="btn-add"
+        onclick={() => {
+          showAdd = true;
+          connectError = '';
+          connectEndpoint = resolveSockethubEndpoint();
+        }}
+      >
         + Add calendar account
       </button>
     {/if}
@@ -490,6 +530,28 @@
 
   .add-form input:focus {
     border-color: var(--accent);
+  }
+
+  /* Which relay receives the credentials — always visible pre-Connect. */
+  .relay-line {
+    margin-top: 0.6rem;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    line-height: 1.45;
+  }
+
+  .relay-line.custom {
+    color: #d97706;
+    border: 1px solid color-mix(in srgb, #d97706 35%, transparent);
+    background: color-mix(in srgb, #d97706 8%, transparent);
+    border-radius: var(--radius-sm);
+    padding: 0.45rem 0.55rem;
+  }
+
+  .relay-line svg {
+    display: inline;
+    vertical-align: -1px;
+    margin-right: 0.2rem;
   }
 
   .error {

--- a/packages/web/src/components/CalendarSettingsModal.svelte
+++ b/packages/web/src/components/CalendarSettingsModal.svelte
@@ -5,12 +5,14 @@
     type CaldavCredentials,
   } from '../lib/caldav';
   import {
+    accountEndpoint,
     addCalendarAccount,
     calendarAccounts,
     removeCalendarAccount,
     updateCalendarAccount,
     type CalendarAccount,
   } from '../lib/calendar-accounts';
+  import { trapFocus } from '../lib/actions';
   import { resolveSockethubEndpoint } from '../lib/enrich';
   import { showToast } from '../lib/toast';
 
@@ -49,8 +51,12 @@
       username: username.trim(),
       password,
     };
+    // Resolved once, at this explicit local action, and pinned on the
+    // account — later credential-bearing requests never re-resolve the
+    // synced setting (see CalendarAccount.endpoint).
+    const endpoint = resolveSockethubEndpoint();
     try {
-      const calendars = await fetchCalendars(creds, resolveSockethubEndpoint());
+      const calendars = await fetchCalendars(creds, endpoint);
       if (calendars.length === 0) {
         connectError = 'Connected, but the account has no calendars.';
         return;
@@ -61,7 +67,7 @@
       } catch {
         // keep as-is
       }
-      addCalendarAccount({ label: host, ...creds, calendars });
+      addCalendarAccount({ label: host, ...creds, endpoint, calendars });
       showAdd = false;
       serverUrl = '';
       username = '';
@@ -79,7 +85,7 @@
   async function handleRefresh(account: CalendarAccount) {
     refreshingId = account.id;
     try {
-      const calendars = await fetchCalendars(account, resolveSockethubEndpoint());
+      const calendars = await fetchCalendars(account, accountEndpoint(account));
       const ids = new Set(calendars.map((c) => c.id));
       updateCalendarAccount(account.id, {
         calendars,
@@ -138,7 +144,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="overlay" role="dialog" aria-modal="true" aria-label="Calendar accounts" onclick={onclose}>
-  <div class="modal" onclick={(e) => e.stopPropagation()}>
+  <div class="modal" use:trapFocus onclick={(e) => e.stopPropagation()}>
     <div class="head">
       <h3 class="title">Calendar accounts</h3>
       <button type="button" class="icon-btn" aria-label="Close" onclick={onclose}>

--- a/packages/web/src/components/CalendarSettingsModal.svelte
+++ b/packages/web/src/components/CalendarSettingsModal.svelte
@@ -1,0 +1,542 @@
+<script lang="ts">
+  import {
+    CaldavError,
+    fetchCalendars,
+    type CaldavCredentials,
+  } from '../lib/caldav';
+  import {
+    addCalendarAccount,
+    calendarAccounts,
+    removeCalendarAccount,
+    updateCalendarAccount,
+    type CalendarAccount,
+  } from '../lib/calendar-accounts';
+  import { resolveSockethubEndpoint } from '../lib/enrich';
+  import { showToast } from '../lib/toast';
+
+  let { onclose }: { onclose: () => void } = $props();
+
+  let showAdd = $state(false);
+  let serverUrl = $state('');
+  let username = $state('');
+  let password = $state('');
+  let connecting = $state(false);
+  let connectError = $state('');
+  let refreshingId = $state<string | null>(null);
+  let confirmRemoveId = $state<string | null>(null);
+
+  const canConnect = $derived(
+    !!serverUrl.trim() && !!username.trim() && !!password && !connecting,
+  );
+
+  /** Accept a bare host ("caldav.fastmail.com") — discovery wants a URL. */
+  function normalizeUrl(raw: string): string {
+    const trimmed = raw.trim();
+    return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  }
+
+  function friendlyError(err: unknown): string {
+    if (err instanceof CaldavError) return err.message;
+    return 'Could not reach the calendar relay — are you offline?';
+  }
+
+  async function handleConnect() {
+    if (!canConnect) return;
+    connecting = true;
+    connectError = '';
+    const creds: CaldavCredentials = {
+      url: normalizeUrl(serverUrl),
+      username: username.trim(),
+      password,
+    };
+    try {
+      const calendars = await fetchCalendars(creds, resolveSockethubEndpoint());
+      if (calendars.length === 0) {
+        connectError = 'Connected, but the account has no calendars.';
+        return;
+      }
+      let host = creds.url;
+      try {
+        host = new URL(creds.url).host;
+      } catch {
+        // keep as-is
+      }
+      addCalendarAccount({ label: host, ...creds, calendars });
+      showAdd = false;
+      serverUrl = '';
+      username = '';
+      password = '';
+      showToast(`Found ${calendars.length} calendar${calendars.length === 1 ? '' : 's'}`);
+    } catch (err) {
+      console.error('Calendar discovery failed', err);
+      connectError = friendlyError(err);
+    } finally {
+      connecting = false;
+    }
+  }
+
+  /** Re-run discovery, keeping hidden/default choices for surviving calendars. */
+  async function handleRefresh(account: CalendarAccount) {
+    refreshingId = account.id;
+    try {
+      const calendars = await fetchCalendars(account, resolveSockethubEndpoint());
+      const ids = new Set(calendars.map((c) => c.id));
+      updateCalendarAccount(account.id, {
+        calendars,
+        hiddenCalendarIds: account.hiddenCalendarIds?.filter((id) => ids.has(id)),
+        defaultCalendarId:
+          account.defaultCalendarId && ids.has(account.defaultCalendarId)
+            ? account.defaultCalendarId
+            : undefined,
+      });
+    } catch (err) {
+      console.error('Calendar refresh failed', err);
+      showToast(friendlyError(err));
+    } finally {
+      refreshingId = null;
+    }
+  }
+
+  function toggleHidden(account: CalendarAccount, calendarId: string) {
+    const hidden = new Set(account.hiddenCalendarIds ?? []);
+    if (hidden.has(calendarId)) {
+      hidden.delete(calendarId);
+    } else {
+      hidden.add(calendarId);
+    }
+    updateCalendarAccount(account.id, { hiddenCalendarIds: [...hidden] });
+  }
+
+  function toggleDefault(account: CalendarAccount, calendarId: string) {
+    updateCalendarAccount(account.id, {
+      defaultCalendarId:
+        account.defaultCalendarId === calendarId ? undefined : calendarId,
+    });
+  }
+
+  function handleRemove(accountId: string) {
+    if (confirmRemoveId !== accountId) {
+      confirmRemoveId = accountId;
+      return;
+    }
+    removeCalendarAccount(accountId);
+    confirmRemoveId = null;
+  }
+
+  function handleEscape(e: KeyboardEvent) {
+    if (e.key !== 'Escape') return;
+    if (showAdd) {
+      showAdd = false;
+      return;
+    }
+    onclose();
+  }
+</script>
+
+<svelte:window onkeydown={handleEscape} />
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" role="dialog" aria-modal="true" aria-label="Calendar accounts" onclick={onclose}>
+  <div class="modal" onclick={(e) => e.stopPropagation()}>
+    <div class="head">
+      <h3 class="title">Calendar accounts</h3>
+      <button type="button" class="icon-btn" aria-label="Close" onclick={onclose}>
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="18" y1="6" x2="6" y2="18"></line>
+          <line x1="6" y1="6" x2="18" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+    <p class="sub">
+      Scheduled cards can post straight to your calendar. Credentials stay on
+      this device and are relayed per-request — no server stores them.
+    </p>
+
+    {#each $calendarAccounts as account (account.id)}
+      <div class="acct">
+        <div class="acct-head">
+          <span class="acct-label">{account.label}</span>
+          <span class="acct-user">{account.username}</span>
+          <button
+            type="button"
+            class="mini-btn"
+            disabled={refreshingId === account.id}
+            onclick={() => handleRefresh(account)}
+          >
+            {refreshingId === account.id ? 'Refreshing…' : 'Refresh'}
+          </button>
+          <button
+            type="button"
+            class="mini-btn danger"
+            onclick={() => handleRemove(account.id)}
+            onmouseleave={() => (confirmRemoveId = null)}
+          >
+            {confirmRemoveId === account.id ? 'Really remove?' : 'Remove'}
+          </button>
+        </div>
+        {#each account.calendars as cal (cal.id)}
+          {@const hidden = account.hiddenCalendarIds?.includes(cal.id)}
+          <div class="cal-line" class:hidden>
+            <span class="dot" style="background: {cal.color || 'var(--accent)'}"></span>
+            <span class="cal-name">{cal.name}</span>
+            {#if cal.components.includes('task')}
+              <span class="tag">tasks</span>
+            {/if}
+            <span class="line-actions">
+              <button
+                type="button"
+                class="star-btn"
+                class:on={account.defaultCalendarId === cal.id}
+                title={account.defaultCalendarId === cal.id
+                  ? 'Default calendar'
+                  : 'Make default'}
+                aria-label="Make {cal.name} the default calendar"
+                aria-pressed={account.defaultCalendarId === cal.id}
+                onclick={() => toggleDefault(account, cal.id)}
+              >★</button>
+              <label class="vis-label">
+                <input
+                  type="checkbox"
+                  checked={!hidden}
+                  aria-label="Show {cal.name} in pickers"
+                  onchange={() => toggleHidden(account, cal.id)}
+                />
+                show
+              </label>
+            </span>
+          </div>
+        {/each}
+      </div>
+    {:else}
+      <p class="empty">No accounts connected yet.</p>
+    {/each}
+
+    {#if showAdd}
+      <form class="add-form" onsubmit={(e) => { e.preventDefault(); void handleConnect(); }}>
+        <label class="flabel" for="cal-server">Server</label>
+        <input
+          id="cal-server"
+          type="text"
+          bind:value={serverUrl}
+          placeholder="caldav.fastmail.com"
+          autocomplete="url"
+        />
+        <label class="flabel" for="cal-user">Username</label>
+        <input
+          id="cal-user"
+          type="text"
+          bind:value={username}
+          placeholder="you@example.com"
+          autocomplete="username"
+        />
+        <label class="flabel" for="cal-pass">App password</label>
+        <input
+          id="cal-pass"
+          type="password"
+          bind:value={password}
+          autocomplete="current-password"
+        />
+        {#if connectError}
+          <p class="error">{connectError}</p>
+        {/if}
+        <button type="submit" class="btn-primary" disabled={!canConnect}>
+          {connecting ? 'Connecting…' : 'Connect & find calendars'}
+        </button>
+        <p class="hint">
+          Use an app-specific password — most providers (Fastmail, iCloud,
+          Nextcloud) issue them under security settings.
+        </p>
+      </form>
+    {:else}
+      <button type="button" class="btn-add" onclick={() => { showAdd = true; connectError = ''; }}>
+        + Add calendar account
+      </button>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--overlay);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    z-index: 200;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 3rem 1rem;
+  }
+
+  .modal {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.25rem;
+    max-width: 440px;
+    width: 100%;
+    box-shadow: 0 12px 40px var(--shadow);
+  }
+
+  .head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .title {
+    font-size: 1.05rem;
+    font-weight: 650;
+  }
+
+  .icon-btn {
+    width: 30px;
+    height: 30px;
+    border-radius: var(--radius-sm);
+    display: grid;
+    place-items: center;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+
+  .icon-btn:hover {
+    background: var(--surface-hover);
+    color: var(--text);
+  }
+
+  .sub {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+    margin: 0.35rem 0 0.9rem;
+  }
+
+  .acct {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg);
+    padding: 0.6rem 0.7rem;
+    margin-bottom: 0.6rem;
+  }
+
+  .acct-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.4rem;
+    min-width: 0;
+  }
+
+  .acct-label {
+    font-size: 0.85rem;
+    font-weight: 650;
+    flex-shrink: 0;
+  }
+
+  .acct-user {
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mini-btn {
+    border: 1px solid var(--border);
+    background: none;
+    color: var(--text-muted);
+    border-radius: 999px;
+    padding: 0.12rem 0.55rem;
+    font-size: 0.7rem;
+    font-family: inherit;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+
+  .mini-btn:hover:not(:disabled) {
+    color: var(--text);
+    border-color: var(--text-muted);
+  }
+
+  .mini-btn.danger:hover {
+    color: var(--danger);
+    border-color: var(--danger);
+  }
+
+  .mini-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .cal-line {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.28rem 0.1rem;
+    font-size: 0.82rem;
+  }
+
+  .dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .cal-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .cal-line.hidden .cal-name {
+    opacity: 0.45;
+  }
+
+  .tag {
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.02rem 0.4rem;
+    font-size: 0.6rem;
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .line-actions {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    flex-shrink: 0;
+  }
+
+  .star-btn {
+    border: none;
+    background: none;
+    color: var(--border);
+    font-size: 0.9rem;
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+    transition: color 0.15s;
+  }
+
+  .star-btn:hover {
+    color: var(--text-muted);
+  }
+
+  .star-btn.on {
+    color: #eab308;
+  }
+
+  .vis-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+
+  .vis-label input {
+    accent-color: var(--accent);
+  }
+
+  .empty {
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    margin-bottom: 0.75rem;
+  }
+
+  .add-form {
+    display: flex;
+    flex-direction: column;
+    margin-top: 0.5rem;
+  }
+
+  .flabel {
+    font-size: 0.66rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 550;
+    margin: 0.6rem 0 0.25rem;
+  }
+
+  .add-form input {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.45rem 0.6rem;
+    color: var(--text);
+    /* ≥1rem: iOS Safari focus-zoom floor (AGENTS.md). */
+    font-size: 1rem;
+    font-family: inherit;
+    outline: none;
+  }
+
+  .add-form input:focus {
+    border-color: var(--accent);
+  }
+
+  .error {
+    margin-top: 0.6rem;
+    font-size: 0.78rem;
+    color: var(--danger);
+    line-height: 1.45;
+  }
+
+  .btn-primary {
+    margin-top: 0.85rem;
+    background: var(--accent);
+    border: none;
+    color: white;
+    padding: 0.5rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.85rem;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  .btn-primary:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .hint {
+    margin-top: 0.6rem;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    line-height: 1.45;
+  }
+
+  .btn-add {
+    width: 100%;
+    background: none;
+    border: 1px dashed var(--border);
+    color: var(--text-muted);
+    padding: 0.5rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.82rem;
+    font-family: inherit;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s;
+  }
+
+  .btn-add:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+</style>

--- a/packages/web/src/components/CollectionTodoTile.svelte
+++ b/packages/web/src/components/CollectionTodoTile.svelte
@@ -3,10 +3,10 @@
   import { dndzone } from 'svelte-dnd-action';
   import { slide } from 'svelte/transition';
   import {
-    collectionItems, storeItem, deleteItem,
+    collectionItems, deleteItem,
     appConfig, updateConfig, reorderCollectionItems,
   } from '../lib/stores';
-  import { cleanForStorage } from '../lib/clean-for-storage';
+  import { setItemCompleted } from '../lib/schedule-sync';
   import {
     filterCompletedTodos,
     filterOpenTodos,
@@ -71,15 +71,10 @@
 
   async function toggleCompleted(e: Event, item: InboxItem) {
     e.stopPropagation();
-    const nowCompleted = !item.completed;
-    const updated = {
-      ...item,
-      isTodo: true,
-      completed: nowCompleted,
-      completedAt: nowCompleted ? new Date().toISOString() : undefined,
-    };
     try {
-      await storeItem(cleanForStorage(updated));
+      // Shared helper: local flip + best-effort calendar sync for scheduled
+      // tasks (STATUS:COMPLETED on the posted VTODO).
+      await setItemCompleted(item, !item.completed);
     } catch (error) {
       console.error('Failed to toggle todo completion', error);
       // Checkbox reverts on next render because the item prop is unchanged

--- a/packages/web/src/components/InboxCard.svelte
+++ b/packages/web/src/components/InboxCard.svelte
@@ -7,6 +7,7 @@
   import DocumentCard from './DocumentCard.svelte';
   import EmailCard from './EmailCard.svelte';
   import { draggingItemId, DRAG_MIME } from '../lib/drag';
+  import { formatScheduled, isOverdue, isPast } from '../lib/schedule';
 
   let { item, onselect }: { item: InboxItem; onselect: (item: InboxItem) => void } = $props();
 
@@ -118,6 +119,10 @@
       year: 'numeric',
     });
   }
+
+  const scheduledLabel = $derived(item.startsAt ? formatScheduled(item) : '');
+  const scheduleOverdue = $derived(isOverdue(item));
+  const schedulePast = $derived(isPast(item));
 </script>
 
 <article class="card" role="button" tabindex="0"
@@ -196,6 +201,22 @@
 
   <footer class="card-footer">
     <time class="date">{formatDate(item.createdAt)}</time>
+    {#if scheduledLabel}
+      <span
+        class="sched-chip"
+        class:overdue={scheduleOverdue}
+        class:past={schedulePast && !scheduleOverdue}
+        title="Scheduled · {scheduledLabel}"
+      >
+        <svg aria-hidden="true" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="3" y="4" width="18" height="18" rx="2"></rect>
+          <line x1="16" y1="2" x2="16" y2="6"></line>
+          <line x1="8" y1="2" x2="8" y2="6"></line>
+          <line x1="3" y1="10" x2="21" y2="10"></line>
+        </svg>
+        {scheduledLabel}
+      </span>
+    {/if}
   </footer>
 </article>
 
@@ -284,6 +305,36 @@
 
   .date {
     color: var(--text-muted);
+  }
+
+  /* Scheduled chip: the card wears its calendar time at a glance. */
+  .sched-chip {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.7rem;
+    color: var(--accent);
+    background: var(--accent-subtler);
+    border: 1px solid var(--accent-subtle-strong);
+    border-radius: 999px;
+    padding: 0.1rem 0.5rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+
+  .sched-chip.overdue {
+    color: var(--danger);
+    background: color-mix(in srgb, var(--danger) 8%, transparent);
+    border-color: color-mix(in srgb, var(--danger) 35%, transparent);
+  }
+
+  .sched-chip.past {
+    color: var(--text-muted);
+    background: var(--surface-tint);
+    border-color: var(--border);
   }
 
   .card-notes {

--- a/packages/web/src/components/InboxGrid.svelte
+++ b/packages/web/src/components/InboxGrid.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { InboxItem } from '@inbox-rs/rs-module';
   import { inview } from '../lib/actions';
-  import { connected, sortedItems } from '../lib/stores';
+  import { archivedItems, connected, sortedItems } from '../lib/stores';
   import InboxCard from './InboxCard.svelte';
 
   let {
@@ -12,6 +12,12 @@
     onconnect: () => void;
   } = $props();
   const items = $derived($sortedItems);
+
+  // Cards archived by adding them to a calendar. Collapsed by default,
+  // mirroring the Todos page's "N completed" pattern — same mental model:
+  // handled, out of the way, still reachable.
+  const archived = $derived($archivedItems);
+  let archivedExpanded = $state(false);
 
   // Incremental rendering: mount cards in pages of PAGE as the user scrolls,
   // instead of all at once. At a few thousand items, mounting every card up
@@ -68,6 +74,43 @@
   </div>
 {/if}
 
+{#if archived.length > 0}
+  <div class="archived-section">
+    <button
+      type="button"
+      class="archived-toggle"
+      aria-expanded={archivedExpanded}
+      onclick={() => (archivedExpanded = !archivedExpanded)}
+    >
+      <svg
+        aria-hidden="true"
+        class="archived-chevron"
+        class:open={archivedExpanded}
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <polyline points="9 18 15 12 9 6"></polyline>
+      </svg>
+      {archived.length} archived — on your calendar
+    </button>
+    {#if archivedExpanded}
+      <div class="grid-wrap">
+        <div class="grid archived-grid">
+          {#each archived as item (item.id)}
+            <InboxCard {item} {onselect} />
+          {/each}
+        </div>
+      </div>
+    {/if}
+  </div>
+{/if}
+
 <style>
   .status-bar {
     display: flex;
@@ -116,6 +159,49 @@
      before the user reaches the end of the rendered cards. */
   .load-sentinel {
     height: 1px;
+  }
+
+  /* ── Archived (on calendar) ──────────────────────────────────────────
+     Collapsed row mirroring the Todos page's "N completed" section. */
+  .archived-section {
+    margin-top: 1.5rem;
+  }
+
+  .archived-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin: 0 auto 0.75rem;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    font-family: inherit;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+  }
+
+  .archived-toggle:hover {
+    color: var(--text);
+    background: var(--surface-tint);
+  }
+
+  .archived-chevron {
+    transition: transform 0.15s;
+  }
+
+  .archived-chevron.open {
+    transform: rotate(90deg);
+  }
+
+  .archived-grid > :global(.card) {
+    opacity: 0.7;
+  }
+
+  .archived-grid > :global(.card:hover) {
+    opacity: 1;
   }
 
   @container (max-width: 760px) {

--- a/packages/web/src/components/InboxGrid.svelte
+++ b/packages/web/src/components/InboxGrid.svelte
@@ -30,6 +30,12 @@
   const PAGE = 60;
   let visibleCount = $state(PAGE);
   const visibleItems = $derived(items.slice(0, visibleCount));
+
+  // Same incremental-rendering safeguard for the archived section:
+  // expanding it must not mount every archived card (and queue every media
+  // fetch) in one update.
+  let archivedVisibleCount = $state(PAGE);
+  const visibleArchived = $derived(archived.slice(0, archivedVisibleCount));
 </script>
 
 {#if items.length === 0}
@@ -102,10 +108,24 @@
     {#if archivedExpanded}
       <div class="grid-wrap">
         <div class="grid archived-grid">
-          {#each archived as item (item.id)}
+          {#each visibleArchived as item (item.id)}
             <InboxCard {item} {onselect} />
           {/each}
         </div>
+        {#if archivedVisibleCount < archived.length}
+          {#key archivedVisibleCount}
+            <div
+              class="load-sentinel"
+              aria-hidden="true"
+              use:inview={() => {
+                archivedVisibleCount = Math.min(
+                  archivedVisibleCount + PAGE,
+                  archived.length,
+                );
+              }}
+            ></div>
+          {/key}
+        {/if}
       </div>
     {/if}
   </div>

--- a/packages/web/src/components/ScheduleSheet.svelte
+++ b/packages/web/src/components/ScheduleSheet.svelte
@@ -9,6 +9,7 @@
     clearSchedule,
     fromInputValues,
     nextRoundHour,
+    type PendingSchedule,
     quickOptions,
     toDateInputValue,
     toTimeInputValue,
@@ -31,21 +32,41 @@
 
   let {
     item,
+    subject,
+    initial = null,
+    onpick,
     onclose,
   }: {
-    item: InboxItem;
+    /** Persist mode: schedule an existing item (saves + posts directly). */
+    item?: InboxItem;
+    /** Pick mode context for a not-yet-created item (capture-time chips). */
+    subject?: { title?: string; isTodo?: boolean };
+    /** Pick mode: the previously chosen pending schedule, for re-editing. */
+    initial?: PendingSchedule | null;
+    /**
+     * Pick mode: return the choice instead of persisting — the caller
+     * applies it once the item exists (null = clear the pending schedule).
+     */
+    onpick?: (schedule: PendingSchedule | null) => void;
     /** Called after any successful action, and on plain dismissal. */
     onclose: () => void;
   } = $props();
 
-  const isTodoish = item.isTodo || item.type === 'todo';
+  const pickMode = !!onpick;
+  const displayTitle = item?.title ?? subject?.title ?? '';
+  const isTodoish = item
+    ? item.isTodo || item.type === 'todo'
+    : !!subject?.isTodo;
 
-  // ── Editable state, seeded from the item's current schedule ────────────
-  // (or from the prefilled guess: next round hour, 1 h, event/task by card
-  // kind — the fastest path is glance → confirm.)
-  const initialStart = item.startsAt ? new Date(item.startsAt) : nextRoundHour();
+  // ── Editable state, seeded from the item's current schedule (persist
+  // mode), the previously picked pending schedule (pick mode), or the
+  // prefilled guess: next round hour, 1 h, event/task by card kind — the
+  // fastest path is glance → confirm.
+  const initialStart = item?.startsAt
+    ? new Date(item.startsAt)
+    : (initial?.start ?? nextRoundHour());
   const initialDuration =
-    item.startsAt && item.endsAt
+    item?.startsAt && item.endsAt
       ? Math.max(
           1,
           Math.round(
@@ -54,27 +75,31 @@
               60_000,
           ),
         )
-      : 60;
+      : (initial?.durationMin ?? 60);
+  const initialAllDay = item ? !!item.allDay : !!initial?.allDay;
+  /** Whether something is already scheduled/picked — drives labels. */
+  const hasExisting = item ? !!item.startsAt : !!initial;
 
   let kind = $state<ScheduleKind>(
-    item.scheduleKind ?? (isTodoish ? 'task' : 'event'),
+    item?.scheduleKind ?? initial?.kind ?? (isTodoish ? 'task' : 'event'),
   );
   let dateStr = $state(toDateInputValue(initialStart));
-  let timeStr = $state(
-    item.allDay ? '' : toTimeInputValue(initialStart),
-  );
-  let allDay = $state(!!item.allDay);
+  let timeStr = $state(initialAllDay ? '' : toTimeInputValue(initialStart));
+  let allDay = $state(initialAllDay);
   let durationMin = $state(initialDuration);
   let saving = $state(false);
 
   // ── Destination calendar ───────────────────────────────────────────────
   // Already-posted entries open on their current home (even if hidden);
-  // otherwise last-used-per-kind → account default → first suitable.
-  const eventHome = choiceForEventUrl(item.eventUrl);
+  // otherwise the previously picked pending calendar, then
+  // last-used-per-kind → account default → first suitable.
+  const eventHome = choiceForEventUrl(item?.eventUrl);
   let selectedCalendarId = $state<string | undefined>(
     eventHome?.calendar.id ??
-      pickPreferredCalendar(item.scheduleKind ?? (isTodoish ? 'task' : 'event'))
-        ?.calendar.id,
+      initial?.calendarId ??
+      pickPreferredCalendar(
+        item?.scheduleKind ?? initial?.kind ?? (isTodoish ? 'task' : 'event'),
+      )?.calendar.id,
   );
   /** Once the user picks by hand, kind switches stop re-deriving the target. */
   let calendarTouched = $state(false);
@@ -92,7 +117,7 @@
 
   function setKind(next: ScheduleKind) {
     kind = next;
-    if (!calendarTouched && !item.eventUrl) {
+    if (!calendarTouched && !item?.eventUrl) {
       selectedCalendarId = pickPreferredCalendar(next)?.calendar.id;
     }
   }
@@ -129,7 +154,7 @@
   }
 
   function scheduledItem(): InboxItem | null {
-    if (!start) return null;
+    if (!item || !start) return null;
     return applySchedule(item, {
       kind,
       start,
@@ -158,6 +183,19 @@
    * and a toast explains; pressing the button again retries.
    */
   async function save() {
+    // Pick mode: hand the choice back — the caller applies it once the
+    // item exists (and posts it, via applyPendingSchedule).
+    if (pickMode) {
+      if (!start) return;
+      onpick?.({
+        kind,
+        start,
+        durationMin,
+        allDay: effectiveAllDay,
+        calendarId: willPost ? selectedChoice?.calendar.id : undefined,
+      });
+      return;
+    }
     const updated = scheduledItem();
     if (!updated) return;
     if (!(await persist(updated, 'Failed to save schedule'))) return;
@@ -198,6 +236,11 @@
    * the card and calendar don't silently diverge.
    */
   async function remove() {
+    if (pickMode) {
+      onpick?.(null);
+      return;
+    }
+    if (!item) return;
     if (item.eventUrl) {
       saving = true;
       try {
@@ -231,8 +274,10 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="overlay" role="dialog" aria-modal="true" aria-label="Schedule" onclick={() => { if (!saving) onclose(); }}>
   <div class="sheet" onclick={(e) => e.stopPropagation()}>
-    <h3 class="title">{item.startsAt ? 'Scheduled' : 'Add to calendar'}</h3>
-    <p class="ctx">{item.title || 'Untitled'}</p>
+    <h3 class="title">
+      {pickMode ? 'When?' : hasExisting ? 'Scheduled' : 'Add to calendar'}
+    </h3>
+    <p class="ctx">{displayTitle || 'Untitled'}</p>
 
     <div class="seg" role="radiogroup" aria-label="Entry kind">
       <button
@@ -347,18 +392,26 @@
     {/if}
 
     <button type="button" class="btn-primary" disabled={!canSave} onclick={save}>
-      {#if willPost}
-        {item.eventUrl ? 'Update event' : kind === 'task' ? 'Add task' : 'Add to calendar'}
+      {#if pickMode}
+        Set time
+      {:else if willPost}
+        {item?.eventUrl ? 'Update event' : kind === 'task' ? 'Add task' : 'Add to calendar'}
       {:else}
-        {item.startsAt ? 'Update schedule' : 'Schedule'}
+        {hasExisting ? 'Update schedule' : 'Schedule'}
       {/if}
     </button>
-    <button type="button" class="btn-ghost" disabled={!canSave} onclick={saveAndDownload}>
-      Save &amp; download .ics
-    </button>
-    {#if item.startsAt}
+    {#if !pickMode}
+      <button type="button" class="btn-ghost" disabled={!canSave} onclick={saveAndDownload}>
+        Save &amp; download .ics
+      </button>
+    {/if}
+    {#if hasExisting}
       <button type="button" class="btn-remove" disabled={saving} onclick={remove}>
-        {item.eventUrl ? 'Remove from calendar' : 'Remove schedule'}
+        {pickMode
+          ? 'Clear time'
+          : item?.eventUrl
+            ? 'Remove from calendar'
+            : 'Remove schedule'}
       </button>
     {/if}
   </div>

--- a/packages/web/src/components/ScheduleSheet.svelte
+++ b/packages/web/src/components/ScheduleSheet.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import type { InboxItem } from '@inbox-rs/rs-module';
-  import { storeItem } from '../lib/stores';
+  import { trapFocus } from '../lib/actions';
+  import { CaldavError } from '../lib/caldav';
   import { cleanForStorage } from '../lib/clean-for-storage';
-  import { showToast } from '../lib/toast';
-  import { downloadIcs } from '../lib/ics';
   import {
     applySchedule,
     clearSchedule,
@@ -11,26 +10,22 @@
     nextRoundHour,
     type PendingSchedule,
     quickOptions,
+    type ScheduleKind,
     toDateInputValue,
     toTimeInputValue,
-    type ScheduleKind,
   } from '../lib/schedule';
-  import {
-    calendarAccounts,
-    choiceForEventUrl,
-    findCalendarChoice,
-    pickPreferredCalendar,
-    type CalendarChoice,
-  } from '../lib/calendar-accounts';
-  import { trapFocus } from '../lib/actions';
-  import {
-    postScheduledItem,
-    recordCalendarUse,
-    removePostedEntry,
-  } from '../lib/schedule-sync';
-  import { CaldavError } from '../lib/caldav';
-  import CalendarPicker from './CalendarPicker.svelte';
+  import { postScheduledItem, removePostedEntry } from '../lib/schedule-sync';
+  import { choiceForEventUrl } from '../lib/calendar-accounts';
+  import { showToast } from '../lib/toast';
+  import { storeItem } from '../lib/stores';
 
+  /**
+   * The time sheet — deliberately calendar-free. Setting a time is card
+   * metadata (due dates, "this happens Friday"); adding the card to a
+   * calendar is a separate action (AddToCalendarSheet). The one link back:
+   * when the card is already ON a calendar, saving a time change silently
+   * updates the posted entry so the projection never drifts.
+   */
   let {
     item,
     subject,
@@ -38,7 +33,7 @@
     onpick,
     onclose,
   }: {
-    /** Persist mode: schedule an existing item (saves + posts directly). */
+    /** Persist mode: edit the time on an existing item. */
     item?: InboxItem;
     /** Pick mode context for a not-yet-created item (capture-time chips). */
     subject?: { title?: string; isTodo?: boolean };
@@ -78,7 +73,7 @@
         )
       : (initial?.durationMin ?? 60);
   const initialAllDay = item ? !!item.allDay : !!initial?.allDay;
-  /** Whether something is already scheduled/picked — drives labels. */
+  /** Whether a time is already set — drives titles and the remove action. */
   const hasExisting = item ? !!item.startsAt : !!initial;
 
   let kind = $state<ScheduleKind>(
@@ -89,45 +84,6 @@
   let allDay = $state(initialAllDay);
   let durationMin = $state(initialDuration);
   let saving = $state(false);
-
-  // ── Destination calendar ───────────────────────────────────────────────
-  // Already-posted entries open on their current home (even if hidden);
-  // otherwise the previously picked pending calendar, then
-  // last-used-per-kind → account default → first suitable.
-  const eventHome = choiceForEventUrl(item?.eventUrl);
-  let selectedCalendarId = $state<string | undefined>(
-    eventHome?.calendar.id ??
-      initial?.calendarId ??
-      pickPreferredCalendar(
-        item?.scheduleKind ?? initial?.kind ?? (isTodoish ? 'task' : 'event'),
-      )?.calendar.id,
-  );
-  /** Once the user picks by hand, kind switches stop re-deriving the target. */
-  let calendarTouched = $state(false);
-  let showCalendarPicker = $state(false);
-
-  const hasAccounts = $derived($calendarAccounts.length > 0);
-  const selectedChoice = $derived<CalendarChoice | undefined>(
-    findCalendarChoice(selectedCalendarId) ??
-      (eventHome?.calendar.id === selectedCalendarId ? eventHome : undefined),
-  );
-  const calendarSupportsKind = $derived(
-    !!selectedChoice?.calendar.components.includes(kind),
-  );
-  const willPost = $derived(hasAccounts && !!selectedChoice && calendarSupportsKind);
-
-  function setKind(next: ScheduleKind) {
-    kind = next;
-    if (!calendarTouched && !item?.eventUrl) {
-      selectedCalendarId = pickPreferredCalendar(next)?.calendar.id;
-    }
-  }
-
-  function handleCalendarPick(choice: CalendarChoice) {
-    selectedCalendarId = choice.calendar.id;
-    calendarTouched = true;
-    showCalendarPicker = false;
-  }
 
   const DURATIONS = [
     { label: '30 m', min: 30 },
@@ -164,7 +120,10 @@
     });
   }
 
-  async function persist(updated: InboxItem, failMessage: string): Promise<boolean> {
+  async function persist(
+    updated: InboxItem,
+    failMessage: string,
+  ): Promise<boolean> {
     saving = true;
     try {
       await storeItem(cleanForStorage(updated));
@@ -179,41 +138,32 @@
   }
 
   /**
-   * Save locally, then post to the chosen calendar when one is selected.
-   * Local-first: a failed post never loses the schedule — the card keeps it
-   * and a toast explains; pressing the button again retries.
+   * Save the time. When the card is already on a calendar, the posted entry
+   * is updated in the same gesture (local-first: a failed sync keeps the
+   * local time and toasts why — the projection catches up on the next save).
    */
   async function save() {
-    // Pick mode: hand the choice back — the caller applies it once the
-    // item exists (and posts it, via applyPendingSchedule).
     if (pickMode) {
       if (!start) return;
-      onpick?.({
-        kind,
-        start,
-        durationMin,
-        allDay: effectiveAllDay,
-        calendarId: willPost ? selectedChoice?.calendar.id : undefined,
-      });
+      onpick?.({ kind, start, durationMin, allDay: effectiveAllDay });
       return;
     }
     const updated = scheduledItem();
     if (!updated) return;
-    if (!(await persist(updated, 'Failed to save schedule'))) return;
-    if (willPost && selectedChoice) {
+    if (!(await persist(updated, 'Failed to save time'))) return;
+    const home = choiceForEventUrl(updated.eventUrl);
+    if (updated.eventUrl && home) {
       saving = true;
       try {
-        const posted = await postScheduledItem(
-          updated,
-          selectedChoice.calendar.id,
-        );
+        const posted = await postScheduledItem(updated, home.calendar.id);
         await storeItem(cleanForStorage(posted));
-        recordCalendarUse(kind, selectedChoice.calendar.id);
       } catch (err) {
-        console.error('Calendar post failed', err);
+        console.error('Calendar sync failed', err);
         const reason =
-          err instanceof CaldavError ? err.message : 'the calendar relay is unreachable';
-        showToast(`Saved locally — ${reason}`);
+          err instanceof CaldavError
+            ? err.message
+            : 'the calendar relay is unreachable';
+        showToast(`Time saved — calendar copy not updated: ${reason}`);
       } finally {
         saving = false;
       }
@@ -221,20 +171,10 @@
     onclose();
   }
 
-  /** Save (so chips reflect the schedule) and hand the user the .ics. */
-  async function saveAndDownload() {
-    const updated = scheduledItem();
-    if (!updated) return;
-    if (await persist(updated, 'Failed to save schedule')) {
-      downloadIcs(updated);
-      onclose();
-    }
-  }
-
   /**
-   * Removing the schedule also removes the posted calendar entry. If the
-   * server refuses (and the entry may still exist), keep the schedule so
-   * the card and calendar don't silently diverge.
+   * Removing the time also removes the posted calendar entry (an entry
+   * can't exist without its time). If the server refuses, keep everything
+   * so card and calendar don't silently diverge.
    */
   async function remove() {
     if (pickMode) {
@@ -249,22 +189,22 @@
       } catch (err) {
         console.error('Calendar delete failed', err);
         const reason =
-          err instanceof CaldavError ? err.message : 'the calendar relay is unreachable';
+          err instanceof CaldavError
+            ? err.message
+            : 'the calendar relay is unreachable';
         showToast(`Still on your calendar — ${reason}`);
         saving = false;
         return;
       }
       saving = false;
     }
-    if (await persist(clearSchedule(item), 'Failed to remove schedule')) {
+    if (await persist(clearSchedule(item), 'Failed to remove time')) {
       onclose();
     }
   }
 
   function handleEscape(e: KeyboardEvent) {
     if (e.key !== 'Escape' || saving) return;
-    // The calendar picker layers on top and closes itself first.
-    if (showCalendarPicker) return;
     onclose();
   }
 </script>
@@ -276,7 +216,7 @@
 <div class="overlay" role="dialog" aria-modal="true" aria-label="Schedule" onclick={() => { if (!saving) onclose(); }}>
   <div class="sheet" use:trapFocus onclick={(e) => e.stopPropagation()}>
     <h3 class="title">
-      {pickMode ? 'When?' : hasExisting ? 'Scheduled' : 'Add to calendar'}
+      {pickMode ? 'When?' : hasExisting ? 'Edit time' : 'Set time'}
     </h3>
     <p class="ctx">{displayTitle || 'Untitled'}</p>
 
@@ -287,7 +227,7 @@
         class:on={kind === 'event'}
         role="radio"
         aria-checked={kind === 'event'}
-        onclick={() => setKind('event')}
+        onclick={() => (kind = 'event')}
       >
         Event
       </button>
@@ -297,7 +237,7 @@
         class:on={kind === 'task'}
         role="radio"
         aria-checked={kind === 'task'}
-        onclick={() => setKind('task')}
+        onclick={() => (kind = 'task')}
       >
         Task
       </button>
@@ -370,68 +310,20 @@
       </label>
     {/if}
 
-    {#if hasAccounts}
-      <button
-        type="button"
-        class="zone"
-        onclick={() => (showCalendarPicker = true)}
-      >
-        {#if selectedChoice}
-          <span
-            class="dot"
-            style="background: {selectedChoice.calendar.color || 'var(--accent)'}"
-          ></span>
-          <span class="zone-name">{selectedChoice.calendar.name}</span>
-          <span class="zone-sub">· {selectedChoice.account.label}</span>
-        {:else}
-          <span class="zone-name muted">Choose calendar…</span>
-        {/if}
-        <svg class="chev" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <polyline points="6 9 12 15 18 9"></polyline>
-        </svg>
-      </button>
-      {#if selectedChoice && !calendarSupportsKind}
-        <p class="zone-warn">
-          {selectedChoice.calendar.name} doesn't support {kind}s — the
-          schedule stays on the card only.
-        </p>
-      {/if}
-    {/if}
-
     <button type="button" class="btn-primary" disabled={!canSave} onclick={save}>
-      {#if pickMode}
-        Set time
-      {:else if willPost}
-        {item?.eventUrl ? 'Update event' : kind === 'task' ? 'Add task' : 'Add to calendar'}
-      {:else}
-        {hasExisting ? 'Update schedule' : 'Schedule'}
-      {/if}
+      {pickMode ? 'Set time' : hasExisting ? 'Update time' : 'Set time'}
     </button>
-    {#if !pickMode}
-      <button type="button" class="btn-ghost" disabled={!canSave} onclick={saveAndDownload}>
-        Save &amp; download .ics
-      </button>
-    {/if}
     {#if hasExisting}
       <button type="button" class="btn-remove" disabled={saving} onclick={remove}>
         {pickMode
           ? 'Clear time'
           : item?.eventUrl
-            ? 'Remove from calendar'
-            : 'Remove schedule'}
+            ? 'Remove time & calendar entry'
+            : 'Remove time'}
       </button>
     {/if}
   </div>
 </div>
-
-{#if showCalendarPicker}
-  <CalendarPicker
-    {kind}
-    selectedId={selectedCalendarId}
-    onpick={handleCalendarPick}
-    onclose={() => (showCalendarPicker = false)}
-  />
-{/if}
 
 <style>
   .overlay {
@@ -585,68 +477,6 @@
     accent-color: var(--accent);
   }
 
-  /* Destination calendar zone — the location-chip idiom from filing. */
-  .zone {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    width: 100%;
-    margin-top: 0.85rem;
-    border: 1px solid var(--border);
-    background: var(--bg);
-    border-radius: 10px;
-    padding: 0.5rem 0.65rem;
-    font-family: inherit;
-    font-size: 0.82rem;
-    color: var(--text);
-    cursor: pointer;
-    transition: border-color 0.15s;
-    text-align: left;
-  }
-
-  .zone:hover {
-    border-color: var(--accent);
-  }
-
-  .zone .dot {
-    width: 9px;
-    height: 9px;
-    border-radius: 50%;
-    flex-shrink: 0;
-  }
-
-  .zone-name {
-    font-weight: 550;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .zone-name.muted {
-    color: var(--text-muted);
-    font-weight: 400;
-  }
-
-  .zone-sub {
-    font-size: 0.7rem;
-    color: var(--text-muted);
-    flex-shrink: 0;
-  }
-
-  .zone .chev {
-    margin-left: auto;
-    color: var(--text-muted);
-    flex-shrink: 0;
-  }
-
-  .zone-warn {
-    margin-top: 0.4rem;
-    font-size: 0.72rem;
-    color: var(--text-muted);
-    line-height: 1.4;
-  }
-
   .btn-primary {
     display: block;
     width: 100%;
@@ -672,14 +502,13 @@
     cursor: default;
   }
 
-  .btn-ghost,
   .btn-remove {
     display: block;
     width: 100%;
     margin-top: 0.35rem;
     background: none;
     border: none;
-    color: var(--text-muted);
+    color: var(--danger);
     padding: 0.4rem;
     font-size: 0.78rem;
     font-family: inherit;
@@ -687,20 +516,10 @@
     border-radius: var(--radius-sm);
   }
 
-  .btn-ghost:hover:not(:disabled) {
-    color: var(--text);
-    background: var(--surface-hover);
-  }
-
-  .btn-remove {
-    color: var(--danger);
-  }
-
   .btn-remove:hover:not(:disabled) {
     background: color-mix(in srgb, var(--danger) 10%, transparent);
   }
 
-  .btn-ghost:disabled,
   .btn-remove:disabled {
     opacity: 0.5;
     cursor: default;

--- a/packages/web/src/components/ScheduleSheet.svelte
+++ b/packages/web/src/components/ScheduleSheet.svelte
@@ -1,0 +1,450 @@
+<script lang="ts">
+  import type { InboxItem } from '@inbox-rs/rs-module';
+  import { storeItem } from '../lib/stores';
+  import { cleanForStorage } from '../lib/clean-for-storage';
+  import { showToast } from '../lib/toast';
+  import { downloadIcs } from '../lib/ics';
+  import {
+    applySchedule,
+    clearSchedule,
+    fromInputValues,
+    nextRoundHour,
+    quickOptions,
+    toDateInputValue,
+    toTimeInputValue,
+    type ScheduleKind,
+  } from '../lib/schedule';
+
+  let {
+    item,
+    onclose,
+  }: {
+    item: InboxItem;
+    /** Called after any successful action, and on plain dismissal. */
+    onclose: () => void;
+  } = $props();
+
+  const isTodoish = item.isTodo || item.type === 'todo';
+
+  // ── Editable state, seeded from the item's current schedule ────────────
+  // (or from the prefilled guess: next round hour, 1 h, event/task by card
+  // kind — the fastest path is glance → confirm.)
+  const initialStart = item.startsAt ? new Date(item.startsAt) : nextRoundHour();
+  const initialDuration =
+    item.startsAt && item.endsAt
+      ? Math.max(
+          1,
+          Math.round(
+            (new Date(item.endsAt).getTime() -
+              new Date(item.startsAt).getTime()) /
+              60_000,
+          ),
+        )
+      : 60;
+
+  let kind = $state<ScheduleKind>(
+    item.scheduleKind ?? (isTodoish ? 'task' : 'event'),
+  );
+  let dateStr = $state(toDateInputValue(initialStart));
+  let timeStr = $state(
+    item.allDay ? '' : toTimeInputValue(initialStart),
+  );
+  let allDay = $state(!!item.allDay);
+  let durationMin = $state(initialDuration);
+  let saving = $state(false);
+
+  const DURATIONS = [
+    { label: '30 m', min: 30 },
+    { label: '1 h', min: 60 },
+    { label: '2 h', min: 120 },
+  ];
+
+  const quick = quickOptions();
+
+  const start = $derived(fromInputValues(dateStr, allDay ? '' : timeStr));
+  // Tasks may be date-only ("sometime that day") — that's all-day semantics.
+  const effectiveAllDay = $derived(allDay || (kind === 'task' && !timeStr));
+  const canSave = $derived(!!start && !saving);
+
+  /** Quick chips highlight when they match the current selection exactly. */
+  function isQuickSelected(optStart: Date): boolean {
+    if (allDay || !start) return false;
+    return start.getTime() === optStart.getTime();
+  }
+
+  function pickQuick(optStart: Date) {
+    allDay = false;
+    dateStr = toDateInputValue(optStart);
+    timeStr = toTimeInputValue(optStart);
+  }
+
+  function scheduledItem(): InboxItem | null {
+    if (!start) return null;
+    return applySchedule(item, {
+      kind,
+      start,
+      durationMin,
+      allDay: effectiveAllDay,
+    });
+  }
+
+  async function persist(updated: InboxItem, failMessage: string): Promise<boolean> {
+    saving = true;
+    try {
+      await storeItem(cleanForStorage(updated));
+      return true;
+    } catch (err) {
+      console.error(failMessage, err);
+      showToast(failMessage);
+      return false;
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function save() {
+    const updated = scheduledItem();
+    if (!updated) return;
+    if (await persist(updated, 'Failed to save schedule')) onclose();
+  }
+
+  /** Save (so chips reflect the schedule) and hand the user the .ics. */
+  async function saveAndDownload() {
+    const updated = scheduledItem();
+    if (!updated) return;
+    if (await persist(updated, 'Failed to save schedule')) {
+      downloadIcs(updated);
+      onclose();
+    }
+  }
+
+  async function remove() {
+    if (await persist(clearSchedule(item), 'Failed to remove schedule')) {
+      onclose();
+    }
+  }
+
+  function handleEscape(e: KeyboardEvent) {
+    if (e.key !== 'Escape' || saving) return;
+    onclose();
+  }
+</script>
+
+<svelte:window onkeydown={handleEscape} />
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" role="dialog" aria-modal="true" aria-label="Schedule" onclick={() => { if (!saving) onclose(); }}>
+  <div class="sheet" onclick={(e) => e.stopPropagation()}>
+    <h3 class="title">{item.startsAt ? 'Scheduled' : 'Add to calendar'}</h3>
+    <p class="ctx">{item.title || 'Untitled'}</p>
+
+    <div class="seg" role="radiogroup" aria-label="Entry kind">
+      <button
+        type="button"
+        class="seg-btn"
+        class:on={kind === 'event'}
+        role="radio"
+        aria-checked={kind === 'event'}
+        onclick={() => (kind = 'event')}
+      >
+        Event
+      </button>
+      <button
+        type="button"
+        class="seg-btn"
+        class:on={kind === 'task'}
+        role="radio"
+        aria-checked={kind === 'task'}
+        onclick={() => (kind = 'task')}
+      >
+        Task
+      </button>
+    </div>
+
+    {#if quick.length > 0}
+      <div class="chips">
+        {#each quick as opt (opt.label)}
+          <button
+            type="button"
+            class="chip"
+            class:sel={isQuickSelected(opt.start)}
+            onclick={() => pickQuick(opt.start)}
+          >
+            {opt.label}
+          </button>
+        {/each}
+      </div>
+    {/if}
+
+    <span class="flabel" id="sched-when">{kind === 'task' ? 'Due' : 'Date & time'}</span>
+    <div class="inputrow" aria-labelledby="sched-when">
+      <input type="date" class="input" bind:value={dateStr} />
+      {#if !allDay}
+        <input
+          type="time"
+          class="input time"
+          bind:value={timeStr}
+          placeholder={kind === 'task' ? 'time?' : undefined}
+        />
+      {/if}
+    </div>
+
+    {#if kind === 'event'}
+      <span class="flabel">Duration</span>
+      <div class="chips">
+        {#each DURATIONS as d (d.min)}
+          <button
+            type="button"
+            class="chip"
+            class:sel={!allDay && durationMin === d.min}
+            disabled={allDay}
+            onclick={() => {
+              allDay = false;
+              durationMin = d.min;
+            }}
+          >
+            {d.label}
+          </button>
+        {/each}
+        <button
+          type="button"
+          class="chip"
+          class:sel={allDay}
+          onclick={() => (allDay = !allDay)}
+        >
+          All-day
+        </button>
+      </div>
+    {:else}
+      <label class="allday-row">
+        <input type="checkbox" bind:checked={allDay} />
+        No specific time — due sometime that day
+      </label>
+    {/if}
+
+    <button type="button" class="btn-primary" disabled={!canSave} onclick={save}>
+      {item.startsAt ? 'Update schedule' : 'Schedule'}
+    </button>
+    <button type="button" class="btn-ghost" disabled={!canSave} onclick={saveAndDownload}>
+      Save &amp; download .ics
+    </button>
+    {#if item.startsAt}
+      <button type="button" class="btn-remove" disabled={saving} onclick={remove}>
+        Remove schedule
+      </button>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--overlay);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    z-index: 200;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+  }
+
+  .sheet {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.25rem;
+    max-width: 380px;
+    width: 100%;
+    box-shadow: 0 12px 40px var(--shadow);
+  }
+
+  .title {
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  .ctx {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    margin-bottom: 0.85rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* Event / Task segmented control */
+  .seg {
+    display: flex;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 3px;
+    margin-bottom: 0.85rem;
+  }
+
+  .seg-btn {
+    flex: 1;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    font-family: inherit;
+    padding: 0.32rem;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+
+  .seg-btn.on {
+    background: var(--accent);
+    color: white;
+    font-weight: 600;
+  }
+
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .chip {
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--text);
+    border-radius: 999px;
+    padding: 0.28rem 0.7rem;
+    font-size: 0.78rem;
+    font-family: inherit;
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+  }
+
+  .chip:hover:not(:disabled) {
+    border-color: var(--accent);
+  }
+
+  .chip.sel {
+    border-color: var(--accent);
+    background: var(--accent-subtle);
+    color: var(--accent);
+  }
+
+  .chip:disabled {
+    opacity: 0.45;
+    cursor: default;
+  }
+
+  .flabel {
+    display: block;
+    font-size: 0.68rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 550;
+    margin: 0.85rem 0 0.35rem;
+  }
+
+  .inputrow {
+    display: flex;
+    gap: 0.45rem;
+  }
+
+  .input {
+    flex: 1;
+    min-width: 0;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.42rem 0.55rem;
+    /* ≥1rem: form controls below 1rem trigger iOS Safari focus-zoom
+       (see AGENTS.md → "Form controls: never below 1rem"). */
+    font-size: 1rem;
+    font-family: inherit;
+    color: var(--text);
+    color-scheme: dark light;
+  }
+
+  .input.time {
+    flex: 0.6;
+  }
+
+  .input:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+
+  .allday-row {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin-top: 0.7rem;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+
+  .allday-row input {
+    accent-color: var(--accent);
+  }
+
+  .btn-primary {
+    display: block;
+    width: 100%;
+    margin-top: 1rem;
+    background: var(--accent);
+    border: none;
+    color: white;
+    padding: 0.55rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.88rem;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  .btn-primary:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .btn-ghost,
+  .btn-remove {
+    display: block;
+    width: 100%;
+    margin-top: 0.35rem;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    padding: 0.4rem;
+    font-size: 0.78rem;
+    font-family: inherit;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+  }
+
+  .btn-ghost:hover:not(:disabled) {
+    color: var(--text);
+    background: var(--surface-hover);
+  }
+
+  .btn-remove {
+    color: var(--danger);
+  }
+
+  .btn-remove:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--danger) 10%, transparent);
+  }
+
+  .btn-ghost:disabled,
+  .btn-remove:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+</style>

--- a/packages/web/src/components/ScheduleSheet.svelte
+++ b/packages/web/src/components/ScheduleSheet.svelte
@@ -14,6 +14,20 @@
     toTimeInputValue,
     type ScheduleKind,
   } from '../lib/schedule';
+  import {
+    calendarAccounts,
+    choiceForEventUrl,
+    findCalendarChoice,
+    pickPreferredCalendar,
+    type CalendarChoice,
+  } from '../lib/calendar-accounts';
+  import {
+    postScheduledItem,
+    recordCalendarUse,
+    removePostedEntry,
+  } from '../lib/schedule-sync';
+  import { CaldavError } from '../lib/caldav';
+  import CalendarPicker from './CalendarPicker.svelte';
 
   let {
     item,
@@ -52,6 +66,42 @@
   let allDay = $state(!!item.allDay);
   let durationMin = $state(initialDuration);
   let saving = $state(false);
+
+  // ── Destination calendar ───────────────────────────────────────────────
+  // Already-posted entries open on their current home (even if hidden);
+  // otherwise last-used-per-kind → account default → first suitable.
+  const eventHome = choiceForEventUrl(item.eventUrl);
+  let selectedCalendarId = $state<string | undefined>(
+    eventHome?.calendar.id ??
+      pickPreferredCalendar(item.scheduleKind ?? (isTodoish ? 'task' : 'event'))
+        ?.calendar.id,
+  );
+  /** Once the user picks by hand, kind switches stop re-deriving the target. */
+  let calendarTouched = $state(false);
+  let showCalendarPicker = $state(false);
+
+  const hasAccounts = $derived($calendarAccounts.length > 0);
+  const selectedChoice = $derived<CalendarChoice | undefined>(
+    findCalendarChoice(selectedCalendarId) ??
+      (eventHome?.calendar.id === selectedCalendarId ? eventHome : undefined),
+  );
+  const calendarSupportsKind = $derived(
+    !!selectedChoice?.calendar.components.includes(kind),
+  );
+  const willPost = $derived(hasAccounts && !!selectedChoice && calendarSupportsKind);
+
+  function setKind(next: ScheduleKind) {
+    kind = next;
+    if (!calendarTouched && !item.eventUrl) {
+      selectedCalendarId = pickPreferredCalendar(next)?.calendar.id;
+    }
+  }
+
+  function handleCalendarPick(choice: CalendarChoice) {
+    selectedCalendarId = choice.calendar.id;
+    calendarTouched = true;
+    showCalendarPicker = false;
+  }
 
   const DURATIONS = [
     { label: '30 m', min: 30 },
@@ -102,10 +152,34 @@
     }
   }
 
+  /**
+   * Save locally, then post to the chosen calendar when one is selected.
+   * Local-first: a failed post never loses the schedule — the card keeps it
+   * and a toast explains; pressing the button again retries.
+   */
   async function save() {
     const updated = scheduledItem();
     if (!updated) return;
-    if (await persist(updated, 'Failed to save schedule')) onclose();
+    if (!(await persist(updated, 'Failed to save schedule'))) return;
+    if (willPost && selectedChoice) {
+      saving = true;
+      try {
+        const posted = await postScheduledItem(
+          updated,
+          selectedChoice.calendar.id,
+        );
+        await storeItem(cleanForStorage(posted));
+        recordCalendarUse(kind, selectedChoice.calendar.id);
+      } catch (err) {
+        console.error('Calendar post failed', err);
+        const reason =
+          err instanceof CaldavError ? err.message : 'the calendar relay is unreachable';
+        showToast(`Saved locally — ${reason}`);
+      } finally {
+        saving = false;
+      }
+    }
+    onclose();
   }
 
   /** Save (so chips reflect the schedule) and hand the user the .ics. */
@@ -118,7 +192,26 @@
     }
   }
 
+  /**
+   * Removing the schedule also removes the posted calendar entry. If the
+   * server refuses (and the entry may still exist), keep the schedule so
+   * the card and calendar don't silently diverge.
+   */
   async function remove() {
+    if (item.eventUrl) {
+      saving = true;
+      try {
+        await removePostedEntry(item);
+      } catch (err) {
+        console.error('Calendar delete failed', err);
+        const reason =
+          err instanceof CaldavError ? err.message : 'the calendar relay is unreachable';
+        showToast(`Still on your calendar — ${reason}`);
+        saving = false;
+        return;
+      }
+      saving = false;
+    }
     if (await persist(clearSchedule(item), 'Failed to remove schedule')) {
       onclose();
     }
@@ -126,6 +219,8 @@
 
   function handleEscape(e: KeyboardEvent) {
     if (e.key !== 'Escape' || saving) return;
+    // The calendar picker layers on top and closes itself first.
+    if (showCalendarPicker) return;
     onclose();
   }
 </script>
@@ -146,7 +241,7 @@
         class:on={kind === 'event'}
         role="radio"
         aria-checked={kind === 'event'}
-        onclick={() => (kind = 'event')}
+        onclick={() => setKind('event')}
       >
         Event
       </button>
@@ -156,7 +251,7 @@
         class:on={kind === 'task'}
         role="radio"
         aria-checked={kind === 'task'}
-        onclick={() => (kind = 'task')}
+        onclick={() => setKind('task')}
       >
         Task
       </button>
@@ -223,19 +318,60 @@
       </label>
     {/if}
 
+    {#if hasAccounts}
+      <button
+        type="button"
+        class="zone"
+        onclick={() => (showCalendarPicker = true)}
+      >
+        {#if selectedChoice}
+          <span
+            class="dot"
+            style="background: {selectedChoice.calendar.color || 'var(--accent)'}"
+          ></span>
+          <span class="zone-name">{selectedChoice.calendar.name}</span>
+          <span class="zone-sub">· {selectedChoice.account.label}</span>
+        {:else}
+          <span class="zone-name muted">Choose calendar…</span>
+        {/if}
+        <svg class="chev" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="6 9 12 15 18 9"></polyline>
+        </svg>
+      </button>
+      {#if selectedChoice && !calendarSupportsKind}
+        <p class="zone-warn">
+          {selectedChoice.calendar.name} doesn't support {kind}s — the
+          schedule stays on the card only.
+        </p>
+      {/if}
+    {/if}
+
     <button type="button" class="btn-primary" disabled={!canSave} onclick={save}>
-      {item.startsAt ? 'Update schedule' : 'Schedule'}
+      {#if willPost}
+        {item.eventUrl ? 'Update event' : kind === 'task' ? 'Add task' : 'Add to calendar'}
+      {:else}
+        {item.startsAt ? 'Update schedule' : 'Schedule'}
+      {/if}
     </button>
     <button type="button" class="btn-ghost" disabled={!canSave} onclick={saveAndDownload}>
       Save &amp; download .ics
     </button>
     {#if item.startsAt}
       <button type="button" class="btn-remove" disabled={saving} onclick={remove}>
-        Remove schedule
+        {item.eventUrl ? 'Remove from calendar' : 'Remove schedule'}
       </button>
     {/if}
   </div>
 </div>
+
+{#if showCalendarPicker}
+  <CalendarPicker
+    {kind}
+    selectedId={selectedCalendarId}
+    onpick={handleCalendarPick}
+    onclose={() => (showCalendarPicker = false)}
+  />
+{/if}
 
 <style>
   .overlay {
@@ -387,6 +523,68 @@
 
   .allday-row input {
     accent-color: var(--accent);
+  }
+
+  /* Destination calendar zone — the location-chip idiom from filing. */
+  .zone {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    margin-top: 0.85rem;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 10px;
+    padding: 0.5rem 0.65rem;
+    font-family: inherit;
+    font-size: 0.82rem;
+    color: var(--text);
+    cursor: pointer;
+    transition: border-color 0.15s;
+    text-align: left;
+  }
+
+  .zone:hover {
+    border-color: var(--accent);
+  }
+
+  .zone .dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .zone-name {
+    font-weight: 550;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .zone-name.muted {
+    color: var(--text-muted);
+    font-weight: 400;
+  }
+
+  .zone-sub {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .zone .chev {
+    margin-left: auto;
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .zone-warn {
+    margin-top: 0.4rem;
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    line-height: 1.4;
   }
 
   .btn-primary {

--- a/packages/web/src/components/ScheduleSheet.svelte
+++ b/packages/web/src/components/ScheduleSheet.svelte
@@ -167,6 +167,13 @@
       } finally {
         saving = false;
       }
+    } else if (updated.eventUrl) {
+      // Posted, but its calendar account is gone (removed in settings) —
+      // the doc contract says a skipped sync must say why.
+      console.error('Calendar sync skipped: no account for', updated.eventUrl);
+      showToast(
+        'Time saved — calendar copy not updated: its calendar account was removed',
+      );
     }
     onclose();
   }

--- a/packages/web/src/components/ScheduleSheet.svelte
+++ b/packages/web/src/components/ScheduleSheet.svelte
@@ -22,6 +22,7 @@
     pickPreferredCalendar,
     type CalendarChoice,
   } from '../lib/calendar-accounts';
+  import { trapFocus } from '../lib/actions';
   import {
     postScheduledItem,
     recordCalendarUse,
@@ -273,7 +274,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="overlay" role="dialog" aria-modal="true" aria-label="Schedule" onclick={() => { if (!saving) onclose(); }}>
-  <div class="sheet" onclick={(e) => e.stopPropagation()}>
+  <div class="sheet" use:trapFocus onclick={(e) => e.stopPropagation()}>
     <h3 class="title">
       {pickMode ? 'When?' : hasExisting ? 'Scheduled' : 'Add to calendar'}
     </h3>
@@ -317,14 +318,20 @@
       </div>
     {/if}
 
-    <span class="flabel" id="sched-when">{kind === 'task' ? 'Due' : 'Date & time'}</span>
-    <div class="inputrow" aria-labelledby="sched-when">
-      <input type="date" class="input" bind:value={dateStr} />
+    <span class="flabel">{kind === 'task' ? 'Due' : 'Date & time'}</span>
+    <div class="inputrow">
+      <input
+        type="date"
+        class="input"
+        bind:value={dateStr}
+        aria-label={kind === 'task' ? 'Due date' : 'Date'}
+      />
       {#if !allDay}
         <input
           type="time"
           class="input time"
           bind:value={timeStr}
+          aria-label={kind === 'task' ? 'Due time (optional)' : 'Time'}
           placeholder={kind === 'task' ? 'time?' : undefined}
         />
       {/if}

--- a/packages/web/src/components/TodoQuickAdd.svelte
+++ b/packages/web/src/components/TodoQuickAdd.svelte
@@ -183,10 +183,12 @@
     if (!canCaptureTodo(quickTitle) || quickSaving) return;
     quickSaving = true;
     quickError = '';
-    // storeItem creates the todo; the move is a second step. Track the boundary
-    // so a move failure doesn't leave the title around to be re-submitted — that
-    // would store a duplicate unfiled todo on retry.
+    // storeItem creates the todo; filing and scheduling are follow-up steps.
+    // Track each boundary so the error names the stage that actually failed —
+    // and so a failure never leaves the title around to be re-submitted,
+    // which would store a duplicate todo on retry.
     let created = false;
+    let filed = false;
     try {
       const todo = makeUnfiledTodo(quickTitle);
       await storeItem(todo);
@@ -197,6 +199,7 @@
         await moveItemToCollection(todo.id, targetCollectionId);
         notifyIfOutOfView(targetCollectionId);
       }
+      filed = true;
       if (pendingSchedule) {
         // Apply after the move so the stored item keeps its collectionId.
         // Posts to the picked calendar best-effort (local-first, toasts on
@@ -207,16 +210,20 @@
             : todo,
           pendingSchedule,
         );
-        pendingSchedule = null;
       }
     } catch (error) {
       console.error('Failed to add todo', error);
-      quickError = created
-        ? 'Todo added, but filing it into the collection failed.'
-        : error instanceof Error
-          ? error.message
-          : 'Failed to add todo';
+      quickError = filed
+        ? 'Todo added, but saving its schedule failed.'
+        : created
+          ? 'Todo added, but filing it into the collection failed.'
+          : error instanceof Error
+            ? error.message
+            : 'Failed to add todo';
     } finally {
+      // The pending time belongs to the todo just created (even when a
+      // follow-up step failed) — never let it leak onto the next capture.
+      if (created) pendingSchedule = null;
       quickSaving = false;
       // Return focus so the user can keep capturing; tick() lets a hero→compact
       // remount settle before refocusing the (new) element.

--- a/packages/web/src/components/TodoQuickAdd.svelte
+++ b/packages/web/src/components/TodoQuickAdd.svelte
@@ -16,7 +16,10 @@
   import { modLabel } from '../lib/platform';
   import { showToast } from '../lib/toast';
   import type { FilingSubject } from '../lib/collection-suggest';
+  import { formatScheduled, type PendingSchedule } from '../lib/schedule';
+  import { applyPendingSchedule } from '../lib/schedule-sync';
   import CollectionPicker from './CollectionPicker.svelte';
+  import ScheduleSheet from './ScheduleSheet.svelte';
   import {
     activeGroupIds,
     collections,
@@ -122,6 +125,25 @@
   // ── Destination picker (shared CollectionPicker, chip trigger) ─────────
   let pickerOpen = $state(false);
 
+  // ── Optional capture-time schedule ("When?" chip → ScheduleSheet) ──────
+  let pendingSchedule = $state<PendingSchedule | null>(null);
+  let scheduleOpen = $state(false);
+
+  const whenLabel = $derived(
+    pendingSchedule
+      ? formatScheduled({
+          startsAt: pendingSchedule.start.toISOString(),
+          allDay: pendingSchedule.allDay,
+        })
+      : 'When?',
+  );
+
+  function handleSchedulePick(schedule: PendingSchedule | null) {
+    pendingSchedule = schedule;
+    scheduleOpen = false;
+    quickInputEl?.focus();
+  }
+
   /** Chip display parts for the current quick-add destination. */
   const chip = $derived.by(() => {
     const col = quickAddCollectionId
@@ -174,6 +196,18 @@
       if (targetCollectionId) {
         await moveItemToCollection(todo.id, targetCollectionId);
         notifyIfOutOfView(targetCollectionId);
+      }
+      if (pendingSchedule) {
+        // Apply after the move so the stored item keeps its collectionId.
+        // Posts to the picked calendar best-effort (local-first, toasts on
+        // failure) — see applyPendingSchedule.
+        await applyPendingSchedule(
+          targetCollectionId
+            ? { ...todo, collectionId: targetCollectionId }
+            : todo,
+          pendingSchedule,
+        );
+        pendingSchedule = null;
       }
     } catch (error) {
       console.error('Failed to add todo', error);
@@ -289,6 +323,34 @@
       </svg>
     </button>
   {/if}
+  <button
+    type="button"
+    class="quick-add__when"
+    class:has-time={!!pendingSchedule}
+    aria-label="Set a time"
+    aria-haspopup="dialog"
+    aria-expanded={scheduleOpen}
+    disabled={quickSaving}
+    onclick={() => (scheduleOpen = true)}
+  >
+    <svg
+      aria-hidden="true"
+      width="13"
+      height="13"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <rect x="3" y="4" width="18" height="18" rx="2"></rect>
+      <line x1="16" y1="2" x2="16" y2="6"></line>
+      <line x1="8" y1="2" x2="8" y2="6"></line>
+      <line x1="3" y1="10" x2="21" y2="10"></line>
+    </svg>
+    <span class="chip-name">{whenLabel}</span>
+  </button>
   <button type="submit" disabled={!canCaptureTodo(quickTitle) || quickSaving}>
     {quickSaving ? 'Adding...' : 'Add'}
   </button>
@@ -312,19 +374,28 @@
   />
 {/if}
 
+{#if scheduleOpen}
+  <ScheduleSheet
+    subject={{ title: quickTitle, isTodo: true }}
+    initial={pendingSchedule}
+    onpick={handleSchedulePick}
+    onclose={() => (scheduleOpen = false)}
+  />
+{/if}
+
 <style>
   .quick-add {
     /* Full width so the input matches the rows below it; no jump between the
-       empty and populated states. */
+       empty and populated states. Column auto-flow lets the chip set vary
+       (destination chip hidden for fixed collections, When chip always)
+       without enumerating template columns per variant. */
     width: 100%;
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto auto;
+    grid-auto-flow: column;
+    grid-template-columns: minmax(0, 1fr);
+    grid-auto-columns: auto;
     gap: 0.5rem;
     align-items: center;
-  }
-
-  .quick-add--no-select {
-    grid-template-columns: minmax(0, 1fr) auto;
   }
 
   .quick-add--compact {
@@ -449,6 +520,47 @@
     min-height: 2.25rem;
     /* Keep >=1rem (inherited) so iOS Safari doesn't auto-zoom on focus — the
        guideline forbids sub-1rem font-size on form controls. */
+  }
+
+  /* "When?" chip — same chrome as the destination chip; accent-tinted once
+     a time is set so the pending schedule reads at a glance. */
+  .quick-add button.quick-add__when {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: 2.75rem;
+    max-width: 11rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text-muted);
+    padding: 0 0.7rem;
+    font: inherit;
+    font-weight: 400;
+    cursor: pointer;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+    transition: border-color 150ms, color 150ms, box-shadow 150ms;
+  }
+
+  .quick-add button.quick-add__when:hover:not(:disabled) {
+    border-color: var(--accent);
+    transform: none;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  }
+
+  .quick-add button.quick-add__when:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+  }
+
+  .quick-add button.quick-add__when.has-time {
+    border-color: var(--accent-subtle-strong);
+    background: var(--accent-subtler);
+    color: var(--accent);
+  }
+
+  .quick-add--compact button.quick-add__when {
+    min-height: 2.25rem;
   }
 
   .quick-error {

--- a/packages/web/src/components/TodoQuickAdd.svelte
+++ b/packages/web/src/components/TodoQuickAdd.svelte
@@ -327,7 +327,9 @@
     type="button"
     class="quick-add__when"
     class:has-time={!!pendingSchedule}
-    aria-label="Set a time"
+    aria-label={pendingSchedule
+      ? `Scheduled ${whenLabel} — change time`
+      : 'Set a time'}
     aria-haspopup="dialog"
     aria-expanded={scheduleOpen}
     disabled={quickSaving}

--- a/packages/web/src/components/TodoRow.svelte
+++ b/packages/web/src/components/TodoRow.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { InboxItem, Collection, CollectionGroup } from '@inbox-rs/rs-module';
-  import { storeItem } from '../lib/stores';
-  import { cleanForStorage } from '../lib/clean-for-storage';
+  import { setItemCompleted } from '../lib/schedule-sync';
   import { typeIconPath } from '../lib/item-utils';
   import { draggingItemId, DRAG_MIME } from '../lib/drag';
   import { formatScheduled, isOverdue } from '../lib/schedule';
@@ -61,15 +60,10 @@
 
   async function toggleCompleted(e: Event) {
     e.stopPropagation();
-    const nowCompleted = !todo.completed;
-    const updated = {
-      ...todo,
-      isTodo: true,
-      completed: nowCompleted,
-      completedAt: nowCompleted ? new Date().toISOString() : undefined,
-    };
     try {
-      await storeItem(cleanForStorage(updated) as InboxItem);
+      // Shared helper: local flip + best-effort calendar sync for scheduled
+      // tasks (STATUS:COMPLETED on the posted VTODO).
+      await setItemCompleted(todo, !todo.completed);
     } catch (err) {
       console.error('Failed to update todo:', err);
       // Checkbox reverts on next render because the `todo` prop is unchanged

--- a/packages/web/src/components/TodoRow.svelte
+++ b/packages/web/src/components/TodoRow.svelte
@@ -4,6 +4,7 @@
   import { cleanForStorage } from '../lib/clean-for-storage';
   import { typeIconPath } from '../lib/item-utils';
   import { draggingItemId, DRAG_MIME } from '../lib/drag';
+  import { formatScheduled, isOverdue } from '../lib/schedule';
 
   let { todo, collection, group, onselect, onaddincollection }: {
     todo: InboxItem;
@@ -54,6 +55,9 @@
 
   const createdLabel = $derived(formatRelative(todo.createdAt));
   const createdTitle = $derived(new Date(todo.createdAt).toLocaleString());
+
+  const scheduledLabel = $derived(todo.startsAt ? formatScheduled(todo) : '');
+  const scheduleOverdue = $derived(isOverdue(todo));
 
   async function toggleCompleted(e: Event) {
     e.stopPropagation();
@@ -149,6 +153,17 @@
   <!-- The meta block collapses to line 2 on narrow screens via CSS;
        on desktop it sits inline on the right side of the row. -->
   <div class="meta">
+    {#if scheduledLabel}
+      <span class="sched-chip" class:overdue={scheduleOverdue} title="Scheduled · {scheduledLabel}">
+        <svg aria-hidden="true" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="3" y="4" width="18" height="18" rx="2"></rect>
+          <line x1="16" y1="2" x2="16" y2="6"></line>
+          <line x1="8" y1="2" x2="8" y2="6"></line>
+          <line x1="3" y1="10" x2="21" y2="10"></line>
+        </svg>
+        {scheduledLabel}
+      </span>
+    {/if}
     <button
       class="collection-pill"
       type="button"
@@ -327,6 +342,33 @@
     opacity: 0.75;
     flex-shrink: 0;
     white-space: nowrap;
+  }
+
+  /* Scheduled/due chip — red while a pending task is past due. */
+  .sched-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.28rem;
+    font-size: 0.7rem;
+    color: var(--accent);
+    background: var(--accent-subtler);
+    border: 1px solid var(--accent-subtle-strong);
+    border-radius: 999px;
+    padding: 0.08rem 0.45rem;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .sched-chip.overdue {
+    color: var(--danger);
+    background: color-mix(in srgb, var(--danger) 8%, transparent);
+    border-color: color-mix(in srgb, var(--danger) 35%, transparent);
+  }
+
+  .todo-row.completed .sched-chip {
+    color: var(--text-muted);
+    background: var(--surface-tint);
+    border-color: var(--border);
   }
 
   /* Quick-add button: revealed on hover or keyboard focus anywhere in the row

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -36,6 +36,20 @@
   let importExportOpen = $state(false);
   let fileInputEl = $state<HTMLInputElement | null>(null);
 
+  // Calendar accounts modal — lazy like Import/Export so the CalDAV client
+  // code stays out of the main bundle until the feature is opened.
+  type CalendarModalComponent = Component<{ onclose: () => void }>;
+  let CalendarSettingsComponent = $state<CalendarModalComponent | null>(null);
+  let calendarSettingsOpen = $state(false);
+
+  async function openCalendarSettings() {
+    open = false;
+    CalendarSettingsComponent ??= await loadLazy<CalendarModalComponent>(
+      () => import('./CalendarSettingsModal.svelte'),
+    );
+    if (CalendarSettingsComponent) calendarSettingsOpen = true;
+  }
+
   // On a failed chunk fetch, loadLazy toasts and the callers' optional-chained
   // calls no-op — Export/Import doesn't fail silently or leave state dangling.
   async function loadImportExportModal() {
@@ -448,6 +462,19 @@
 
       <div class="divider"></div>
 
+      <div class="section-label">Calendars</div>
+      <button type="button" class="menu-item" role="menuitem" onclick={openCalendarSettings}>
+        <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="3" y="4" width="18" height="18" rx="2"></rect>
+          <line x1="16" y1="2" x2="16" y2="6"></line>
+          <line x1="8" y1="2" x2="8" y2="6"></line>
+          <line x1="3" y1="10" x2="21" y2="10"></line>
+        </svg>
+        Calendar accounts
+      </button>
+
+      <div class="divider"></div>
+
       <div class="section-label">Quick capture</div>
       <a class="menu-item" role="menuitem" href="/capture/">
         <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -558,6 +585,10 @@
 
 {#if ImportExportModalComponent}
   <ImportExportModalComponent bind:this={importExportModal} bind:open={importExportOpen} />
+{/if}
+
+{#if CalendarSettingsComponent && calendarSettingsOpen}
+  <CalendarSettingsComponent onclose={() => (calendarSettingsOpen = false)} />
 {/if}
 
 <style>

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -13,6 +13,7 @@
   import CollectionPicker from './CollectionPicker.svelte';
   import DeleteConfirm from './DeleteConfirm.svelte';
   import ScheduleSheet from './ScheduleSheet.svelte';
+  import AddToCalendarSheet from './AddToCalendarSheet.svelte';
   import { formatScheduled, isOverdue } from '../lib/schedule';
   import BookmarkView from './view-card/BookmarkView.svelte';
   import NoteView from './view-card/NoteView.svelte';
@@ -43,6 +44,7 @@
   let pickerMode = $state<'move' | 'todo'>('move');
 
   let showSchedule = $state(false);
+  let showCalendarSheet = $state(false);
 
   let convertingTodo = $state(false);
   let convertingRef = $state(false);
@@ -260,7 +262,7 @@
    */
   function handleWindowEscape(e: KeyboardEvent) {
     if (e.key !== 'Escape') return;
-    if (showDelete || showPicker || showSchedule) return;
+    if (showDelete || showPicker || showSchedule || showCalendarSheet) return;
     onclose();
   }
 </script>
@@ -528,6 +530,8 @@
           Make a reference
         </button>
       {/if}
+      <!-- Setting a time is card metadata; adding to a calendar is a
+           separate publish action that only appears once a time exists. -->
       <button
         type="button"
         class="action-row"
@@ -544,13 +548,36 @@
           stroke-linecap="round"
           stroke-linejoin="round"
         >
-          <rect x="3" y="4" width="18" height="18" rx="2"></rect>
-          <line x1="16" y1="2" x2="16" y2="6"></line>
-          <line x1="8" y1="2" x2="8" y2="6"></line>
-          <line x1="3" y1="10" x2="21" y2="10"></line>
+          <circle cx="12" cy="12" r="10"></circle>
+          <polyline points="12 6 12 12 16 14"></polyline>
         </svg>
-        {scheduledLabel ? `${scheduledLabel} — change…` : 'Add to calendar…'}
+        {scheduledLabel ? `${scheduledLabel} — change…` : 'Set time…'}
       </button>
+      {#if item.startsAt}
+        <button
+          type="button"
+          class="action-row"
+          onclick={() => (showCalendarSheet = true)}
+        >
+          <svg
+            aria-hidden="true"
+            width="15"
+            height="15"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <rect x="3" y="4" width="18" height="18" rx="2"></rect>
+            <line x1="16" y1="2" x2="16" y2="6"></line>
+            <line x1="8" y1="2" x2="8" y2="6"></line>
+            <line x1="3" y1="10" x2="21" y2="10"></line>
+          </svg>
+          {item.eventUrl ? 'On calendar — manage…' : 'Add to calendar…'}
+        </button>
+      {/if}
       <button type="button" class="action-row" onclick={() => onedit(item)}>
         <svg
           aria-hidden="true"
@@ -589,6 +616,10 @@
 
     {#if showSchedule}
       <ScheduleSheet {item} onclose={() => (showSchedule = false)} />
+    {/if}
+
+    {#if showCalendarSheet}
+      <AddToCalendarSheet {item} onclose={() => (showCalendarSheet = false)} />
     {/if}
   </div>
 </div>

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -12,6 +12,8 @@
   import ShareButton from './ShareButton.svelte';
   import CollectionPicker from './CollectionPicker.svelte';
   import DeleteConfirm from './DeleteConfirm.svelte';
+  import ScheduleSheet from './ScheduleSheet.svelte';
+  import { formatScheduled, isOverdue } from '../lib/schedule';
   import BookmarkView from './view-card/BookmarkView.svelte';
   import NoteView from './view-card/NoteView.svelte';
   import ImageView from './view-card/ImageView.svelte';
@@ -39,6 +41,8 @@
   // choosing where a converted todo lands ('todo').
   let showPicker = $state(false);
   let pickerMode = $state<'move' | 'todo'>('move');
+
+  let showSchedule = $state(false);
 
   let convertingTodo = $state(false);
   let convertingRef = $state(false);
@@ -217,6 +221,9 @@
     };
   });
 
+  const scheduledLabel = $derived(item.startsAt ? formatScheduled(item) : '');
+  const scheduleOverdue = $derived(isOverdue(item));
+
   const wordCount = $derived.by(() => {
     if (!('body' in item)) return 0;
     const body = (item as unknown as Record<string, unknown>).body;
@@ -242,8 +249,9 @@
    *   - DeleteConfirm, Lightbox: they register their own window handlers and
    *     will close themselves. We only need to keep *this* modal open so the
    *     user isn't unexpectedly dumped back to the card list.
-   *   - CollectionPicker: it closes itself via its own window escape
-   *     listener — we early-return so both layers don't close at once.
+   *   - CollectionPicker, ScheduleSheet: they close themselves via their own
+   *     window escape listeners — we early-return so both layers don't close
+   *     at once.
    *
    * Since `<svelte:window>` listeners fire in registration order, this outer
    * listener is registered first (parent mounts before children) and runs
@@ -252,7 +260,7 @@
    */
   function handleWindowEscape(e: KeyboardEvent) {
     if (e.key !== 'Escape') return;
-    if (showDelete || showPicker) return;
+    if (showDelete || showPicker || showSchedule) return;
     onclose();
   }
 </script>
@@ -428,6 +436,27 @@
           {todoStatus}
         </span>
       {/if}
+      {#if scheduledLabel}
+        <span class="meta-item" class:overdue={scheduleOverdue}>
+          <svg
+            aria-hidden="true"
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <rect x="3" y="4" width="18" height="18" rx="2"></rect>
+            <line x1="16" y1="2" x2="16" y2="6"></line>
+            <line x1="8" y1="2" x2="8" y2="6"></line>
+            <line x1="3" y1="10" x2="21" y2="10"></line>
+          </svg>
+          {scheduledLabel}
+        </span>
+      {/if}
     </div>
 
     <button type="button" class="btn-file" onclick={openMovePicker}>
@@ -499,6 +528,29 @@
           Make a reference
         </button>
       {/if}
+      <button
+        type="button"
+        class="action-row"
+        onclick={() => (showSchedule = true)}
+      >
+        <svg
+          aria-hidden="true"
+          width="15"
+          height="15"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <rect x="3" y="4" width="18" height="18" rx="2"></rect>
+          <line x1="16" y1="2" x2="16" y2="6"></line>
+          <line x1="8" y1="2" x2="8" y2="6"></line>
+          <line x1="3" y1="10" x2="21" y2="10"></line>
+        </svg>
+        {scheduledLabel ? `${scheduledLabel} — change…` : 'Add to calendar…'}
+      </button>
       <button type="button" class="action-row" onclick={() => onedit(item)}>
         <svg
           aria-hidden="true"
@@ -533,6 +585,10 @@
         onpick={handlePick}
         onclose={() => (showPicker = false)}
       />
+    {/if}
+
+    {#if showSchedule}
+      <ScheduleSheet {item} onclose={() => (showSchedule = false)} />
     {/if}
   </div>
 </div>
@@ -932,6 +988,10 @@
 
   .meta-group {
     font-weight: 600;
+  }
+
+  .meta-item.overdue {
+    color: var(--danger);
   }
 
   /* ── Primary filing action ────────────── */

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -15,6 +15,7 @@
   import ScheduleSheet from './ScheduleSheet.svelte';
   import AddToCalendarSheet from './AddToCalendarSheet.svelte';
   import { formatScheduled, isOverdue } from '../lib/schedule';
+  import { removePostedEntry } from '../lib/schedule-sync';
   import BookmarkView from './view-card/BookmarkView.svelte';
   import NoteView from './view-card/NoteView.svelte';
   import ImageView from './view-card/ImageView.svelte';
@@ -57,6 +58,31 @@
     onclose();
   }
 
+  /**
+   * A todo↔reference conversion changes the card's kind, so a posted
+   * calendar entry no longer matches its projection (a VEVENT for what is
+   * now a task, or vice versa) — and archive state belongs to the calendar
+   * ownership that conversion breaks. Detach the entry (best-effort server
+   * delete — a failure only orphans a calendar entry, never blocks the
+   * conversion), strip the pointer + archive flags, and keep the time,
+   * flipping its kind to match.
+   */
+  function detachCalendarOnConversion(
+    updated: Record<string, unknown>,
+    newKind: 'event' | 'task',
+  ) {
+    if (item.eventUrl) {
+      void removePostedEntry(item).catch((error) => {
+        console.warn('Calendar entry not removed on conversion', error);
+      });
+    }
+    delete updated.eventUrl;
+    delete updated.eventEtag;
+    delete updated.archived;
+    delete updated.archivedAt;
+    if (updated.startsAt) updated.scheduleKind = newKind;
+  }
+
   /** Promote the current item to an unfiled todo. */
   async function convertToUnfiledTodo() {
     convertingTodo = true;
@@ -72,6 +98,7 @@
         completed: false,
       };
       delete updated.collectionId;
+      detachCalendarOnConversion(updated, 'task');
       await storeItem(updated as unknown as InboxItem);
       showPicker = false;
       onclose();
@@ -102,13 +129,14 @@
       await moveItemToCollection(item.id, collectionId);
       // Now flip the todo flags. storeItem only touches the item doc — the
       // itemIds arrays are already reconciled by the move above.
-      const updated = {
+      const updated: Record<string, unknown> = {
         ...rest,
         isTodo: true,
         completed: false,
         collectionId,
       };
-      await storeItem(updated as InboxItem);
+      detachCalendarOnConversion(updated, 'task');
+      await storeItem(updated as unknown as InboxItem);
       recordCollectionUse(collectionId);
       showPicker = false;
       onclose();
@@ -135,6 +163,7 @@
         updated.type = 'note';
         if (!updated.body) updated.body = '';
       }
+      detachCalendarOnConversion(updated, 'event');
       await storeItem(updated as unknown as InboxItem);
       onclose();
     } finally {

--- a/packages/web/src/lib/actions.ts
+++ b/packages/web/src/lib/actions.ts
@@ -47,6 +47,65 @@ export function autofocusIf(node: HTMLElement, enabled: boolean) {
 }
 
 /**
+ * Contain keyboard focus within the bound dialog element.
+ *
+ * `aria-modal` alone doesn't move or trap focus — a keyboard user can Tab
+ * to controls behind the overlay. This action: focuses the first focusable
+ * descendant on mount (unless something inside is already focused, e.g. via
+ * `use:autofocus`), cycles Tab/Shift-Tab at the edges, and restores focus
+ * to the previously focused element when the dialog unmounts.
+ *
+ * Example:
+ * ```svelte
+ * <div class="sheet" role="dialog" aria-modal="true" use:trapFocus>
+ * ```
+ */
+export function trapFocus(node: HTMLElement) {
+  const previouslyFocused =
+    document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+
+  const focusables = (): HTMLElement[] =>
+    Array.from(
+      node.querySelectorAll<HTMLElement>(
+        'a[href], button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter((el) => el.offsetParent !== null);
+
+  requestAnimationFrame(() => {
+    if (!node.contains(document.activeElement)) focusables()[0]?.focus();
+  });
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Tab') return;
+    const items = focusables();
+    if (items.length === 0) return;
+    const first = items[0];
+    const last = items[items.length - 1];
+    const active = document.activeElement;
+    // Also catch focus that escaped (or never entered) the dialog.
+    if (e.shiftKey && (active === first || !node.contains(active))) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && (active === last || !node.contains(active))) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  // Window-level: a node listener would miss Tab presses once focus has
+  // escaped the dialog (the exact case the trap must recover from).
+  window.addEventListener('keydown', handleKeydown, true);
+  return {
+    destroy: () => {
+      window.removeEventListener('keydown', handleKeydown, true);
+      previouslyFocused?.focus();
+    },
+  };
+}
+
+/**
  * Run `onEnter` once when the bound element first approaches the viewport.
  *
  * Used to gate expensive work (binary fetches for card media) on visibility,

--- a/packages/web/src/lib/actions.ts
+++ b/packages/web/src/lib/actions.ts
@@ -47,13 +47,23 @@ export function autofocusIf(node: HTMLElement, enabled: boolean) {
 }
 
 /**
+ * Dialogs currently holding a focus trap, in mount order. Only the topmost
+ * (last-mounted) trap acts on Tab — without this, a dialog stacked on
+ * another (CalendarPicker over ScheduleSheet) would have both window-level
+ * handlers fighting: the lower one sees focus "outside itself" and yanks
+ * it back out of the upper dialog.
+ */
+const trapStack: HTMLElement[] = [];
+
+/**
  * Contain keyboard focus within the bound dialog element.
  *
  * `aria-modal` alone doesn't move or trap focus — a keyboard user can Tab
  * to controls behind the overlay. This action: focuses the first focusable
  * descendant on mount (unless something inside is already focused, e.g. via
  * `use:autofocus`), cycles Tab/Shift-Tab at the edges, and restores focus
- * to the previously focused element when the dialog unmounts.
+ * to the previously focused element when the dialog unmounts. Stacked
+ * dialogs coordinate through {@link trapStack}.
  *
  * Example:
  * ```svelte
@@ -65,6 +75,7 @@ export function trapFocus(node: HTMLElement) {
     document.activeElement instanceof HTMLElement
       ? document.activeElement
       : null;
+  trapStack.push(node);
 
   const focusables = (): HTMLElement[] =>
     Array.from(
@@ -79,6 +90,9 @@ export function trapFocus(node: HTMLElement) {
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key !== 'Tab') return;
+    // Only the topmost trap acts; lower dialogs stay inert until they
+    // surface again.
+    if (trapStack[trapStack.length - 1] !== node) return;
     const items = focusables();
     if (items.length === 0) return;
     const first = items[0];
@@ -100,6 +114,8 @@ export function trapFocus(node: HTMLElement) {
   return {
     destroy: () => {
       window.removeEventListener('keydown', handleKeydown, true);
+      const idx = trapStack.indexOf(node);
+      if (idx !== -1) trapStack.splice(idx, 1);
       previouslyFocused?.focus();
     },
   };

--- a/packages/web/src/lib/build-item.test.ts
+++ b/packages/web/src/lib/build-item.test.ts
@@ -145,6 +145,55 @@ describe('buildBookmarkItem', () => {
   });
 });
 
+describe('edit preservation of type-agnostic fields', () => {
+  it('editing keeps the schedule and posted-entry pointer', () => {
+    const editItem: NoteItem = {
+      id: 'item-1',
+      type: 'note',
+      title: 'Old',
+      body: 'old',
+      createdAt: '2026-04-01T00:00:00Z',
+      collectionId: 'col-1',
+      startsAt: '2026-05-01T09:00:00.000Z',
+      endsAt: '2026-05-01T10:00:00.000Z',
+      scheduleKind: 'event',
+      eventUrl: 'https://cal.example.org/nick/personal/item-1%40inbox-rs.ics',
+      eventEtag: '"e1"',
+    };
+    const result = buildNoteItem(ctx({ editItem }), {
+      title: 'New title',
+      body: 'new body',
+      description: '',
+    });
+    expect(result.item).toMatchObject({
+      title: 'New title',
+      collectionId: 'col-1',
+      startsAt: '2026-05-01T09:00:00.000Z',
+      endsAt: '2026-05-01T10:00:00.000Z',
+      scheduleKind: 'event',
+      eventUrl: 'https://cal.example.org/nick/personal/item-1%40inbox-rs.ics',
+      eventEtag: '"e1"',
+    });
+  });
+
+  it('unscheduled edits stay unscheduled', () => {
+    const editItem: NoteItem = {
+      id: 'item-1',
+      type: 'note',
+      title: 'Old',
+      body: 'old',
+      createdAt: '2026-04-01T00:00:00Z',
+    };
+    const result = buildNoteItem(ctx({ editItem }), {
+      title: 'New',
+      body: 'new',
+      description: '',
+    });
+    expect(result.item.startsAt).toBeUndefined();
+    expect(result.item.eventUrl).toBeUndefined();
+  });
+});
+
 describe('buildNoteItem', () => {
   it('falls back to first 50 chars of body when title is empty', () => {
     const longBody = 'a'.repeat(80);

--- a/packages/web/src/lib/build-item.ts
+++ b/packages/web/src/lib/build-item.ts
@@ -58,6 +58,8 @@ function preserveCollection<T extends InboxItem>(
       'scheduleKind',
       'eventUrl',
       'eventEtag',
+      'archived',
+      'archivedAt',
     ] as const) {
       if (ctx.editItem[key] !== undefined) {
         (schedule as Record<string, unknown>)[key] = ctx.editItem[key];

--- a/packages/web/src/lib/build-item.ts
+++ b/packages/web/src/lib/build-item.ts
@@ -35,11 +35,12 @@ export interface BuildContext {
 }
 
 /**
- * Carry the edit target's collection membership onto a freshly-rebuilt item.
- * `collectionId` is a type-agnostic placement field the per-type forms never
- * surface, so without this every edit would drop it and silently move the
- * item back to the Inbox. Applied unconditionally on edit (including across
- * type conversions) so an item filed in a collection stays there.
+ * Carry the edit target's type-agnostic fields onto a freshly-rebuilt item.
+ * Collection membership and scheduling are placement/metadata the per-type
+ * forms never surface, so without this every edit would silently move the
+ * item back to the Inbox and strip its calendar schedule (losing the
+ * eventUrl/eventEtag pointer to an already-posted entry). Applied
+ * unconditionally on edit (including across type conversions).
  */
 function preserveCollection<T extends InboxItem>(
   ctx: BuildContext,
@@ -47,6 +48,22 @@ function preserveCollection<T extends InboxItem>(
 ): T {
   if (ctx.editItem?.collectionId) {
     item.collectionId = ctx.editItem.collectionId;
+  }
+  if (ctx.editItem) {
+    const schedule: Partial<InboxItem> = {};
+    for (const key of [
+      'startsAt',
+      'endsAt',
+      'allDay',
+      'scheduleKind',
+      'eventUrl',
+      'eventEtag',
+    ] as const) {
+      if (ctx.editItem[key] !== undefined) {
+        (schedule as Record<string, unknown>)[key] = ctx.editItem[key];
+      }
+    }
+    Object.assign(item, schedule);
   }
   return item;
 }

--- a/packages/web/src/lib/caldav.test.ts
+++ b/packages/web/src/lib/caldav.test.ts
@@ -154,6 +154,36 @@ describe('fetchCalendars', () => {
     );
     await expect(fetchCalendars(CREDS, ENDPOINT)).rejects.toThrow(/503/);
   });
+
+  it('normalizes network/timeout failures into a coded CaldavError', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new TypeError('Failed to fetch'),
+    );
+    const err = await fetchCalendars(CREDS, ENDPOINT).catch((e) => e);
+    expect(err).toBeInstanceOf(CaldavError);
+    expect(err.code).toBe('caldav:relay-unreachable');
+  });
+
+  it('drops discovered entries missing the RemoteCalendar shape', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      ndjson({
+        type: 'collection',
+        totalItems: 3,
+        items: [
+          {
+            id: 'https://cal/x/',
+            type: 'calendar',
+            name: 'OK',
+            components: ['event'],
+          },
+          { id: 'https://cal/y/', type: 'calendar', name: 'No components' },
+          { id: 'https://cal/z/', type: 'calendar', components: ['event'] },
+        ],
+      }),
+    );
+    const calendars = await fetchCalendars(CREDS, ENDPOINT);
+    expect(calendars.map((c) => c.name)).toEqual(['OK']);
+  });
 });
 
 describe('mutations', () => {
@@ -228,6 +258,17 @@ describe('mutations', () => {
       type: 'task',
       etag: '"e1"',
     });
+  });
+
+  it('delete throws (not no-ops) when a posted entry has no etag', async () => {
+    const stranded = note({ eventUrl: `${CAL}x.ics`, eventEtag: undefined });
+    await expect(deleteEntry(CREDS, CAL, stranded, ENDPOINT)).rejects.toThrow(
+      /no stored etag/,
+    );
+    // Never-posted items are still a clean no-op.
+    await expect(
+      deleteEntry(CREDS, CAL, note(), ENDPOINT),
+    ).resolves.toBeUndefined();
   });
 
   it('surfaces conflicts with their code', async () => {

--- a/packages/web/src/lib/caldav.test.ts
+++ b/packages/web/src/lib/caldav.test.ts
@@ -1,0 +1,243 @@
+import type { BookmarkItem, NoteItem, TodoItem } from '@inbox-rs/rs-module';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  CaldavError,
+  createEntry,
+  deleteEntry,
+  fetchCalendars,
+  itemToCalendarObject,
+  uidFor,
+  updateEntry,
+} from './caldav';
+
+const ENDPOINT = 'https://sockethub.test/sockethub-http';
+const CREDS = {
+  url: 'https://cal.example.org/',
+  username: 'nick',
+  password: 'secret',
+};
+
+function note(overrides: Partial<NoteItem> = {}): NoteItem {
+  return {
+    id: 'item-1',
+    type: 'note',
+    title: 'Prepare demo',
+    body: '',
+    createdAt: '2026-07-01T00:00:00Z',
+    startsAt: '2026-08-03T13:00:00.000Z',
+    endsAt: '2026-08-03T14:00:00.000Z',
+    scheduleKind: 'event',
+    ...overrides,
+  };
+}
+
+function ndjson(...lines: unknown[]): Response {
+  return new Response(lines.map((l) => JSON.stringify(l)).join('\n'), {
+    status: 200,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('itemToCalendarObject', () => {
+  it('maps a timed event: name, instants with offsets, bookmark url', () => {
+    const bookmark: BookmarkItem = {
+      id: 'bm-1',
+      type: 'bookmark',
+      title: 'Read this',
+      url: 'https://example.org/post',
+      createdAt: '2026-07-01T00:00:00Z',
+      startsAt: '2026-08-03T13:00:00.000Z',
+      endsAt: '2026-08-03T14:00:00.000Z',
+      scheduleKind: 'event',
+      description: 'notes',
+    };
+    expect(itemToCalendarObject(bookmark)).toEqual({
+      type: 'event',
+      uid: 'bm-1@inbox-rs',
+      name: 'Read this',
+      content: 'notes',
+      url: 'https://example.org/post',
+      startTime: '2026-08-03T13:00:00.000Z',
+      endTime: '2026-08-03T14:00:00.000Z',
+    });
+  });
+
+  it('maps all-day entries to local date-only strings without endTime', () => {
+    // Local-midnight start, as applySchedule stores it.
+    const start = new Date(2026, 7, 3);
+    const obj = itemToCalendarObject(
+      note({ startsAt: start.toISOString(), endsAt: undefined, allDay: true }),
+    )!;
+    expect(obj.allDay).toBe(true);
+    expect(obj.startTime).toBe('2026-08-03');
+    expect(obj.endTime).toBeUndefined();
+  });
+
+  it('maps tasks to due, with completed status + completedTime', () => {
+    const todo: TodoItem = {
+      id: 'todo-1',
+      type: 'todo',
+      title: 'Call dentist',
+      completed: true,
+      completedAt: '2026-08-01T10:00:00Z',
+      createdAt: '2026-07-01T00:00:00Z',
+      startsAt: '2026-08-05T12:00:00.000Z',
+      scheduleKind: 'task',
+    };
+    expect(itemToCalendarObject(todo)).toEqual({
+      type: 'task',
+      uid: 'todo-1@inbox-rs',
+      name: 'Call dentist',
+      due: '2026-08-05T12:00:00.000Z',
+      status: 'completed',
+      completedTime: '2026-08-01T10:00:00Z',
+    });
+  });
+
+  it('returns null for unscheduled items', () => {
+    expect(itemToCalendarObject(note({ startsAt: undefined }))).toBeNull();
+  });
+});
+
+describe('fetchCalendars', () => {
+  it('sends [credentials, fetch] and returns calendar descriptors', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      ndjson(
+        { type: 'credentials', actor: { id: 'x' } }, // ack line — skipped
+        {
+          type: 'collection',
+          totalItems: 1,
+          items: [
+            {
+              id: 'https://cal.example.org/nick/personal/',
+              type: 'calendar',
+              name: 'Personal',
+              components: ['event', 'task'],
+            },
+          ],
+        },
+      ),
+    );
+    const calendars = await fetchCalendars(CREDS, ENDPOINT);
+    expect(calendars).toHaveLength(1);
+    expect(calendars[0].name).toBe('Personal');
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(ENDPOINT);
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toHaveLength(2);
+    expect(body[0].type).toBe('credentials');
+    expect(body[0].object.password).toBe('secret');
+    expect(body[1].type).toBe('fetch');
+    expect(body[1].actor.id).toBe('caldav://nick@cal.example.org');
+    // fetch must carry no target/object per the platform's constraints
+    expect(body[1].target).toBeUndefined();
+    expect(body[1].object).toBeUndefined();
+  });
+
+  it('throws a coded CaldavError from an error line', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      ndjson({ type: 'error', error: 'caldav:authentication-failed' }),
+    );
+    const err = await fetchCalendars(CREDS, ENDPOINT).catch((e) => e);
+    expect(err).toBeInstanceOf(CaldavError);
+    expect(err.code).toBe('caldav:authentication-failed');
+    expect(err.message).toMatch(/app password/);
+  });
+
+  it('throws when the relay itself fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('nope', { status: 503 }),
+    );
+    await expect(fetchCalendars(CREDS, ENDPOINT)).rejects.toThrow(/503/);
+  });
+});
+
+describe('mutations', () => {
+  const CAL = 'https://cal.example.org/nick/personal/';
+
+  it('create targets the calendar and returns href + etag', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      ndjson({
+        type: 'create',
+        actor: {},
+        target: {},
+        object: { id: `${CAL}item-1%40inbox-rs.ics`, etag: '"e1"' },
+      }),
+    );
+    const posted = await createEntry(CREDS, CAL, note(), ENDPOINT);
+    expect(posted).toEqual({
+      eventUrl: `${CAL}item-1%40inbox-rs.ics`,
+      eventEtag: '"e1"',
+    });
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0][1] as RequestInit).body as string,
+    );
+    expect(body[1].target).toEqual({ id: CAL, type: 'calendar' });
+    expect(body[1].object.uid).toBe(uidFor(note()));
+  });
+
+  it('update sends id + etag alongside the object', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      ndjson({
+        type: 'update',
+        object: { id: `${CAL}x.ics`, etag: '"e2"' },
+      }),
+    );
+    const scheduled = note({ eventUrl: `${CAL}x.ics`, eventEtag: '"e1"' });
+    const posted = await updateEntry(CREDS, CAL, scheduled, ENDPOINT);
+    expect(posted.eventEtag).toBe('"e2"');
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0][1] as RequestInit).body as string,
+    );
+    expect(body[1].object.id).toBe(`${CAL}x.ics`);
+    expect(body[1].object.etag).toBe('"e1"');
+    expect(body[1].object.uid).toBe('item-1@inbox-rs');
+  });
+
+  it('update refuses items without a posted entry', async () => {
+    await expect(updateEntry(CREDS, CAL, note(), ENDPOINT)).rejects.toThrow(
+      /no posted entry/,
+    );
+  });
+
+  it('delete sends the required id/type/etag triple', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        ndjson({ type: 'delete', object: { id: `${CAL}x.ics` } }),
+      );
+    await deleteEntry(
+      CREDS,
+      CAL,
+      note({
+        eventUrl: `${CAL}x.ics`,
+        eventEtag: '"e1"',
+        scheduleKind: 'task',
+      }),
+      ENDPOINT,
+    );
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0][1] as RequestInit).body as string,
+    );
+    expect(body[1].object).toEqual({
+      id: `${CAL}x.ics`,
+      type: 'task',
+      etag: '"e1"',
+    });
+  });
+
+  it('surfaces conflicts with their code', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      ndjson({ type: 'error', error: 'caldav:conflict' }),
+    );
+    const scheduled = note({ eventUrl: `${CAL}x.ics`, eventEtag: '"stale"' });
+    const err = await updateEntry(CREDS, CAL, scheduled, ENDPOINT).catch(
+      (e) => e,
+    );
+    expect(err.code).toBe('caldav:conflict');
+  });
+});

--- a/packages/web/src/lib/caldav.ts
+++ b/packages/web/src/lib/caldav.ts
@@ -1,0 +1,274 @@
+/**
+ * CalDAV client for the sockethub `caldav` platform.
+ *
+ * The browser can't speak CalDAV directly (no CORS on calendar servers), so
+ * every operation relays through Sockethub's HTTP actions endpoint: one POST
+ * carrying `[credentials, message]` — the request-scoped credentials store
+ * is torn down when the request completes, so the password is never stored
+ * server-side. Responses stream back as NDJSON.
+ *
+ * Contract (see sockethub packages/platform-caldav):
+ * - timed values must carry a UTC offset — our ISO `...Z` strings qualify
+ * - all-day values must be date-only `YYYY-MM-DD` in the user's local day
+ * - `update` requires id + etag + uid; `delete` requires id + type + etag
+ * - client-supplied UIDs are allowed — we always use `<itemId>@inbox-rs`,
+ *   so the uid needed for updates is derivable from the item alone
+ * - failures arrive as machine-readable `caldav:*` codes
+ */
+import type { InboxItem } from '@inbox-rs/rs-module';
+import { toDateInputValue } from './schedule';
+
+export const CALDAV_CONTEXT = [
+  'https://www.w3.org/ns/activitystreams',
+  'https://sockethub.org/ns/context/v1.jsonld',
+  'https://sockethub.org/ns/context/platform/caldav/v1.jsonld',
+];
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+export interface CaldavCredentials {
+  url: string;
+  username: string;
+  password: string;
+}
+
+export interface RemoteCalendar {
+  id: string;
+  name: string;
+  color?: string;
+  components: Array<'event' | 'task'>;
+}
+
+/** Human-readable messages for the platform's machine codes. */
+const ERROR_MESSAGES: Record<string, string> = {
+  'caldav:authentication-failed':
+    'Sign-in failed — check the username and app password',
+  'caldav:connection-failed': 'Could not reach the calendar server',
+  'caldav:not-caldav': 'That server does not speak CalDAV',
+  'caldav:https-required': 'The calendar server must use https',
+  'caldav:conflict': 'The entry changed in your calendar app',
+  'caldav:not-found': 'The entry no longer exists on the server',
+  'caldav:invalid-calendar': 'That calendar was not found on the server',
+  'caldav:unsupported-component':
+    'That calendar does not support this entry type',
+};
+
+export class CaldavError extends Error {
+  /** `caldav:<code>`, or `caldav:unknown` when the server said something else. */
+  readonly code: string;
+
+  constructor(raw: string) {
+    const match = /caldav:[a-z-]+/.exec(raw);
+    const code = match ? match[0] : 'caldav:unknown';
+    super(ERROR_MESSAGES[code] ?? raw);
+    this.code = code;
+  }
+}
+
+/** Stable actor for the credentials store; identifies the account, not a URL. */
+function actorFor(creds: CaldavCredentials) {
+  let host = creds.url;
+  try {
+    host = new URL(creds.url).host;
+  } catch {
+    // keep raw url — the server will reject invalid credentials anyway
+  }
+  return { id: `caldav://${creds.username}@${host}`, type: 'person' };
+}
+
+function credentialsPayload(creds: CaldavCredentials) {
+  return {
+    '@context': CALDAV_CONTEXT,
+    type: 'credentials',
+    actor: actorFor(creds),
+    object: {
+      type: 'credentials',
+      url: creds.url,
+      username: creds.username,
+      password: creds.password,
+    },
+  };
+}
+
+/**
+ * POST `[credentials, message]` and return the message's result line.
+ * NDJSON lines that are neither an error nor the expected result (the
+ * credentials ack, whatever its shape) are skipped.
+ */
+async function send(
+  creds: CaldavCredentials,
+  message: Record<string, unknown>,
+  expectTypes: string[],
+  endpoint: string,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Request-Id': crypto.randomUUID(),
+    },
+    body: JSON.stringify([
+      credentialsPayload(creds),
+      { '@context': CALDAV_CONTEXT, actor: actorFor(creds), ...message },
+    ]),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new CaldavError(`calendar relay responded with ${res.status}`);
+  }
+  const text = await res.text();
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    let payload: unknown;
+    try {
+      payload = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const p = payload as Record<string, unknown>;
+    if (typeof p.error === 'string' && p.error) {
+      throw new CaldavError(p.error);
+    }
+    if (typeof p.type === 'string' && expectTypes.includes(p.type)) {
+      return p;
+    }
+  }
+  throw new CaldavError('calendar relay returned no result');
+}
+
+/** Discover the account's calendars (used at connect time and on refresh). */
+export async function fetchCalendars(
+  creds: CaldavCredentials,
+  endpoint: string,
+): Promise<RemoteCalendar[]> {
+  const result = await send(creds, { type: 'fetch' }, ['collection'], endpoint);
+  const items = Array.isArray(result.items) ? result.items : [];
+  return items.filter(
+    (item): item is RemoteCalendar =>
+      !!item &&
+      typeof (item as RemoteCalendar).id === 'string' &&
+      (item as { type?: string }).type === 'calendar',
+  );
+}
+
+/** The UID we stamp on every entry; derivable from the item forever after. */
+export function uidFor(item: Pick<InboxItem, 'id'>): string {
+  return `${item.id}@inbox-rs`;
+}
+
+/**
+ * Map a scheduled item onto the platform's event/task object. Exported for
+ * tests. Returns null when the item carries no schedule.
+ */
+export function itemToCalendarObject(
+  item: InboxItem,
+): Record<string, unknown> | null {
+  if (!item.startsAt) return null;
+  const isTask = item.scheduleKind === 'task';
+  const allDay = item.allDay === true;
+  // All-day entries are calendar dates in the user's local day; timed
+  // entries are instants (our stored ISO strings end in Z — a UTC offset).
+  const when = allDay
+    ? toDateInputValue(new Date(item.startsAt))
+    : item.startsAt;
+  const base: Record<string, unknown> = {
+    type: isTask ? 'task' : 'event',
+    uid: uidFor(item),
+    name: item.title || 'Untitled',
+    ...(allDay ? { allDay: true } : {}),
+    ...(item.description ? { content: item.description } : {}),
+    ...(item.type === 'bookmark' && item.url ? { url: item.url } : {}),
+  };
+  if (isTask) {
+    base.due = when;
+    if (item.completed) {
+      base.status = 'completed';
+      base.completedTime = item.completedAt ?? new Date().toISOString();
+    }
+    return base;
+  }
+  base.startTime = when;
+  if (!allDay && item.endsAt) base.endTime = item.endsAt;
+  return base;
+}
+
+export interface PostedEntry {
+  eventUrl: string;
+  eventEtag?: string;
+}
+
+function mutationResult(result: Record<string, unknown>): PostedEntry {
+  const object = (result.object ?? {}) as { id?: string; etag?: string };
+  if (!object.id) throw new CaldavError('calendar relay returned no entry id');
+  return { eventUrl: object.id, eventEtag: object.etag };
+}
+
+/** Create the item's entry in the given calendar. */
+export async function createEntry(
+  creds: CaldavCredentials,
+  calendarId: string,
+  item: InboxItem,
+  endpoint: string,
+): Promise<PostedEntry> {
+  const object = itemToCalendarObject(item);
+  if (!object) throw new CaldavError('item has no schedule');
+  const result = await send(
+    creds,
+    {
+      type: 'create',
+      target: { id: calendarId, type: 'calendar' },
+      object,
+    },
+    ['create'],
+    endpoint,
+  );
+  return mutationResult(result);
+}
+
+/** Replace the item's existing entry (requires the stored href + etag). */
+export async function updateEntry(
+  creds: CaldavCredentials,
+  calendarId: string,
+  item: InboxItem,
+  endpoint: string,
+): Promise<PostedEntry> {
+  const object = itemToCalendarObject(item);
+  if (!object || !item.eventUrl || !item.eventEtag) {
+    throw new CaldavError('item has no posted entry to update');
+  }
+  const result = await send(
+    creds,
+    {
+      type: 'update',
+      target: { id: calendarId, type: 'calendar' },
+      object: { ...object, id: item.eventUrl, etag: item.eventEtag },
+    },
+    ['update'],
+    endpoint,
+  );
+  return mutationResult(result);
+}
+
+/** Delete the item's entry from its calendar. */
+export async function deleteEntry(
+  creds: CaldavCredentials,
+  calendarId: string,
+  item: InboxItem,
+  endpoint: string,
+): Promise<void> {
+  if (!item.eventUrl || !item.eventEtag) return;
+  await send(
+    creds,
+    {
+      type: 'delete',
+      target: { id: calendarId, type: 'calendar' },
+      object: {
+        id: item.eventUrl,
+        type: item.scheduleKind === 'task' ? 'task' : 'event',
+        etag: item.eventEtag,
+      },
+    },
+    ['delete'],
+    endpoint,
+  );
+}

--- a/packages/web/src/lib/caldav.ts
+++ b/packages/web/src/lib/caldav.ts
@@ -51,6 +51,10 @@ const ERROR_MESSAGES: Record<string, string> = {
   'caldav:invalid-calendar': 'That calendar was not found on the server',
   'caldav:unsupported-component':
     'That calendar does not support this entry type',
+  // Client-side code: the relay itself was unreachable (offline, DNS, or
+  // the 30 s timeout) — distinct from the calendar server being down.
+  'caldav:relay-unreachable':
+    'Could not reach the calendar relay — are you offline?',
 };
 
 export class CaldavError extends Error {
@@ -101,22 +105,35 @@ async function send(
   expectTypes: string[],
   endpoint: string,
 ): Promise<Record<string, unknown>> {
-  const res = await fetch(endpoint, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Request-Id': crypto.randomUUID(),
-    },
-    body: JSON.stringify([
-      credentialsPayload(creds),
-      { '@context': CALDAV_CONTEXT, actor: actorFor(creds), ...message },
-    ]),
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-  });
+  // Normalize transport failures (network down, DNS, the timeout's
+  // DOMException) into coded CaldavErrors — callers branch on `.code` and a
+  // raw TypeError would bypass every one of those checks.
+  let res: Response;
+  let text: string;
+  try {
+    res = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Request-Id': crypto.randomUUID(),
+      },
+      body: JSON.stringify([
+        credentialsPayload(creds),
+        { '@context': CALDAV_CONTEXT, actor: actorFor(creds), ...message },
+      ]),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch {
+    throw new CaldavError('caldav:relay-unreachable');
+  }
   if (!res.ok) {
     throw new CaldavError(`calendar relay responded with ${res.status}`);
   }
-  const text = await res.text();
+  try {
+    text = await res.text();
+  } catch {
+    throw new CaldavError('caldav:relay-unreachable');
+  }
   for (const line of text.split('\n')) {
     if (!line.trim()) continue;
     let payload: unknown;
@@ -143,12 +160,19 @@ export async function fetchCalendars(
 ): Promise<RemoteCalendar[]> {
   const result = await send(creds, { type: 'fetch' }, ['collection'], endpoint);
   const items = Array.isArray(result.items) ? result.items : [];
-  return items.filter(
-    (item): item is RemoteCalendar =>
-      !!item &&
-      typeof (item as RemoteCalendar).id === 'string' &&
-      (item as { type?: string }).type === 'calendar',
-  );
+  // Validate the full RemoteCalendar shape — an entry missing `components`
+  // would blow up later in pickPreferredCalendar/the picker UI, far from
+  // the malformed response that caused it.
+  return items.filter((item): item is RemoteCalendar => {
+    const c = item as Partial<RemoteCalendar> | null;
+    return (
+      !!c &&
+      typeof c.id === 'string' &&
+      (c as { type?: string }).type === 'calendar' &&
+      typeof c.name === 'string' &&
+      Array.isArray(c.components)
+    );
+  });
 }
 
 /** The UID we stamp on every entry; derivable from the item forever after. */
@@ -256,7 +280,14 @@ export async function deleteEntry(
   item: InboxItem,
   endpoint: string,
 ): Promise<void> {
-  if (!item.eventUrl || !item.eventEtag) return;
+  // Never posted → nothing to delete. But a posted entry without its etag
+  // is a failure, not a no-op: the platform's delete requires the etag, and
+  // silently returning would strand the entry on the calendar (e.g. as a
+  // stale duplicate after a calendar move).
+  if (!item.eventUrl) return;
+  if (!item.eventEtag) {
+    throw new CaldavError('posted entry has no stored etag — cannot delete');
+  }
   await send(
     creds,
     {

--- a/packages/web/src/lib/calendar-accounts.test.ts
+++ b/packages/web/src/lib/calendar-accounts.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  addCalendarAccount,
+  calendarAccounts,
+  choiceForEventUrl,
+  findCalendarChoice,
+  pickPreferredCalendar,
+  recordCalendarUse,
+  removeCalendarAccount,
+  updateCalendarAccount,
+  visibleCalendarChoices,
+} from './calendar-accounts';
+
+const CAL_PERSONAL = {
+  id: 'https://cal.example.org/nick/personal/',
+  name: 'Personal',
+  components: ['event', 'task'] as Array<'event' | 'task'>,
+};
+const CAL_WORK = {
+  id: 'https://cal.example.org/nick/work/',
+  name: 'Work',
+  components: ['event'] as Array<'event' | 'task'>,
+};
+
+function seedAccount(overrides: Record<string, unknown> = {}) {
+  return addCalendarAccount({
+    label: 'Fastmail',
+    url: 'https://cal.example.org/',
+    username: 'nick',
+    password: 'secret',
+    calendars: [CAL_PERSONAL, CAL_WORK],
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  calendarAccounts.set([]);
+});
+
+describe('account CRUD + persistence', () => {
+  it('persists accounts to localStorage on every change', () => {
+    const account = seedAccount();
+    const stored = JSON.parse(
+      localStorage.getItem('inbox-rs:calendar-accounts') ?? '[]',
+    );
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe(account.id);
+
+    removeCalendarAccount(account.id);
+    expect(
+      JSON.parse(localStorage.getItem('inbox-rs:calendar-accounts') ?? '[]'),
+    ).toHaveLength(0);
+  });
+
+  it('updates patch a single account', () => {
+    const account = seedAccount();
+    updateCalendarAccount(account.id, { defaultCalendarId: CAL_WORK.id });
+    expect(get(calendarAccounts)[0].defaultCalendarId).toBe(CAL_WORK.id);
+  });
+});
+
+describe('visibility and lookup', () => {
+  it('hidden calendars leave the picker but still resolve for posted entries', () => {
+    const account = seedAccount({ hiddenCalendarIds: [CAL_WORK.id] });
+    expect(visibleCalendarChoices().map((c) => c.calendar.name)).toEqual([
+      'Personal',
+    ]);
+    expect(findCalendarChoice(CAL_WORK.id)).toBeUndefined();
+    // An entry already posted to the hidden calendar still finds its home.
+    const choice = choiceForEventUrl(`${CAL_WORK.id}abc.ics`);
+    expect(choice?.calendar.id).toBe(CAL_WORK.id);
+    expect(choice?.account.id).toBe(account.id);
+  });
+
+  it('choiceForEventUrl matches by href prefix only', () => {
+    seedAccount();
+    expect(choiceForEventUrl(`${CAL_PERSONAL.id}x.ics`)?.calendar.name).toBe(
+      'Personal',
+    );
+    expect(choiceForEventUrl('https://other.example/x.ics')).toBeUndefined();
+    expect(choiceForEventUrl(undefined)).toBeUndefined();
+  });
+});
+
+describe('pickPreferredCalendar', () => {
+  it('prefers last-used, then account default, then first supporting the kind', () => {
+    seedAccount({ defaultCalendarId: CAL_WORK.id });
+    // No last-used → account default (Work).
+    expect(pickPreferredCalendar('event')?.calendar.name).toBe('Work');
+    // Work doesn't support tasks → falls to the first task-capable calendar.
+    expect(pickPreferredCalendar('task')?.calendar.name).toBe('Personal');
+    // Last-used wins once recorded.
+    recordCalendarUse('event', CAL_PERSONAL.id);
+    expect(pickPreferredCalendar('event')?.calendar.name).toBe('Personal');
+  });
+
+  it('returns undefined with no accounts', () => {
+    expect(pickPreferredCalendar('event')).toBeUndefined();
+  });
+});

--- a/packages/web/src/lib/calendar-accounts.test.ts
+++ b/packages/web/src/lib/calendar-accounts.test.ts
@@ -2,6 +2,7 @@
 import { get } from 'svelte/store';
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
+  accountEndpoint,
   addCalendarAccount,
   calendarAccounts,
   choiceForEventUrl,
@@ -30,6 +31,7 @@ function seedAccount(overrides: Record<string, unknown> = {}) {
     url: 'https://cal.example.org/',
     username: 'nick',
     password: 'secret',
+    endpoint: 'https://relay.example.org/sockethub-http',
     calendars: [CAL_PERSONAL, CAL_WORK],
     ...overrides,
   });
@@ -59,6 +61,18 @@ describe('account CRUD + persistence', () => {
     const account = seedAccount();
     updateCalendarAccount(account.id, { defaultCalendarId: CAL_WORK.id });
     expect(get(calendarAccounts)[0].defaultCalendarId).toBe(CAL_WORK.id);
+  });
+
+  it('accountEndpoint returns the pinned relay, with a default fallback', () => {
+    const account = seedAccount();
+    expect(accountEndpoint(account)).toBe(
+      'https://relay.example.org/sockethub-http',
+    );
+    // Legacy entries without a pin fall back to the app default — never the
+    // synced setting.
+    expect(accountEndpoint({ ...account, endpoint: '' })).toMatch(
+      /sockethub-http$/,
+    );
   });
 });
 

--- a/packages/web/src/lib/calendar-accounts.ts
+++ b/packages/web/src/lib/calendar-accounts.ts
@@ -7,11 +7,20 @@
  * no server ever stores them. Each device that wants to post to a calendar
  * connects its own account.
  *
+ * Accepted trade-off: localStorage is readable by any same-origin script,
+ * so an XSS compromise could exfiltrate the stored app passwords. Client-
+ * side encryption without a per-session passphrase would only obfuscate
+ * (the key would be equally reachable). Mitigations instead: the UI
+ * insists on app-specific passwords (scoped, revocable at the provider),
+ * and the relay endpoint is pinned per account at connect time so synced
+ * settings can never redirect credential traffic (see `endpoint`).
+ *
  * The discovered calendar list is cached per account so pickers render
  * instantly; "Refresh" in settings re-runs discovery.
  */
 import { derived, get, writable } from 'svelte/store';
 import type { RemoteCalendar } from './caldav';
+import { DEFAULT_SOCKETHUB_ENDPOINT } from './link-metadata';
 import type { ScheduleKind } from './schedule';
 
 const STORAGE_KEY = 'inbox-rs:calendar-accounts';
@@ -24,12 +33,27 @@ export interface CalendarAccount {
   url: string;
   username: string;
   password: string;
+  /**
+   * The sockethub relay endpoint, pinned at connect time. Credential-bearing
+   * requests must NOT resolve the relay from the synced `sockethubUrl`
+   * setting at call time: settings sync through remoteStorage, so a
+   * compromised linked device could silently redirect this device's
+   * credential traffic. Pinning here (device-local, set only by the explicit
+   * local connect action) closes that path — changing relays means
+   * re-adding the account.
+   */
+  endpoint: string;
   /** Cached discovery result. */
   calendars: RemoteCalendar[];
   /** Deny-list so newly discovered calendars default to visible. */
   hiddenCalendarIds?: string[];
   /** Preferred calendar for this account (settings ★). */
   defaultCalendarId?: string;
+}
+
+/** The pinned relay for an account (default fallback for legacy entries). */
+export function accountEndpoint(account: CalendarAccount): string {
+  return account.endpoint || DEFAULT_SOCKETHUB_ENDPOINT;
 }
 
 function load(): CalendarAccount[] {

--- a/packages/web/src/lib/calendar-accounts.ts
+++ b/packages/web/src/lib/calendar-accounts.ts
@@ -1,0 +1,160 @@
+/**
+ * Calendar accounts — device-local by design.
+ *
+ * Credentials (CalDAV app passwords) live in localStorage on this device
+ * only. They are deliberately NOT synced through remoteStorage: user data
+ * there syncs in plaintext, and per-request relay through sockethub means
+ * no server ever stores them. Each device that wants to post to a calendar
+ * connects its own account.
+ *
+ * The discovered calendar list is cached per account so pickers render
+ * instantly; "Refresh" in settings re-runs discovery.
+ */
+import { derived, get, writable } from 'svelte/store';
+import type { RemoteCalendar } from './caldav';
+import type { ScheduleKind } from './schedule';
+
+const STORAGE_KEY = 'inbox-rs:calendar-accounts';
+const LAST_USED_KEY = 'inbox-rs:last-calendar';
+
+export interface CalendarAccount {
+  id: string;
+  /** Display label, e.g. "Fastmail". Defaults to the server host. */
+  label: string;
+  url: string;
+  username: string;
+  password: string;
+  /** Cached discovery result. */
+  calendars: RemoteCalendar[];
+  /** Deny-list so newly discovered calendars default to visible. */
+  hiddenCalendarIds?: string[];
+  /** Preferred calendar for this account (settings ★). */
+  defaultCalendarId?: string;
+}
+
+function load(): CalendarAccount[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export const calendarAccounts = writable<CalendarAccount[]>(load());
+
+calendarAccounts.subscribe((accounts) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(accounts));
+  } catch (err) {
+    console.error('Failed to persist calendar accounts', err);
+  }
+});
+
+export const hasCalendarAccounts = derived(
+  calendarAccounts,
+  (accounts) => accounts.length > 0,
+);
+
+export function addCalendarAccount(
+  account: Omit<CalendarAccount, 'id'>,
+): CalendarAccount {
+  const created: CalendarAccount = { ...account, id: crypto.randomUUID() };
+  calendarAccounts.update((accounts) => [...accounts, created]);
+  return created;
+}
+
+export function updateCalendarAccount(
+  id: string,
+  patch: Partial<Omit<CalendarAccount, 'id'>>,
+): void {
+  calendarAccounts.update((accounts) =>
+    accounts.map((a) => (a.id === id ? { ...a, ...patch } : a)),
+  );
+}
+
+export function removeCalendarAccount(id: string): void {
+  calendarAccounts.update((accounts) => accounts.filter((a) => a.id !== id));
+}
+
+export interface CalendarChoice {
+  account: CalendarAccount;
+  calendar: RemoteCalendar;
+}
+
+/** Every non-hidden calendar across accounts, in account order. */
+export function visibleCalendarChoices(
+  accounts: CalendarAccount[] = get(calendarAccounts),
+): CalendarChoice[] {
+  return accounts.flatMap((account) =>
+    account.calendars
+      .filter((c) => !account.hiddenCalendarIds?.includes(c.id))
+      .map((calendar) => ({ account, calendar })),
+  );
+}
+
+export function findCalendarChoice(
+  calendarId: string | undefined,
+): CalendarChoice | undefined {
+  if (!calendarId) return undefined;
+  return visibleCalendarChoices().find((c) => c.calendar.id === calendarId);
+}
+
+/**
+ * The calendar an already-posted entry lives in: its href sits under the
+ * calendar collection's href. Hidden calendars still match — hiding affects
+ * the picker, not the ability to update/remove what was already posted.
+ */
+export function choiceForEventUrl(
+  eventUrl: string | undefined,
+): CalendarChoice | undefined {
+  if (!eventUrl) return undefined;
+  for (const account of get(calendarAccounts)) {
+    for (const calendar of account.calendars) {
+      const prefix = calendar.id.endsWith('/')
+        ? calendar.id
+        : `${calendar.id}/`;
+      if (eventUrl.startsWith(prefix)) return { account, calendar };
+    }
+  }
+  return undefined;
+}
+
+/** Remember the chosen calendar per entry kind ("events" vs "tasks"). */
+export function recordCalendarUse(
+  kind: ScheduleKind,
+  calendarId: string,
+): void {
+  try {
+    localStorage.setItem(`${LAST_USED_KEY}:${kind}`, calendarId);
+  } catch {
+    // best-effort — the picker just falls back to the default
+  }
+}
+
+/**
+ * The picker's initial selection: last used for this kind → an account's
+ * default → the first visible calendar supporting the kind → first visible.
+ */
+export function pickPreferredCalendar(
+  kind: ScheduleKind,
+): CalendarChoice | undefined {
+  const choices = visibleCalendarChoices();
+  if (choices.length === 0) return undefined;
+  let lastUsed: string | null = null;
+  try {
+    lastUsed = localStorage.getItem(`${LAST_USED_KEY}:${kind}`);
+  } catch {
+    // fall through to defaults
+  }
+  const supports = (c: CalendarChoice) => c.calendar.components.includes(kind);
+  return (
+    choices.find((c) => c.calendar.id === lastUsed && supports(c)) ??
+    choices.find(
+      (c) => c.calendar.id === c.account.defaultCalendarId && supports(c),
+    ) ??
+    choices.find(supports) ??
+    choices[0]
+  );
+}

--- a/packages/web/src/lib/enrich.ts
+++ b/packages/web/src/lib/enrich.ts
@@ -25,7 +25,8 @@ export function linkPreviewsEnabled(): boolean {
 }
 
 /** The user's own Sockethub endpoint when set, else the app default. */
-function resolveSockethubEndpoint(): string {
+/** Shared by every sockethub-backed feature (link previews, CalDAV). */
+export function resolveSockethubEndpoint(): string {
   return get(userSettings).sockethubUrl?.trim() || DEFAULT_SOCKETHUB_ENDPOINT;
 }
 

--- a/packages/web/src/lib/ics.test.ts
+++ b/packages/web/src/lib/ics.test.ts
@@ -69,7 +69,17 @@ describe('buildIcs', () => {
   });
 
   it('builds all-day events with an exclusive DTEND', () => {
-    const ics = buildIcs(note({ allDay: true, endsAt: undefined }), NOW)!;
+    // Local-time fixture: all-day dates are taken in the runner's local
+    // day, so a fixed-offset instant would flip dates on far-west runners.
+    const localMidnight = new Date(2026, 6, 31);
+    const ics = buildIcs(
+      note({
+        startsAt: localMidnight.toISOString(),
+        allDay: true,
+        endsAt: undefined,
+      }),
+      NOW,
+    )!;
     expect(ics.text).toContain('DTSTART;VALUE=DATE:20260731');
     expect(ics.text).toContain('DTEND;VALUE=DATE:20260801');
   });
@@ -106,7 +116,24 @@ describe('buildIcs', () => {
     )!;
     expect(ics.text).toContain('SUMMARY:Docs\\; part 1');
     expect(ics.text).toContain('DESCRIPTION:line1\\nline2');
-    expect(ics.text).toContain('URL:https://example.org/a\\,b');
+    // URL is a URI value type — emitted verbatim, no TEXT escaping.
+    expect(ics.text).toContain('URL:https://example.org/a,b');
+  });
+
+  it('drops a URL carrying control characters instead of injecting lines', () => {
+    const ics = buildIcs(
+      {
+        id: 'bm-2',
+        type: 'bookmark',
+        title: 'x',
+        url: 'https://example.org/\r\nX-INJECTED:1',
+        createdAt: '2026-07-28T09:00:00Z',
+        startsAt: '2026-07-31T09:00:00Z',
+      },
+      NOW,
+    )!;
+    expect(ics.text).not.toContain('URL:');
+    expect(ics.text).not.toContain('X-INJECTED');
   });
 
   it('derives a safe filename from the title', () => {

--- a/packages/web/src/lib/ics.test.ts
+++ b/packages/web/src/lib/ics.test.ts
@@ -1,0 +1,116 @@
+import type { InboxItem, NoteItem, TodoItem } from '@inbox-rs/rs-module';
+import { describe, expect, it } from 'vitest';
+import { buildIcs, escapeText, foldLine } from './ics';
+
+const NOW = new Date('2026-07-30T12:00:00Z');
+
+function note(overrides: Partial<NoteItem> = {}): InboxItem {
+  return {
+    id: 'abc-123',
+    type: 'note',
+    title: 'Test note',
+    body: '',
+    createdAt: '2026-07-28T09:00:00Z',
+    startsAt: '2026-07-31T09:00:00+02:00',
+    ...overrides,
+  } as NoteItem;
+}
+
+describe('escapeText', () => {
+  it('escapes backslash, semicolon, comma and newlines', () => {
+    expect(escapeText('a\\b;c,d\ne\r\nf')).toBe('a\\\\b\\;c\\,d\\ne\\nf');
+  });
+});
+
+describe('foldLine', () => {
+  it('leaves short lines alone', () => {
+    expect(foldLine('SUMMARY:short')).toBe('SUMMARY:short');
+  });
+
+  it('folds long lines at 75 octets with a leading space', () => {
+    const folded = foldLine(`DESCRIPTION:${'x'.repeat(200)}`);
+    const lines = folded.split('\r\n');
+    expect(lines.length).toBeGreaterThan(1);
+    for (const [i, line] of lines.entries()) {
+      expect(new TextEncoder().encode(line).length).toBeLessThanOrEqual(75);
+      if (i > 0) expect(line.startsWith(' ')).toBe(true);
+    }
+    // Unfolding restores the original content.
+    expect(folded.replace(/\r\n /g, '')).toBe(`DESCRIPTION:${'x'.repeat(200)}`);
+  });
+
+  it('never splits a multi-byte character across a fold', () => {
+    const folded = foldLine(`SUMMARY:${'é'.repeat(100)}`);
+    for (const line of folded.split('\r\n')) {
+      // Round-tripping through encode/decode is lossless only when no
+      // character was split.
+      const bytes = new TextEncoder().encode(line);
+      expect(new TextDecoder('utf-8', { fatal: true }).decode(bytes)).toBe(
+        line,
+      );
+    }
+  });
+});
+
+describe('buildIcs', () => {
+  it('returns null for unscheduled items', () => {
+    expect(buildIcs(note({ startsAt: undefined }), NOW)).toBeNull();
+  });
+
+  it('builds a timed VEVENT in UTC', () => {
+    const ics = buildIcs(note({ endsAt: '2026-07-31T10:00:00+02:00' }), NOW)!;
+    expect(ics.text).toContain('BEGIN:VEVENT');
+    expect(ics.text).toContain('DTSTART:20260731T070000Z');
+    expect(ics.text).toContain('DTEND:20260731T080000Z');
+    expect(ics.text).toContain('UID:abc-123@inbox-rs');
+    expect(ics.text).toContain('SUMMARY:Test note');
+    expect(ics.text).toContain('DTSTAMP:20260730T120000Z');
+    expect(ics.text.endsWith('END:VCALENDAR\r\n')).toBe(true);
+  });
+
+  it('builds all-day events with an exclusive DTEND', () => {
+    const ics = buildIcs(note({ allDay: true, endsAt: undefined }), NOW)!;
+    expect(ics.text).toContain('DTSTART;VALUE=DATE:20260731');
+    expect(ics.text).toContain('DTEND;VALUE=DATE:20260801');
+  });
+
+  it('builds a VTODO with DUE for tasks, STATUS when completed', () => {
+    const todo: TodoItem = {
+      id: 'todo-1',
+      type: 'todo',
+      title: 'Call dentist',
+      completed: true,
+      createdAt: '2026-07-28T09:00:00Z',
+      startsAt: '2026-07-31T14:00:00Z',
+      scheduleKind: 'task',
+    };
+    const ics = buildIcs(todo, NOW)!;
+    expect(ics.text).toContain('BEGIN:VTODO');
+    expect(ics.text).toContain('DUE:20260731T140000Z');
+    expect(ics.text).toContain('STATUS:COMPLETED');
+    expect(ics.text).not.toContain('VEVENT');
+  });
+
+  it('includes DESCRIPTION and bookmark URL, escaped', () => {
+    const ics = buildIcs(
+      {
+        id: 'bm-1',
+        type: 'bookmark',
+        title: 'Docs; part 1',
+        url: 'https://example.org/a,b',
+        description: 'line1\nline2',
+        createdAt: '2026-07-28T09:00:00Z',
+        startsAt: '2026-07-31T09:00:00Z',
+      },
+      NOW,
+    )!;
+    expect(ics.text).toContain('SUMMARY:Docs\\; part 1');
+    expect(ics.text).toContain('DESCRIPTION:line1\\nline2');
+    expect(ics.text).toContain('URL:https://example.org/a\\,b');
+  });
+
+  it('derives a safe filename from the title', () => {
+    const ics = buildIcs(note({ title: 'Héllo / World!!' }), NOW)!;
+    expect(ics.filename).toBe('h-llo-world.ics');
+  });
+});

--- a/packages/web/src/lib/ics.ts
+++ b/packages/web/src/lib/ics.ts
@@ -1,0 +1,158 @@
+/**
+ * iCalendar (RFC 5545) generation for scheduled cards.
+ *
+ * A scheduled card projects to a single VEVENT (scheduleKind 'event') or
+ * VTODO ('task'). Recurrence, timezones-by-reference (VTIMEZONE), and
+ * attendees are deliberately out of scope: timed values are written in UTC,
+ * all-day values as DATE. This keeps the output tiny and universally
+ * importable, and matches the v1 scope of the CalDAV platform
+ * (sockethub/sockethub#1189).
+ */
+import type { InboxItem } from '@inbox-rs/rs-module';
+
+/** RFC 5545 §3.3.11: backslash, semicolon, comma and newline must be escaped. */
+export function escapeText(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\r\n|\r|\n/g, '\\n');
+}
+
+/**
+ * RFC 5545 §3.1: content lines longer than 75 octets must be folded with
+ * CRLF + single space. Folding is done on UTF-8 byte length — splitting a
+ * multi-byte character across a fold produces invalid UTF-8.
+ */
+export function foldLine(line: string): string {
+  const encoder = new TextEncoder();
+  if (encoder.encode(line).length <= 75) return line;
+  const out: string[] = [];
+  let current = '';
+  let currentBytes = 0;
+  // Continuation lines start with a space, which counts toward the 75.
+  let limit = 75;
+  for (const ch of line) {
+    const chBytes = encoder.encode(ch).length;
+    if (currentBytes + chBytes > limit) {
+      out.push(current);
+      current = ' ';
+      currentBytes = 1;
+      limit = 75;
+    }
+    current += ch;
+    currentBytes += chBytes;
+  }
+  out.push(current);
+  return out.join('\r\n');
+}
+
+/** 20260731T090000Z — the UTC instant form. */
+function toUtcStamp(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}` +
+    `T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`
+  );
+}
+
+/**
+ * 20260731 — the DATE form, taken in *local* time. All-day pickers produce
+ * a local calendar date; converting through UTC would shift the day for
+ * anyone east of Greenwich scheduling before their UTC offset past midnight.
+ */
+function toDateStamp(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}`;
+}
+
+/** DATE + n days, for the exclusive DTEND of all-day events. */
+function addDays(iso: string, days: number): string {
+  const d = new Date(iso);
+  d.setDate(d.getDate() + days);
+  return d.toISOString();
+}
+
+export interface IcsResult {
+  /** Full VCALENDAR text, CRLF line endings. */
+  text: string;
+  /** Suggested download filename. */
+  filename: string;
+}
+
+/**
+ * Build a single-entry VCALENDAR for a scheduled item. Returns null when the
+ * item has no startsAt — callers should treat that as "nothing to export".
+ */
+export function buildIcs(
+  item: InboxItem,
+  now: Date = new Date(),
+): IcsResult | null {
+  if (!item.startsAt) return null;
+  const isTask = item.scheduleKind === 'task';
+  const lines: string[] = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//inbox-rs//EN',
+    isTask ? 'BEGIN:VTODO' : 'BEGIN:VEVENT',
+    // Stable UID: re-importing an updated .ics replaces the prior entry
+    // instead of duplicating it.
+    `UID:${escapeText(item.id)}@inbox-rs`,
+    `DTSTAMP:${toUtcStamp(now.toISOString())}`,
+    `SUMMARY:${escapeText(item.title || 'Untitled')}`,
+  ];
+
+  if (isTask) {
+    if (item.allDay) {
+      lines.push(`DUE;VALUE=DATE:${toDateStamp(item.startsAt)}`);
+    } else {
+      lines.push(`DUE:${toUtcStamp(item.startsAt)}`);
+    }
+    if (item.completed) lines.push('STATUS:COMPLETED');
+  } else if (item.allDay) {
+    lines.push(`DTSTART;VALUE=DATE:${toDateStamp(item.startsAt)}`);
+    // DTEND is exclusive: a one-day event ends the following day.
+    lines.push(
+      `DTEND;VALUE=DATE:${toDateStamp(addDays(item.endsAt ?? item.startsAt, 1))}`,
+    );
+  } else {
+    lines.push(`DTSTART:${toUtcStamp(item.startsAt)}`);
+    if (item.endsAt) lines.push(`DTEND:${toUtcStamp(item.endsAt)}`);
+  }
+
+  if (item.description) {
+    lines.push(`DESCRIPTION:${escapeText(item.description)}`);
+  }
+  if (item.type === 'bookmark' && item.url) {
+    lines.push(`URL:${escapeText(item.url)}`);
+  }
+
+  lines.push(isTask ? 'END:VTODO' : 'END:VEVENT', 'END:VCALENDAR');
+
+  const safeTitle = (item.title || 'event')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+  return {
+    text: `${lines.map(foldLine).join('\r\n')}\r\n`,
+    filename: `${safeTitle || 'event'}.ics`,
+  };
+}
+
+/** Trigger a browser download of the item's .ics. No-op when unscheduled. */
+export function downloadIcs(item: InboxItem): void {
+  const ics = buildIcs(item);
+  if (!ics) return;
+  const blob = new Blob([ics.text], { type: 'text/calendar;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = ics.filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/packages/web/src/lib/ics.ts
+++ b/packages/web/src/lib/ics.ts
@@ -10,6 +10,11 @@
  */
 import type { InboxItem } from '@inbox-rs/rs-module';
 
+/** Rejecting the C0 control range is the point: a CR/LF inside a verbatim
+ *  URI value would break out of its content line (property injection). */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: see above
+const CONTROL_CHARS = /[\u0000-\u001f]/;
+
 /** RFC 5545 §3.3.11: backslash, semicolon, comma and newline must be escaped. */
 export function escapeText(value: string): string {
   return value
@@ -125,8 +130,11 @@ export function buildIcs(
   if (item.description) {
     lines.push(`DESCRIPTION:${escapeText(item.description)}`);
   }
-  if (item.type === 'bookmark' && item.url) {
-    lines.push(`URL:${escapeText(item.url)}`);
+  // URL is a URI value type (RFC 5545 §3.3.13) — TEXT backslash-escaping
+  // does not apply and would corrupt commas/semicolons in query strings.
+  // Emit verbatim; CONTROL_CHARS guards against content-line breakout.
+  if (item.type === 'bookmark' && item.url && !CONTROL_CHARS.test(item.url)) {
+    lines.push(`URL:${item.url}`);
   }
 
   lines.push(isTask ? 'END:VTODO' : 'END:VEVENT', 'END:VCALENDAR');

--- a/packages/web/src/lib/schedule-sync.test.ts
+++ b/packages/web/src/lib/schedule-sync.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import type { NoteItem, TodoItem } from '@inbox-rs/rs-module';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./stores', () => ({ storeItem: vi.fn(async () => {}) }));
+vi.mock('./caldav', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    createEntry: vi.fn(async () => ({
+      eventUrl: 'https://cal.example.org/nick/personal/x.ics',
+      eventEtag: '"e1"',
+    })),
+    updateEntry: vi.fn(async () => ({
+      eventUrl: 'https://cal.example.org/nick/personal/x.ics',
+      eventEtag: '"e2"',
+    })),
+    deleteEntry: vi.fn(async () => {}),
+  };
+});
+
+import { calendarAccounts } from './calendar-accounts';
+import { addItemToCalendar, removeItemFromCalendar } from './schedule-sync';
+import { storeItem } from './stores';
+
+const CAL = {
+  id: 'https://cal.example.org/nick/personal/',
+  name: 'Personal',
+  components: ['event', 'task'] as Array<'event' | 'task'>,
+};
+
+function note(overrides: Partial<NoteItem> = {}): NoteItem {
+  return {
+    id: 'n1',
+    type: 'note',
+    title: 'n',
+    body: '',
+    createdAt: '2026-07-01T00:00:00Z',
+    startsAt: '2026-08-03T13:00:00.000Z',
+    scheduleKind: 'event',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  calendarAccounts.set([
+    {
+      id: 'acc1',
+      label: 'Fastmail',
+      url: 'https://cal.example.org/',
+      username: 'nick',
+      password: 'pw',
+      endpoint: 'https://relay.example.org/sockethub-http',
+      calendars: [CAL],
+    },
+  ]);
+});
+
+function lastStored(): Record<string, unknown> {
+  const calls = vi.mocked(storeItem).mock.calls;
+  return calls[calls.length - 1][0] as Record<string, unknown>;
+}
+
+describe('addItemToCalendar — the archive ownership rule', () => {
+  it('archives an Inbox reference card on first post', async () => {
+    const result = await addItemToCalendar(note(), CAL.id);
+    expect(result.archived).toBe(true);
+    expect(result.archivedAt).toBeTruthy();
+    expect(lastStored().archived).toBe(true);
+  });
+
+  it('never archives todos — they complete instead', async () => {
+    const todo: TodoItem = {
+      id: 't1',
+      type: 'todo',
+      title: 't',
+      completed: false,
+      createdAt: '2026-07-01T00:00:00Z',
+      startsAt: '2026-08-03T13:00:00.000Z',
+      scheduleKind: 'task',
+    };
+    const result = await addItemToCalendar(todo, CAL.id);
+    expect(result.archived).toBeUndefined();
+  });
+
+  it('does not archive filed cards — they are already triaged', async () => {
+    const filed = note({ collectionId: 'col-1' });
+    const result = await addItemToCalendar(filed, CAL.id);
+    expect(result.archived).toBeUndefined();
+  });
+
+  it('does not re-archive on subsequent posts (calendar move keeps state)', async () => {
+    const posted = note({
+      eventUrl: `${CAL.id}x.ics`,
+      eventEtag: '"e1"',
+    });
+    const result = await addItemToCalendar(posted, CAL.id);
+    expect(result.archived).toBeUndefined();
+  });
+});
+
+describe('removeItemFromCalendar', () => {
+  it('clears the entry pointer and un-archives, keeping the time', async () => {
+    const archived = note({
+      eventUrl: `${CAL.id}x.ics`,
+      eventEtag: '"e1"',
+      archived: true,
+      archivedAt: '2026-08-01T00:00:00Z',
+    });
+    const result = await removeItemFromCalendar(archived);
+    expect(result.eventUrl).toBeUndefined();
+    expect(result.eventEtag).toBeUndefined();
+    expect(result.archived).toBeUndefined();
+    expect(result.archivedAt).toBeUndefined();
+    expect(result.startsAt).toBe(archived.startsAt);
+  });
+});

--- a/packages/web/src/lib/schedule-sync.ts
+++ b/packages/web/src/lib/schedule-sync.ts
@@ -14,9 +14,12 @@ import {
   recordCalendarUse,
 } from './calendar-accounts';
 import { cleanForStorage } from './clean-for-storage';
-import { applySchedule, type PendingSchedule } from './schedule';
+import {
+  applySchedule,
+  clearPostedEntry,
+  type PendingSchedule,
+} from './schedule';
 import { storeItem } from './stores';
-import { showToast } from './toast';
 
 /**
  * Post the (already locally saved) scheduled item to `calendarId`. Handles
@@ -126,31 +129,55 @@ export async function setItemCompleted(
 }
 
 /**
- * Apply a capture-time schedule to a freshly created item: persist the
- * schedule fields, then post to the chosen calendar when one was picked.
- * A failed post keeps the local schedule and toasts why — same local-first
- * contract as the schedule sheet. `item` must already carry its final
- * collectionId (call after any moveItemToCollection).
+ * Apply a capture-time schedule to a freshly created item. Deliberately
+ * calendar-free: setting a time is card metadata; adding to a calendar is a
+ * separate action taken later from the card. `item` must already carry its
+ * final collectionId (call after any moveItemToCollection).
  */
 export async function applyPendingSchedule(
   item: InboxItem,
   pending: PendingSchedule,
 ): Promise<void> {
-  let scheduled = applySchedule(item, pending);
-  await storeItem(cleanForStorage(scheduled));
-  if (!pending.calendarId) return;
-  try {
-    scheduled = await postScheduledItem(scheduled, pending.calendarId);
-    await storeItem(cleanForStorage(scheduled));
-    recordCalendarUse(pending.kind, pending.calendarId);
-  } catch (err) {
-    console.error('Calendar post failed', err);
-    const reason =
-      err instanceof CaldavError
-        ? err.message
-        : 'the calendar relay is unreachable';
-    showToast(`Scheduled locally — ${reason}`);
+  await storeItem(cleanForStorage(applySchedule(item, pending)));
+}
+
+/**
+ * Post the item to a calendar and apply the ownership rule: adding an
+ * *Inbox reference card* to a calendar completes its triage — the calendar
+ * owns it now, so the card is archived out of the Inbox. Todos are never
+ * archived (they still need completing in the app), and filed cards are
+ * already triaged. Returns the stored item.
+ */
+export async function addItemToCalendar(
+  item: InboxItem,
+  calendarId: string,
+): Promise<InboxItem> {
+  const firstPost = !item.eventUrl;
+  let posted = await postScheduledItem(item, calendarId);
+  const isTodoish = posted.isTodo || posted.type === 'todo';
+  if (firstPost && !isTodoish && !posted.collectionId) {
+    posted = {
+      ...posted,
+      archived: true,
+      archivedAt: new Date().toISOString(),
+    };
   }
+  await storeItem(cleanForStorage(posted));
+  return posted;
+}
+
+/**
+ * Detach the item from its calendar: delete the server entry, keep the
+ * time, un-archive (the card returns to the Inbox queue). Throws when the
+ * server refused and the entry may still exist — callers keep state as-is.
+ */
+export async function removeItemFromCalendar(
+  item: InboxItem,
+): Promise<InboxItem> {
+  await removePostedEntry(item);
+  const updated = clearPostedEntry(item);
+  await storeItem(cleanForStorage(updated));
+  return updated;
 }
 
 export { recordCalendarUse };

--- a/packages/web/src/lib/schedule-sync.ts
+++ b/packages/web/src/lib/schedule-sync.ts
@@ -69,9 +69,9 @@ export async function postScheduledItem(
 }
 
 /**
- * Delete the item's posted entry. Resolves true when the calendar no longer
- * has the entry (deleted now, already gone, or never posted); throws only
- * when the server refused and the entry may still exist.
+ * Delete the item's posted entry. Resolves (with no value) once the calendar
+ * no longer has the entry — deleted now, already gone, or never posted;
+ * throws only when the server refused and the entry may still exist.
  */
 export async function removePostedEntry(item: InboxItem): Promise<void> {
   const current = choiceForEventUrl(item.eventUrl);

--- a/packages/web/src/lib/schedule-sync.ts
+++ b/packages/web/src/lib/schedule-sync.ts
@@ -14,7 +14,9 @@ import {
 } from './calendar-accounts';
 import { cleanForStorage } from './clean-for-storage';
 import { resolveSockethubEndpoint } from './enrich';
+import { applySchedule, type PendingSchedule } from './schedule';
 import { storeItem } from './stores';
+import { showToast } from './toast';
 
 /**
  * Post the (already locally saved) scheduled item to `calendarId`. Handles
@@ -111,6 +113,34 @@ export async function setItemCompleted(
     await storeItem(cleanForStorage({ ...updated, ...posted }));
   } catch (err) {
     console.warn('Calendar completion sync failed (kept local state)', err);
+  }
+}
+
+/**
+ * Apply a capture-time schedule to a freshly created item: persist the
+ * schedule fields, then post to the chosen calendar when one was picked.
+ * A failed post keeps the local schedule and toasts why — same local-first
+ * contract as the schedule sheet. `item` must already carry its final
+ * collectionId (call after any moveItemToCollection).
+ */
+export async function applyPendingSchedule(
+  item: InboxItem,
+  pending: PendingSchedule,
+): Promise<void> {
+  let scheduled = applySchedule(item, pending);
+  await storeItem(cleanForStorage(scheduled));
+  if (!pending.calendarId) return;
+  try {
+    scheduled = await postScheduledItem(scheduled, pending.calendarId);
+    await storeItem(cleanForStorage(scheduled));
+    recordCalendarUse(pending.kind, pending.calendarId);
+  } catch (err) {
+    console.error('Calendar post failed', err);
+    const reason =
+      err instanceof CaldavError
+        ? err.message
+        : 'the calendar relay is unreachable';
+    showToast(`Scheduled locally — ${reason}`);
   }
 }
 

--- a/packages/web/src/lib/schedule-sync.ts
+++ b/packages/web/src/lib/schedule-sync.ts
@@ -8,12 +8,12 @@
 import type { InboxItem } from '@inbox-rs/rs-module';
 import { CaldavError, createEntry, deleteEntry, updateEntry } from './caldav';
 import {
+  accountEndpoint,
   choiceForEventUrl,
   findCalendarChoice,
   recordCalendarUse,
 } from './calendar-accounts';
 import { cleanForStorage } from './clean-for-storage';
-import { resolveSockethubEndpoint } from './enrich';
 import { applySchedule, type PendingSchedule } from './schedule';
 import { storeItem } from './stores';
 import { showToast } from './toast';
@@ -29,7 +29,6 @@ export async function postScheduledItem(
   item: InboxItem,
   calendarId: string,
 ): Promise<InboxItem> {
-  const endpoint = resolveSockethubEndpoint();
   const target = findCalendarChoice(calendarId);
   if (!target) throw new CaldavError('caldav:invalid-calendar');
 
@@ -39,7 +38,7 @@ export async function postScheduledItem(
       current.account,
       calendarId,
       item,
-      endpoint,
+      accountEndpoint(current.account),
     );
     return { ...item, ...posted };
   }
@@ -48,14 +47,24 @@ export async function postScheduledItem(
     // (deleted out-of-band in the calendar app) is fine — the goal state is
     // "not there", and create below still runs.
     try {
-      await deleteEntry(current.account, current.calendar.id, item, endpoint);
+      await deleteEntry(
+        current.account,
+        current.calendar.id,
+        item,
+        accountEndpoint(current.account),
+      );
     } catch (err) {
       if (!(err instanceof CaldavError && err.code === 'caldav:not-found')) {
         throw err;
       }
     }
   }
-  const posted = await createEntry(target.account, calendarId, item, endpoint);
+  const posted = await createEntry(
+    target.account,
+    calendarId,
+    item,
+    accountEndpoint(target.account),
+  );
   return { ...item, ...posted };
 }
 
@@ -72,7 +81,7 @@ export async function removePostedEntry(item: InboxItem): Promise<void> {
       current.account,
       current.calendar.id,
       item,
-      resolveSockethubEndpoint(),
+      accountEndpoint(current.account),
     );
   } catch (err) {
     if (err instanceof CaldavError && err.code === 'caldav:not-found') return;
@@ -108,7 +117,7 @@ export async function setItemCompleted(
       current.account,
       current.calendar.id,
       updated,
-      resolveSockethubEndpoint(),
+      accountEndpoint(current.account),
     );
     await storeItem(cleanForStorage({ ...updated, ...posted }));
   } catch (err) {

--- a/packages/web/src/lib/schedule-sync.ts
+++ b/packages/web/src/lib/schedule-sync.ts
@@ -1,0 +1,117 @@
+/**
+ * Orchestrates posting a card's schedule to a CalDAV calendar via the
+ * sockethub relay: create vs update vs move, entry removal, and best-effort
+ * completion sync for tasks. The card is always the source of truth — these
+ * helpers only maintain the calendar-side projection and the stored
+ * eventUrl/eventEtag pointing at it.
+ */
+import type { InboxItem } from '@inbox-rs/rs-module';
+import { CaldavError, createEntry, deleteEntry, updateEntry } from './caldav';
+import {
+  choiceForEventUrl,
+  findCalendarChoice,
+  recordCalendarUse,
+} from './calendar-accounts';
+import { cleanForStorage } from './clean-for-storage';
+import { resolveSockethubEndpoint } from './enrich';
+import { storeItem } from './stores';
+
+/**
+ * Post the (already locally saved) scheduled item to `calendarId`. Handles
+ * all three shapes: first post (create), same-calendar change (update), and
+ * calendar move (delete from the old calendar, create in the new one).
+ * Returns the item with its eventUrl/eventEtag refreshed — the caller
+ * persists it.
+ */
+export async function postScheduledItem(
+  item: InboxItem,
+  calendarId: string,
+): Promise<InboxItem> {
+  const endpoint = resolveSockethubEndpoint();
+  const target = findCalendarChoice(calendarId);
+  if (!target) throw new CaldavError('caldav:invalid-calendar');
+
+  const current = choiceForEventUrl(item.eventUrl);
+  if (item.eventUrl && current && current.calendar.id === calendarId) {
+    const posted = await updateEntry(
+      current.account,
+      calendarId,
+      item,
+      endpoint,
+    );
+    return { ...item, ...posted };
+  }
+  if (item.eventUrl && current) {
+    // Moving calendars: remove the old projection first. A vanished entry
+    // (deleted out-of-band in the calendar app) is fine — the goal state is
+    // "not there", and create below still runs.
+    try {
+      await deleteEntry(current.account, current.calendar.id, item, endpoint);
+    } catch (err) {
+      if (!(err instanceof CaldavError && err.code === 'caldav:not-found')) {
+        throw err;
+      }
+    }
+  }
+  const posted = await createEntry(target.account, calendarId, item, endpoint);
+  return { ...item, ...posted };
+}
+
+/**
+ * Delete the item's posted entry. Resolves true when the calendar no longer
+ * has the entry (deleted now, already gone, or never posted); throws only
+ * when the server refused and the entry may still exist.
+ */
+export async function removePostedEntry(item: InboxItem): Promise<void> {
+  const current = choiceForEventUrl(item.eventUrl);
+  if (!item.eventUrl || !current) return;
+  try {
+    await deleteEntry(
+      current.account,
+      current.calendar.id,
+      item,
+      resolveSockethubEndpoint(),
+    );
+  } catch (err) {
+    if (err instanceof CaldavError && err.code === 'caldav:not-found') return;
+    throw err;
+  }
+}
+
+/**
+ * The shared completion toggle: persists the flip locally, then — for tasks
+ * with a posted entry — syncs STATUS:COMPLETED to the calendar best-effort.
+ * Calendar failures never block or revert the local toggle; the next
+ * successful post refreshes the projection.
+ */
+export async function setItemCompleted(
+  item: InboxItem,
+  completed: boolean,
+): Promise<void> {
+  const updated: InboxItem = {
+    ...item,
+    isTodo: true,
+    completed,
+    completedAt: completed ? new Date().toISOString() : undefined,
+  };
+  await storeItem(cleanForStorage(updated));
+
+  if (item.scheduleKind !== 'task' || !item.eventUrl || !item.eventEtag) {
+    return;
+  }
+  const current = choiceForEventUrl(item.eventUrl);
+  if (!current) return;
+  try {
+    const posted = await updateEntry(
+      current.account,
+      current.calendar.id,
+      updated,
+      resolveSockethubEndpoint(),
+    );
+    await storeItem(cleanForStorage({ ...updated, ...posted }));
+  } catch (err) {
+    console.warn('Calendar completion sync failed (kept local state)', err);
+  }
+}
+
+export { recordCalendarUse };

--- a/packages/web/src/lib/schedule.test.ts
+++ b/packages/web/src/lib/schedule.test.ts
@@ -201,4 +201,10 @@ describe('input value round-trip', () => {
     expect(fromInputValues('', '09:00')).toBeNull();
     expect(fromInputValues('2026-99-99', '')).toBeNull();
   });
+
+  it('rejects out-of-range times instead of normalizing them', () => {
+    expect(fromInputValues('2026-07-31', '12:60')).toBeNull();
+    expect(fromInputValues('2026-07-31', '24:00')).toBeNull();
+    expect(fromInputValues('2026-07-31', '23:59')).not.toBeNull();
+  });
 });

--- a/packages/web/src/lib/schedule.test.ts
+++ b/packages/web/src/lib/schedule.test.ts
@@ -1,0 +1,204 @@
+import type { NoteItem } from '@inbox-rs/rs-module';
+import { describe, expect, it } from 'vitest';
+import {
+  applySchedule,
+  clearSchedule,
+  formatScheduled,
+  fromInputValues,
+  isOverdue,
+  isPast,
+  nextRoundHour,
+  quickOptions,
+  toDateInputValue,
+  toTimeInputValue,
+} from './schedule';
+
+// A local-time Wednesday afternoon.
+const WED_1423 = new Date(2026, 6, 29, 14, 23);
+
+function note(overrides: Partial<NoteItem> = {}): NoteItem {
+  return {
+    id: 'n1',
+    type: 'note',
+    title: 'n',
+    body: '',
+    createdAt: '2026-07-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('nextRoundHour', () => {
+  it('rounds up to the next full hour', () => {
+    expect(nextRoundHour(WED_1423).getHours()).toBe(15);
+    expect(nextRoundHour(WED_1423).getMinutes()).toBe(0);
+  });
+});
+
+describe('quickOptions', () => {
+  it('offers tonight/tomorrow/saturday/next-week from a weekday afternoon', () => {
+    const opts = quickOptions(WED_1423);
+    expect(opts.map((o) => o.label)).toEqual([
+      'Tonight 19:00',
+      'Tomorrow 09:00',
+      'Sat morning',
+      'Next week',
+    ]);
+    const sat = opts[2].start;
+    expect(sat.getDay()).toBe(6);
+    expect(sat.getHours()).toBe(10);
+    const mon = opts[3].start;
+    expect(mon.getDay()).toBe(1);
+    expect(mon.getTime()).toBeGreaterThan(WED_1423.getTime());
+  });
+
+  it('drops options already in the past', () => {
+    const lateEvening = new Date(2026, 6, 29, 22, 0);
+    expect(quickOptions(lateEvening).map((o) => o.label)).not.toContain(
+      'Tonight 19:00',
+    );
+  });
+
+  it('never suggests "Sat morning" meaning today', () => {
+    const saturdayMorning = new Date(2026, 7, 1, 8, 0); // Sat Aug 1
+    const sat = quickOptions(saturdayMorning).find(
+      (o) => o.label === 'Sat morning',
+    );
+    expect(sat).toBeDefined();
+    expect(sat!.start.getDate()).toBe(8); // the following Saturday
+  });
+});
+
+describe('formatScheduled', () => {
+  it('renders date and time, dropping the current year', () => {
+    const item = note({ startsAt: new Date(2026, 6, 31, 9, 0).toISOString() });
+    const label = formatScheduled(item, WED_1423);
+    expect(label).toContain('Jul 31');
+    expect(label).not.toContain('2026');
+    expect(label).toContain('·');
+  });
+
+  it('renders date-only for all-day, with year when it differs', () => {
+    const item = note({
+      startsAt: new Date(2027, 0, 5).toISOString(),
+      allDay: true,
+    });
+    const label = formatScheduled(item, WED_1423);
+    expect(label).toContain('2027');
+    expect(label).not.toContain('·');
+  });
+
+  it('is empty for unscheduled or malformed values', () => {
+    expect(formatScheduled(note(), WED_1423)).toBe('');
+    expect(formatScheduled(note({ startsAt: 'garbage' }), WED_1423)).toBe('');
+  });
+});
+
+describe('isOverdue / isPast', () => {
+  const past = new Date(2026, 6, 28, 9, 0).toISOString();
+  it('marks pending past-due tasks overdue, but never events', () => {
+    expect(
+      isOverdue(note({ startsAt: past, scheduleKind: 'task' }), WED_1423),
+    ).toBe(true);
+    expect(
+      isOverdue(
+        note({ startsAt: past, scheduleKind: 'task', completed: true }),
+        WED_1423,
+      ),
+    ).toBe(false);
+    expect(
+      isOverdue(note({ startsAt: past, scheduleKind: 'event' }), WED_1423),
+    ).toBe(false);
+  });
+
+  it('all-day tasks are due end-of-day, not midnight', () => {
+    const todayAllDay = note({
+      startsAt: new Date(2026, 6, 29).toISOString(),
+      allDay: true,
+      scheduleKind: 'task',
+    });
+    expect(isOverdue(todayAllDay, WED_1423)).toBe(false);
+  });
+
+  it('isPast keys off the end for events with a duration', () => {
+    const running = note({
+      startsAt: new Date(2026, 6, 29, 14, 0).toISOString(),
+      endsAt: new Date(2026, 6, 29, 15, 0).toISOString(),
+    });
+    expect(isPast(running, WED_1423)).toBe(false);
+    expect(isPast(note({ startsAt: past }), WED_1423)).toBe(true);
+  });
+});
+
+describe('applySchedule / clearSchedule', () => {
+  it('computes endsAt from duration for timed events', () => {
+    const start = new Date(2026, 6, 31, 9, 0);
+    const item = applySchedule(note(), {
+      kind: 'event',
+      start,
+      durationMin: 90,
+    });
+    expect(item.startsAt).toBe(start.toISOString());
+    expect(new Date(item.endsAt!).getTime() - start.getTime()).toBe(
+      90 * 60_000,
+    );
+    expect(item.scheduleKind).toBe('event');
+    expect(item.allDay).toBeUndefined();
+  });
+
+  it('normalizes all-day starts to local midnight and drops endsAt/duration', () => {
+    const item = applySchedule(note(), {
+      kind: 'event',
+      start: new Date(2026, 6, 31, 9, 30),
+      durationMin: 60,
+      allDay: true,
+    });
+    const d = new Date(item.startsAt!);
+    expect([d.getHours(), d.getMinutes()]).toEqual([0, 0]);
+    expect(item.endsAt).toBeUndefined();
+    expect(item.allDay).toBe(true);
+  });
+
+  it('tasks never get endsAt; rescheduling preserves the posted event ref', () => {
+    const scheduled = applySchedule(
+      note({ eventUrl: 'https://cal/x.ics', eventEtag: '"1"' }),
+      { kind: 'task', start: new Date(2026, 6, 31, 14, 0), durationMin: 60 },
+    );
+    expect(scheduled.endsAt).toBeUndefined();
+    expect(scheduled.eventUrl).toBe('https://cal/x.ics');
+    expect(scheduled.eventEtag).toBe('"1"');
+  });
+
+  it('clearSchedule strips every scheduling field including the event ref', () => {
+    const scheduled = applySchedule(
+      note({ eventUrl: 'https://cal/x.ics', eventEtag: '"1"' }),
+      { kind: 'event', start: new Date(), durationMin: 60 },
+    );
+    const cleared = clearSchedule(scheduled);
+    for (const key of [
+      'startsAt',
+      'endsAt',
+      'allDay',
+      'scheduleKind',
+      'eventUrl',
+      'eventEtag',
+    ] as const) {
+      expect(cleared[key]).toBeUndefined();
+    }
+  });
+});
+
+describe('input value round-trip', () => {
+  it('converts to and from date/time input strings in local time', () => {
+    const d = new Date(2026, 6, 31, 9, 5);
+    expect(toDateInputValue(d)).toBe('2026-07-31');
+    expect(toTimeInputValue(d)).toBe('09:05');
+    expect(fromInputValues('2026-07-31', '09:05')!.getTime()).toBe(d.getTime());
+  });
+
+  it('empty time means local midnight; invalid date is null', () => {
+    const d = fromInputValues('2026-07-31', '')!;
+    expect([d.getHours(), d.getMinutes()]).toEqual([0, 0]);
+    expect(fromInputValues('', '09:00')).toBeNull();
+    expect(fromInputValues('2026-99-99', '')).toBeNull();
+  });
+});

--- a/packages/web/src/lib/schedule.ts
+++ b/packages/web/src/lib/schedule.ts
@@ -1,0 +1,177 @@
+/**
+ * Scheduling helpers: quick-pick time suggestions, schedule formatting for
+ * chips, and applying/clearing the schedule fields on an item.
+ *
+ * All date math is local-time — the user schedules in their own wall-clock;
+ * conversion to UTC happens only at .ics/CalDAV serialization (see ics.ts).
+ */
+import type { InboxItem } from '@inbox-rs/rs-module';
+
+export type ScheduleKind = 'event' | 'task';
+
+export interface QuickOption {
+  label: string;
+  start: Date;
+}
+
+/** The prefilled guess: the next round hour ("14:23" → 15:00). */
+export function nextRoundHour(now: Date = new Date()): Date {
+  const d = new Date(now);
+  d.setHours(d.getHours() + 1, 0, 0, 0);
+  return d;
+}
+
+/**
+ * One-tap suggestions covering the common cases. Options whose moment has
+ * already passed are dropped (no "Tonight 19:00" at 22:00).
+ */
+export function quickOptions(now: Date = new Date()): QuickOption[] {
+  const at = (base: Date, addDays: number, hour: number): Date => {
+    const d = new Date(base);
+    d.setDate(d.getDate() + addDays);
+    d.setHours(hour, 0, 0, 0);
+    return d;
+  };
+  // Next Saturday (never today — "Sat morning" on a Saturday means next week).
+  const untilSaturday = (6 - now.getDay() + 7) % 7 || 7;
+  // Next Monday, same rule.
+  const untilMonday = (1 - now.getDay() + 7) % 7 || 7;
+  const options: QuickOption[] = [
+    { label: 'Tonight 19:00', start: at(now, 0, 19) },
+    { label: 'Tomorrow 09:00', start: at(now, 1, 9) },
+    { label: 'Sat morning', start: at(now, untilSaturday, 10) },
+    { label: 'Next week', start: at(now, untilMonday, 9) },
+  ];
+  return options.filter((o) => o.start.getTime() > now.getTime());
+}
+
+/**
+ * Chip/row label for a scheduled item: "Fri, Jul 31 · 09:00", date-only when
+ * all-day, and with the year appended once it differs from the current one.
+ */
+export function formatScheduled(
+  item: Pick<InboxItem, 'startsAt' | 'allDay'>,
+  now: Date = new Date(),
+): string {
+  if (!item.startsAt) return '';
+  const d = new Date(item.startsAt);
+  if (Number.isNaN(d.getTime())) return '';
+  const date = d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    ...(d.getFullYear() !== now.getFullYear() ? { year: 'numeric' } : {}),
+  });
+  if (item.allDay) return date;
+  const time = d.toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+  return `${date} · ${time}`;
+}
+
+/** A pending task past its due moment. Events merely become "past", not overdue. */
+export function isOverdue(
+  item: Pick<InboxItem, 'startsAt' | 'allDay' | 'scheduleKind' | 'completed'>,
+  now: Date = new Date(),
+): boolean {
+  if (!item.startsAt || item.scheduleKind !== 'task' || item.completed) {
+    return false;
+  }
+  const due = new Date(item.startsAt);
+  if (item.allDay) due.setHours(23, 59, 59, 999); // due "sometime that day"
+  return due.getTime() < now.getTime();
+}
+
+/** The scheduled moment (or the event's end) is behind us. */
+export function isPast(
+  item: Pick<InboxItem, 'startsAt' | 'endsAt' | 'allDay'>,
+  now: Date = new Date(),
+): boolean {
+  if (!item.startsAt) return false;
+  const end = new Date(item.endsAt ?? item.startsAt);
+  if (item.allDay) end.setHours(23, 59, 59, 999);
+  return end.getTime() < now.getTime();
+}
+
+export interface ScheduleInput {
+  kind: ScheduleKind;
+  start: Date;
+  /** Minutes; only meaningful for timed events. */
+  durationMin?: number;
+  allDay?: boolean;
+}
+
+/**
+ * Return a copy of the item carrying the given schedule. Any previously
+ * posted calendar entry's href/etag is preserved — the caller (future CalDAV
+ * sync) uses it to update the projection.
+ */
+export function applySchedule<T extends InboxItem>(
+  item: T,
+  input: ScheduleInput,
+): T {
+  const start = new Date(input.start);
+  if (input.allDay) start.setHours(0, 0, 0, 0);
+  const endsAt =
+    input.kind === 'event' && !input.allDay && input.durationMin
+      ? new Date(start.getTime() + input.durationMin * 60_000).toISOString()
+      : undefined;
+  return {
+    ...item,
+    startsAt: start.toISOString(),
+    endsAt,
+    allDay: input.allDay || undefined,
+    scheduleKind: input.kind,
+  };
+}
+
+/** Return a copy of the item with all scheduling removed. */
+export function clearSchedule<T extends InboxItem>(item: T): T {
+  return {
+    ...item,
+    startsAt: undefined,
+    endsAt: undefined,
+    allDay: undefined,
+    scheduleKind: undefined,
+    eventUrl: undefined,
+    eventEtag: undefined,
+  };
+}
+
+/** YYYY-MM-DD for <input type="date">, in local time. */
+export function toDateInputValue(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** HH:MM for <input type="time">, in local time. */
+export function toTimeInputValue(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
+ * Combine date + time input values into a local Date. An empty time means
+ * midnight (callers treat time-less tasks as all-day). Returns null for an
+ * empty/invalid date.
+ */
+export function fromInputValues(dateStr: string, timeStr: string): Date | null {
+  const dm = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+  if (!dm) return null;
+  const tm = /^(\d{2}):(\d{2})$/.exec(timeStr);
+  const d = new Date(
+    Number(dm[1]),
+    Number(dm[2]) - 1,
+    Number(dm[3]),
+    tm ? Number(tm[1]) : 0,
+    tm ? Number(tm[2]) : 0,
+  );
+  // The Date constructor normalizes out-of-range parts ("2026-99-99" rolls
+  // into 2034) instead of failing — require an exact round-trip.
+  const valid =
+    d.getFullYear() === Number(dm[1]) &&
+    d.getMonth() === Number(dm[2]) - 1 &&
+    d.getDate() === Number(dm[3]);
+  return valid ? d : null;
+}

--- a/packages/web/src/lib/schedule.ts
+++ b/packages/web/src/lib/schedule.ts
@@ -177,10 +177,13 @@ export function fromInputValues(dateStr: string, timeStr: string): Date | null {
     tm ? Number(tm[2]) : 0,
   );
   // The Date constructor normalizes out-of-range parts ("2026-99-99" rolls
-  // into 2034) instead of failing — require an exact round-trip.
+  // into 2034, "12:60" into 13:00) instead of failing — require an exact
+  // round-trip of every supplied component.
   const valid =
     d.getFullYear() === Number(dm[1]) &&
     d.getMonth() === Number(dm[2]) - 1 &&
-    d.getDate() === Number(dm[3]);
+    d.getDate() === Number(dm[3]) &&
+    (!tm ||
+      (d.getHours() === Number(tm[1]) && d.getMinutes() === Number(tm[2])));
   return valid ? d : null;
 }

--- a/packages/web/src/lib/schedule.ts
+++ b/packages/web/src/lib/schedule.ts
@@ -104,12 +104,11 @@ export interface ScheduleInput {
 
 /**
  * A schedule chosen before its item exists (capture-time "When?" chips).
- * Applied via applySchedule once the item is created; `calendarId` carries
- * the destination for the post-creation calendar post.
+ * Applied via applySchedule once the item is created. Deliberately
+ * calendar-free: setting a time is card metadata; adding to a calendar is a
+ * separate action taken later from the card.
  */
-export interface PendingSchedule extends ScheduleInput {
-  calendarId?: string;
-}
+export type PendingSchedule = ScheduleInput;
 
 /**
  * Return a copy of the item carrying the given schedule. Any previously
@@ -135,7 +134,10 @@ export function applySchedule<T extends InboxItem>(
   };
 }
 
-/** Return a copy of the item with all scheduling removed. */
+/**
+ * Return a copy of the item with all scheduling removed — including the
+ * posted-entry pointer and the archived state that posting may have set.
+ */
 export function clearSchedule<T extends InboxItem>(item: T): T {
   return {
     ...item,
@@ -143,8 +145,25 @@ export function clearSchedule<T extends InboxItem>(item: T): T {
     endsAt: undefined,
     allDay: undefined,
     scheduleKind: undefined,
+    ...clearPostedEntryFields(),
+  };
+}
+
+/**
+ * Return a copy of the item detached from its calendar entry, keeping the
+ * time. Un-archives: with the calendar no longer owning the card, it
+ * returns to the Inbox triage queue.
+ */
+export function clearPostedEntry<T extends InboxItem>(item: T): T {
+  return { ...item, ...clearPostedEntryFields() };
+}
+
+function clearPostedEntryFields() {
+  return {
     eventUrl: undefined,
     eventEtag: undefined,
+    archived: undefined,
+    archivedAt: undefined,
   };
 }
 

--- a/packages/web/src/lib/schedule.ts
+++ b/packages/web/src/lib/schedule.ts
@@ -103,6 +103,15 @@ export interface ScheduleInput {
 }
 
 /**
+ * A schedule chosen before its item exists (capture-time "When?" chips).
+ * Applied via applySchedule once the item is created; `calendarId` carries
+ * the destination for the post-creation calendar post.
+ */
+export interface PendingSchedule extends ScheduleInput {
+  calendarId?: string;
+}
+
+/**
  * Return a copy of the item carrying the given schedule. Any previously
  * posted calendar entry's href/etag is preserved — the caller (future CalDAV
  * sync) uses it to update the projection.

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -680,10 +680,29 @@ function sortWithConfiguredOrder<T extends { id: string }>(
 /** Inbox reference items: non-todos with no collectionId. */
 export const sortedItems = derived(items, ($items) => {
   return Object.values($items)
-    .filter((i) => !i.isTodo && i.type !== 'todo' && !i.collectionId)
+    .filter(
+      (i) => !i.isTodo && i.type !== 'todo' && !i.collectionId && !i.archived,
+    )
     .sort(
       (a, b) =>
         new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+});
+
+/**
+ * Inbox reference cards archived by adding them to a calendar — triage
+ * complete, the calendar owns them. Shown in the Inbox's collapsed archived
+ * section (newest archive first); removing the calendar entry un-archives.
+ */
+export const archivedItems = derived(items, ($items) => {
+  return Object.values($items)
+    .filter(
+      (i) => !i.isTodo && i.type !== 'todo' && !i.collectionId && !!i.archived,
+    )
+    .sort(
+      (a, b) =>
+        new Date(b.archivedAt ?? b.createdAt).getTime() -
+        new Date(a.archivedAt ?? a.createdAt).getTime(),
     );
 });
 


### PR DESCRIPTION
Cards convert to calendar events or timed todos, one-way: the card is the editor, the calendar entry is its projection — scheduling never moves or refiles a card. Two commits: the scheduling foundation + .ics export, then live CalDAV posting through the new sockethub `caldav` platform (sockethub/sockethub#1190, evaluated live against Radicale). Two-way sync stays someday/maybe (#190).

## Scheduling foundation (commit 1)

**Data model (rs-module)** — optional fields on every item type: `startsAt`, `endsAt`, `allDay`, `scheduleKind` (`event` | `task`), `eventUrl`/`eventEtag`. No migration needed.

**Schedule sheet** — quick-pick chips (Tonight / Tomorrow 09:00 / Sat morning / Next week, past options auto-drop), Event/Task segment, duration chips + all-day, prefilled with next round hour. **Save & download .ics** always available (RFC 5545 generation: UTF-8-safe folding, escaping, exclusive all-day DTEND, stable UID so re-imports replace).

**Card surfaces** — "Add to calendar…" action row in the view modal that flips to the scheduled time; schedule chips on grid tiles and todo rows (accent = upcoming, red = task overdue, muted = past).

## CalDAV posting (commit 2)

**Relay client** (`lib/caldav.ts`) — every operation is one POST of `[credentials, message]` to the sockethub HTTP actions endpoint (same endpoint + `sockethubUrl` override as link previews). The request-scoped credentials store means no server ever persists the password. `caldav:*` error codes map to friendly messages. Client-supplied UID `<itemId>@inbox-rs` makes the uid that updates require derivable from the item alone.

**Accounts** (`lib/calendar-accounts.ts`) — **device-local by design**: app passwords live in localStorage, deliberately not synced (remoteStorage data syncs in plaintext). Cached calendar discovery, per-calendar visibility, per-account default ★, last-used calendar remembered per kind (events vs tasks).

**Settings** — "Calendar accounts" in the user menu (lazy-loaded modal): server + username + app password → `fetch` discovery (bare hosts normalized to https), refresh, remove.

**Posting flow** (`lib/schedule-sync.ts`) — local-first: the schedule always saves to the card, then posts. Create vs update (etag-checked) vs cross-calendar move (delete + create; tolerates entries already deleted out-of-band). A failed post keeps the schedule and toasts why; pressing the button again retries. "Remove from calendar" deletes server-side first and refuses to silently diverge. Completing a scheduled task posts `STATUS:COMPLETED` best-effort (shared toggle helper now used by TodoRow + CollectionTodoTile).

**Picker** — account-grouped calendars with server colors and `tasks` capability tags; task-incapable calendars disabled in task mode; falls back gracefully to local-only + .ics when no account is set up.

## Capture-time scheduling (commit 3)

**"When?" chip** on the Todos quick-add composer and the add-entry modal (new items, every type): opens the schedule sheet in a new *pick mode* that returns the choice instead of persisting — the schedule (and calendar post) is applied right after the item is created and filed. Untouched, the chip does nothing: scheduling never adds friction to plain capture.

**Fix caught along the way:** editing any item through the modal was silently stripping its schedule fields (and the `eventUrl`/`eventEtag` pointer to an already-posted entry) because the per-type form builders rebuild items from scratch. `preserveCollection` in `build-item.ts` now carries the schedule fields the same way it carries `collectionId`, with tests.

## Verification

- 757 tests across all workspaces (46 new); biome + svelte-check clean; production build passes
- Playwright end-to-end against the real app with the relay mocked at the network layer: account discovery → picker → create (batch shape, uid, endTime verified) → update (stored etag sent) → task completion sync (`STATUS:COMPLETED` posted) → remove (delete with id/type/etag) — 16/16 checks
- The platform side was separately verified live against Radicale in Docker (all verbs, conflict via stale etag, VTIMEZONE, VTODO)
- Capture flows verified with a second Playwright pass: quick-add → pick-mode sheet → task create posted + chip reset; note modal → event create posted; editing the scheduled note keeps its schedule — 12/12 checks

## Notes

- Requires a sockethub deployment that includes `platform-caldav` — sockethub.silverbucket.net needs the new release + platform enabled before posting works in production; `.ics` export works regardless.
- Pre-existing (reproduces on clean master): converting a card to a todo while the view modal is open logs `Cannot read properties of null (reading 'id')` from a derived in `App.svelte` — will fix separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduling for notes, bookmarks, media, documents, emails, and todos.
  * Schedule items as events or tasks, with timed and all-day options.
  * Added calendar account management, selection, and CalDAV synchronization.
  * Added calendar chips for scheduled, past, overdue, and completed states.
  * Added downloadable `.ics` calendar exports.
  * Added quick scheduling during item and todo creation.
  * Added calendar archiving and restoration for Inbox items.
* **Accessibility**
  * Improved dialog keyboard navigation, focus trapping, and Escape-key handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->