### PR TITLE
fix(web): make connecting a calendar the primary path; surface Sockethub setting

### DIFF
--- a/packages/web/src/components/AddToCalendarSheet.svelte
+++ b/packages/web/src/components/AddToCalendarSheet.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { InboxItem } from '@inbox-rs/rs-module';
+  import type { Component } from 'svelte';
   import { trapFocus } from '../lib/actions';
   import { CaldavError } from '../lib/caldav';
   import {
@@ -10,6 +11,7 @@
     pickPreferredCalendar,
   } from '../lib/calendar-accounts';
   import { downloadIcs } from '../lib/ics';
+  import { loadLazy } from '../lib/lazy-load';
   import { formatScheduled } from '../lib/schedule';
   import {
     addItemToCalendar,
@@ -45,6 +47,28 @@
   );
   let showPicker = $state(false);
   let saving = $state(false);
+
+  // Connecting the first account happens right here rather than bouncing the
+  // user out to the user menu — lazy like UserMenu's copy so the CalDAV
+  // settings code stays out of this path until asked for.
+  type SettingsModal = Component<{ onclose: () => void }>;
+  let SettingsComponent = $state<SettingsModal | null>(null);
+  let showSettings = $state(false);
+
+  async function openSettings() {
+    SettingsComponent ??= await loadLazy<SettingsModal>(
+      () => import('./CalendarSettingsModal.svelte'),
+    );
+    if (SettingsComponent) showSettings = true;
+  }
+
+  // Closing the settings modal after connecting the first account lands back
+  // on the posting UI — preselect a calendar so the primary button is
+  // immediately actionable.
+  function closeSettings() {
+    showSettings = false;
+    selectedCalendarId ??= pickPreferredCalendar(kind)?.calendar.id;
+  }
 
   const hasAccounts = $derived($calendarAccounts.length > 0);
   const selectedChoice = $derived<CalendarChoice | undefined>(
@@ -111,7 +135,7 @@
 
   function handleEscape(e: KeyboardEvent) {
     if (e.key !== 'Escape' || saving) return;
-    if (showPicker) return; // picker closes itself first
+    if (showPicker || showSettings) return; // the overlay on top closes itself first
     onclose();
   }
 </script>
@@ -181,13 +205,16 @@
         </button>
       {/if}
     {:else}
-      <button type="button" class="btn-primary" disabled={saving} onclick={handleDownload}>
-        Download .ics
-      </button>
       <p class="hint">
-        Post events straight to your calendar by connecting an account:
-        user&nbsp;menu → Calendar accounts.
+        No calendar connected yet. Connect an account once and cards post
+        straight to it.
       </p>
+      <button type="button" class="btn-primary" onclick={openSettings}>
+        Connect calendar account
+      </button>
+      <button type="button" class="btn-ghost" onclick={handleDownload}>
+        Download .ics instead
+      </button>
     {/if}
   </div>
 </div>
@@ -199,6 +226,10 @@
     onpick={handlePick}
     onclose={() => (showPicker = false)}
   />
+{/if}
+
+{#if SettingsComponent && showSettings}
+  <SettingsComponent onclose={closeSettings} />
 {/if}
 
 <style>

--- a/packages/web/src/components/AddToCalendarSheet.svelte
+++ b/packages/web/src/components/AddToCalendarSheet.svelte
@@ -51,14 +51,23 @@
   // Connecting the first account happens right here rather than bouncing the
   // user out to the user menu — lazy like UserMenu's copy so the CalDAV
   // settings code stays out of this path until asked for.
-  type SettingsModal = Component<{ onclose: () => void }>;
+  type SettingsModal = Component<{ onclose: () => void; onconnected?: () => void }>;
   let SettingsComponent = $state<SettingsModal | null>(null);
   let showSettings = $state(false);
+  // While the settings chunk is in flight the modal isn't mounted yet, so the
+  // Escape/overlay close guards need this to keep the sheet from closing out
+  // from under the load.
+  let settingsLoading = $state(false);
 
   async function openSettings() {
-    SettingsComponent ??= await loadLazy<SettingsModal>(
-      () => import('./CalendarSettingsModal.svelte'),
-    );
+    settingsLoading = true;
+    try {
+      SettingsComponent ??= await loadLazy<SettingsModal>(
+        () => import('./CalendarSettingsModal.svelte'),
+      );
+    } finally {
+      settingsLoading = false;
+    }
     if (SettingsComponent) showSettings = true;
   }
 
@@ -134,7 +143,7 @@
   }
 
   function handleEscape(e: KeyboardEvent) {
-    if (e.key !== 'Escape' || saving) return;
+    if (e.key !== 'Escape' || saving || settingsLoading) return;
     if (showPicker || showSettings) return; // the overlay on top closes itself first
     onclose();
   }
@@ -144,7 +153,7 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" role="dialog" aria-modal="true" aria-label="Add to calendar" onclick={() => { if (!saving) onclose(); }}>
+<div class="overlay" role="dialog" aria-modal="true" aria-label="Add to calendar" onclick={() => { if (!saving && !settingsLoading) onclose(); }}>
   <div class="sheet" use:trapFocus onclick={(e) => e.stopPropagation()}>
     <h3 class="title">{isPosted ? 'On calendar' : 'Add to calendar'}</h3>
     <p class="ctx">{item.title || 'Untitled'}</p>
@@ -209,7 +218,7 @@
         No calendar connected yet. Connect an account once and cards post
         straight to it.
       </p>
-      <button type="button" class="btn-primary" onclick={openSettings}>
+      <button type="button" class="btn-primary" disabled={settingsLoading} onclick={openSettings}>
         Connect calendar account
       </button>
       <button type="button" class="btn-ghost" onclick={handleDownload}>
@@ -229,7 +238,7 @@
 {/if}
 
 {#if SettingsComponent && showSettings}
-  <SettingsComponent onclose={closeSettings} />
+  <SettingsComponent onclose={closeSettings} onconnected={closeSettings} />
 {/if}
 
 <style>

--- a/packages/web/src/components/CalendarSettingsModal.svelte
+++ b/packages/web/src/components/CalendarSettingsModal.svelte
@@ -17,7 +17,18 @@
   import { DEFAULT_SOCKETHUB_ENDPOINT } from '../lib/link-metadata';
   import { showToast } from '../lib/toast';
 
-  let { onclose }: { onclose: () => void } = $props();
+  let {
+    onclose,
+    onconnected,
+  }: {
+    onclose: () => void;
+    /**
+     * Fired after an account connects successfully. The add-to-calendar
+     * sheet uses it to close the modal and return to posting; from the user
+     * menu it's absent and the modal stays open on the accounts list.
+     */
+    onconnected?: () => void;
+  } = $props();
 
   let showAdd = $state(false);
   let serverUrl = $state('');
@@ -90,6 +101,7 @@
       username = '';
       password = '';
       showToast(`Found ${calendars.length} calendar${calendars.length === 1 ? '' : 's'}`);
+      onconnected?.();
     } catch (err) {
       console.error('Calendar discovery failed', err);
       connectError = friendlyError(err);

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -420,7 +420,7 @@
 
         <div class="divider"></div>
 
-        <!-- Link previews — synced setting; endpoint is for self-hosters -->
+        <!-- Link previews — synced setting -->
         <div class="section-label">Link previews</div>
         <div class="theme-switcher" role="group" aria-label="Link previews">
           <button type="button"
@@ -440,24 +440,29 @@
             Off
           </button>
         </div>
-        {#if linkPreviewsOn}
-          <form
-            class="connect-form"
-            onsubmit={(e) => { e.preventDefault(); saveSockethubUrl(); }}
-          >
-            <input
-              type="url"
-              bind:value={sockethubUrlInput}
-              placeholder={DEFAULT_SOCKETHUB_ENDPOINT}
-              aria-label="Sockethub endpoint"
-              onfocus={() => (sockethubUrlEditing = true)}
-              onblur={() => {
-                saveSockethubUrl();
-                sockethubUrlEditing = false;
-              }}
-            />
-          </form>
-        {/if}
+        <div class="divider"></div>
+
+        <!-- Sockethub — the relay behind link previews AND calendar sync, so
+             it gets its own section instead of hiding under either feature.
+             Synced setting; the endpoint override is for self-hosters. -->
+        <div class="section-label">Sockethub service</div>
+        <p class="menu-note">Relays link previews and calendar sync.</p>
+        <form
+          class="connect-form"
+          onsubmit={(e) => { e.preventDefault(); saveSockethubUrl(); }}
+        >
+          <input
+            type="url"
+            bind:value={sockethubUrlInput}
+            placeholder={DEFAULT_SOCKETHUB_ENDPOINT}
+            aria-label="Sockethub endpoint"
+            onfocus={() => (sockethubUrlEditing = true)}
+            onblur={() => {
+              saveSockethubUrl();
+              sockethubUrlEditing = false;
+            }}
+          />
+        </form>
       {/if}
 
       <div class="divider"></div>
@@ -944,6 +949,13 @@
     font-size: 0.7rem;
     opacity: 0.45;
     font-weight: 400;
+  }
+
+  .menu-note {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    line-height: 1.4;
+    padding: 0 0.5rem 0.25rem;
   }
 
   /* ── Connect form ────────────────────────── */


### PR DESCRIPTION
Two discoverability fixes for the calendar feature, from user feedback.

## Add-to-calendar sheet: connect account is now the primary action

When no calendar account is connected, the sheet presented **Download .ics** as the primary (and seemingly only) way to use the feature, with the real path — connecting a CalDAV account — mentioned only in fine print pointing at the user menu.

Now the no-accounts state:
- explains the situation in one line ("No calendar connected yet. Connect an account once and cards post straight to it.")
- makes **Connect calendar account** the primary button, opening the Calendar accounts modal directly on top of the sheet (lazy-loaded, same chunk as the user-menu copy)
- demotes **Download .ics instead** to the secondary ghost action

After connecting and closing the modal, the sheet flips to the posting UI with a calendar preselected, so "Add to calendar" is immediately actionable. Escape closes the top-most layer first (settings → sheet), matching the existing picker behavior.

## User menu: Sockethub endpoint gets its own section

The Sockethub endpoint input existed but was nested inside the **Link previews** section and disappeared entirely when previews were toggled off — even though the same setting selects the calendar relay. It's now a standalone **Sockethub service** section with a note ("Relays link previews and calendar sync"), always visible while connected. It remains connected-only because the synced setting has nowhere to persist before storage connects.

## Verification

- `npm run build`, svelte-check (0 errors), and all 539 web tests pass
- Drove the flow in Playwright against the dev server: seeded a card, set a time, opened the sheet in its no-accounts state, opened Calendar accounts stacked above it, and confirmed the disconnected user menu is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Connect a calendar account directly from the add-to-calendar sheet.
  - Open calendar settings from the calendar flow.
  - Download an alternate `.ics` file when no calendar account is connected.
  - Connected users can view their Sockethub endpoint, with guidance for link previews and calendar synchronization.
- **Bug Fixes**
  - Improved Escape-key and overlay handling while calendar pickers or settings dialogs are open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->