### PR TITLE
feat: calendar posting moves items by default; in-app due alerts + Due band

### DIFF
--- a/packages/rs-module/src/schemas.ts
+++ b/packages/rs-module/src/schemas.ts
@@ -177,6 +177,7 @@ export const userSettingsSchema = {
     theme: { type: 'string', enum: ['system', 'light', 'dark'] },
     linkPreviews: { type: 'boolean' },
     sockethubUrl: { type: 'string' },
+    calendarPostMode: { type: 'string', enum: ['move', 'copy'] },
   },
 };
 

--- a/packages/rs-module/src/types.ts
+++ b/packages/rs-module/src/types.ts
@@ -34,10 +34,11 @@ export interface InboxItemBase {
   eventUrl?: string;
   eventEtag?: string;
   /**
-   * Set when adding an Inbox reference card to a calendar: the calendar now
-   * owns it, so it leaves the Inbox triage queue (collapsed "archived"
-   * section). Never set on todos — they complete instead — and removing the
-   * calendar entry clears it.
+   * Set when posting an item to a calendar in "move" mode: the calendar now
+   * owns it, so it leaves the active lists for its surface's collapsed
+   * "on calendar" section (Inbox archived section for unfiled cards, the
+   * Todos page's section for todos, the collection view's for filed items).
+   * "Copy" mode never sets it, and removing the calendar entry clears it.
    */
   archived?: boolean;
   archivedAt?: string;
@@ -133,6 +134,9 @@ export interface UserSettings {
   /** Sockethub HTTP actions endpoint used for link-metadata fetching.
    *  Undefined/empty means the app's default server. */
   sockethubUrl?: string;
+  /** Whether posting an item to a calendar moves it (archives it in the
+   *  app) or keeps an active copy. Undefined means 'move'. */
+  calendarPostMode?: 'move' | 'copy';
 }
 
 export interface AppConfig {

--- a/packages/rs-module/src/types.ts
+++ b/packages/rs-module/src/types.ts
@@ -38,7 +38,8 @@ export interface InboxItemBase {
    * owns it, so it leaves the active lists for its surface's collapsed
    * "on calendar" section (Inbox archived section for unfiled cards, the
    * Todos page's section for todos, the collection view's for filed items).
-   * "Copy" mode never sets it, and removing the calendar entry clears it.
+   * "Copy" mode never sets it. Re-enabling clears it locally — the calendar
+   * entry is never deleted on the user's behalf.
    */
   archived?: boolean;
   archivedAt?: string;

--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -14,6 +14,7 @@
     createCollection, storeGroup,
     appConfig, setActiveGroupFilters,
   } from './lib/stores';
+  import { initAlerts, setAlertOpenHandler } from './lib/alerts';
   import { captureDetected, captureFile } from './lib/capture';
   import { loadLazy } from './lib/lazy-load';
   import { showToast } from './lib/toast';
@@ -142,6 +143,12 @@
     };
     syncRoute();
     window.addEventListener('hashchange', syncRoute);
+
+    // Due-alert scheduler — app-level, so alerts fire regardless of which
+    // page or filter is active. Idempotent across remounts.
+    setAlertOpenHandler(openView);
+    initAlerts();
+
     return () => window.removeEventListener('hashchange', syncRoute);
   });
 

--- a/packages/web/src/components/AddToCalendarSheet.svelte
+++ b/packages/web/src/components/AddToCalendarSheet.svelte
@@ -15,6 +15,7 @@
   import { formatScheduled } from '../lib/schedule';
   import {
     addItemToCalendar,
+    ReceiptWriteError,
     recordCalendarUse,
     reEnableFromCalendar,
   } from '../lib/schedule-sync';
@@ -151,7 +152,16 @@
       onclose();
     } catch (err) {
       console.error('Calendar post failed', err);
-      showToast(`Couldn't add to calendar — ${friendly(err)}`);
+      if (err instanceof ReceiptWriteError) {
+        // The entry WAS created; only the local receipt failed. Saying
+        // "couldn't add" here would invite a confused re-add.
+        showToast(
+          "Added to the calendar, but the app couldn't record it — the card may still offer to add it.",
+        );
+        onclose();
+      } else {
+        showToast(`Couldn't add to calendar — ${friendly(err)}`);
+      }
     } finally {
       saving = false;
     }

--- a/packages/web/src/components/AddToCalendarSheet.svelte
+++ b/packages/web/src/components/AddToCalendarSheet.svelte
@@ -18,14 +18,17 @@
     recordCalendarUse,
     removeItemFromCalendar,
   } from '../lib/schedule-sync';
+  import { updateUserSettings, userSettings } from '../lib/stores';
   import { showToast } from '../lib/toast';
   import CalendarPicker from './CalendarPicker.svelte';
 
   /**
    * Publishing a timed card to a calendar — the counterpart to the
-   * calendar-free time sheet. Only reachable once a time is set. Posting an
-   * Inbox reference card archives it (the calendar owns it now); removing
-   * the entry brings it back. Todos are never archived — they complete.
+   * calendar-free time sheet. Only reachable once a time is set. Posting in
+   * 'move' mode (the default) archives the item — any kind — into its
+   * surface's collapsed "On calendar" section; the calendar owns it now,
+   * and removing the entry brings it back. 'Keep a copy' posts without
+   * archiving. The choice is remembered in user settings.
    */
   let {
     item,
@@ -39,7 +42,28 @@
   const kind = item.scheduleKind ?? (isTodoish ? 'task' : 'event');
   const timeLabel = formatScheduled(item);
   const isPosted = !!item.eventUrl;
-  const willArchive = !isPosted && !isTodoish && !item.collectionId;
+
+  // Move vs copy — initialized once from the synced preference; toggling
+  // persists so the next sheet opens on the same choice.
+  let postMode = $state<'move' | 'copy'>(
+    $userSettings.calendarPostMode ?? 'move',
+  );
+
+  function setPostMode(mode: 'move' | 'copy') {
+    postMode = mode;
+    updateUserSettings({ calendarPostMode: mode }).catch((err) => {
+      console.error('Failed to save calendar post mode', err);
+    });
+  }
+
+  const willArchive = $derived(!isPosted && postMode === 'move');
+  const archiveNote = $derived(
+    isTodoish
+      ? "The todo moves to the Todos page's “On calendar” section once it's on your calendar. Removing the entry brings it back."
+      : item.collectionId
+        ? "The card moves to its collection's “On calendar” section once it's on your calendar. Removing the entry brings it back."
+        : "The card moves to the Inbox's archived section once it's on your calendar. Removing the entry brings it back.",
+  );
 
   const eventHome = choiceForEventUrl(item.eventUrl);
   let selectedCalendarId = $state<string | undefined>(
@@ -91,7 +115,7 @@
     !saving && !!selectedChoice && calendarSupportsKind,
   );
   /** Selected a different calendar than the entry's current home. */
-  const isMove = $derived(
+  const movingCalendars = $derived(
     isPosted && !!selectedChoice && selectedChoice.calendar.id !== eventHome?.calendar.id,
   );
 
@@ -110,10 +134,20 @@
     if (!canPost || !selectedChoice) return;
     saving = true;
     try {
-      const posted = await addItemToCalendar(item, selectedChoice.calendar.id);
+      const posted = await addItemToCalendar(
+        item,
+        selectedChoice.calendar.id,
+        postMode,
+      );
       recordCalendarUse(kind, selectedChoice.calendar.id);
       if (posted.archived) {
-        showToast('Added to calendar — card archived from the Inbox');
+        showToast(
+          isTodoish
+            ? 'Added to calendar — todo moved to the On-calendar section'
+            : item.collectionId
+              ? "Added to calendar — card moved to the collection's On-calendar section"
+              : 'Added to calendar — card archived from the Inbox',
+        );
       }
       onclose();
     } catch (err) {
@@ -189,16 +223,33 @@
           another calendar.
         </p>
       {/if}
+      {#if !isPosted}
+        <div class="mode-switcher" role="group" aria-label="After adding to calendar">
+          <button type="button"
+            class="mode-option"
+            class:active={postMode === 'move'}
+            aria-pressed={postMode === 'move'}
+            onclick={() => setPostMode('move')}
+          >
+            Move
+          </button>
+          <button type="button"
+            class="mode-option"
+            class:active={postMode === 'copy'}
+            aria-pressed={postMode === 'copy'}
+            onclick={() => setPostMode('copy')}
+          >
+            Keep a copy
+          </button>
+        </div>
+      {/if}
       {#if willArchive}
-        <p class="note">
-          The card moves to the Inbox's archived section once it's on your
-          calendar. Removing the entry brings it back.
-        </p>
+        <p class="note">{archiveNote}</p>
       {/if}
 
-      {#if !isPosted || isMove}
+      {#if !isPosted || movingCalendars}
         <button type="button" class="btn-primary" disabled={!canPost} onclick={post}>
-          {isMove
+          {movingCalendars
             ? 'Move to this calendar'
             : kind === 'task'
               ? 'Add task'
@@ -367,6 +418,42 @@
     font-size: 0.72rem;
     color: var(--text-muted);
     line-height: 1.45;
+  }
+
+  /* Move / Keep-a-copy — same segmented pattern as the user menu's
+     theme switcher. */
+  .mode-switcher {
+    display: flex;
+    gap: 2px;
+    margin-top: 0.7rem;
+  }
+
+  .mode-option {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.4rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: none;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 150ms;
+  }
+
+  .mode-option:hover {
+    color: var(--text);
+    border-color: var(--text-muted);
+  }
+
+  .mode-option.active {
+    color: var(--accent);
+    border-color: var(--accent);
+    background: var(--accent-subtle);
   }
 
   .btn-primary {

--- a/packages/web/src/components/AddToCalendarSheet.svelte
+++ b/packages/web/src/components/AddToCalendarSheet.svelte
@@ -24,13 +24,13 @@
 
   /**
    * Publishing a timed card to a calendar — the counterpart to the
-   * calendar-free time sheet. Only reachable once a time is set. Posting in
-   * 'move' mode (the default) archives the item — any kind — into its
-   * surface's collapsed "On calendar" section; the calendar owns it now.
-   * 'Keep a copy' posts without archiving. Re-enabling a moved item is
-   * local-only (it becomes a copy); this sheet never deletes calendar
-   * entries — that's the calendar's business, not ours. The move/copy
-   * choice is remembered in user settings.
+   * calendar-free time sheet. Only reachable once a time is set, and
+   * ONE-SHOT: posting creates the entry and inbox-rs never updates or
+   * deletes it afterwards. 'Move' mode (the default) archives the item —
+   * any kind — into its surface's collapsed "On calendar" section; 'Keep a
+   * copy' posts without archiving. For a posted item this sheet is a
+   * receipt: it shows the destination calendar and offers local-only
+   * re-enable. The move/copy choice is remembered in user settings.
    */
   let {
     item,
@@ -67,9 +67,11 @@
         : "The card moves to the Inbox's archived section once it's on your calendar. You can re-enable it from there anytime.",
   );
 
+  // The receipt: which calendar this item went to (undefined when the
+  // account has since been removed — the entry still exists there).
   const eventHome = choiceForEventUrl(item.eventUrl);
   let selectedCalendarId = $state<string | undefined>(
-    eventHome?.calendar.id ?? pickPreferredCalendar(kind)?.calendar.id,
+    pickPreferredCalendar(kind)?.calendar.id,
   );
   let showPicker = $state(false);
   let saving = $state(false);
@@ -107,18 +109,13 @@
 
   const hasAccounts = $derived($calendarAccounts.length > 0);
   const selectedChoice = $derived<CalendarChoice | undefined>(
-    findCalendarChoice(selectedCalendarId) ??
-      (eventHome?.calendar.id === selectedCalendarId ? eventHome : undefined),
+    findCalendarChoice(selectedCalendarId),
   );
   const calendarSupportsKind = $derived(
     !!selectedChoice?.calendar.components.includes(kind),
   );
   const canPost = $derived(
     !saving && !!selectedChoice && calendarSupportsKind,
-  );
-  /** Selected a different calendar than the entry's current home. */
-  const movingCalendars = $derived(
-    isPosted && !!selectedChoice && selectedChoice.calendar.id !== eventHome?.calendar.id,
   );
 
   function handlePick(choice: CalendarChoice) {
@@ -205,7 +202,34 @@
       <span class="kind-tag">{kind}</span>
     </div>
 
-    {#if hasAccounts}
+    {#if isPosted}
+      <!-- Receipt: which calendar this went to. Read-only — publishing is
+           one-shot, so there is nothing to change from here. -->
+      <div class="zone static">
+        {#if eventHome}
+          <span
+            class="dot"
+            style="background: {eventHome.calendar.color || 'var(--accent)'}"
+          ></span>
+          <span class="zone-name">{eventHome.calendar.name}</span>
+          <span class="zone-sub">· {eventHome.account.label}</span>
+        {:else}
+          <span class="zone-name muted">On a calendar whose account was removed</span>
+        {/if}
+      </div>
+      {#if item.archived}
+        <button type="button" class="btn-primary" disabled={saving} onclick={reEnable}>
+          Re-enable in {isTodoish ? 'Todos' : item.collectionId ? 'this collection' : 'the Inbox'}
+        </button>
+        <p class="note">
+          Brings it back under this app's management. The calendar entry is
+          not touched.
+        </p>
+      {/if}
+      <button type="button" class="btn-ghost" disabled={saving} onclick={handleDownload}>
+        Download .ics
+      </button>
+    {:else if hasAccounts}
       <button type="button" class="zone" onclick={() => (showPicker = true)}>
         {#if selectedChoice}
           <span
@@ -227,51 +251,34 @@
           another calendar.
         </p>
       {/if}
-      {#if !isPosted}
-        <div class="mode-switcher" role="group" aria-label="After adding to calendar">
-          <button type="button"
-            class="mode-option"
-            class:active={postMode === 'move'}
-            aria-pressed={postMode === 'move'}
-            onclick={() => setPostMode('move')}
-          >
-            Move
-          </button>
-          <button type="button"
-            class="mode-option"
-            class:active={postMode === 'copy'}
-            aria-pressed={postMode === 'copy'}
-            onclick={() => setPostMode('copy')}
-          >
-            Keep a copy
-          </button>
-        </div>
-      {/if}
+      <div class="mode-switcher" role="group" aria-label="After adding to calendar">
+        <button type="button"
+          class="mode-option"
+          class:active={postMode === 'move'}
+          aria-pressed={postMode === 'move'}
+          onclick={() => setPostMode('move')}
+        >
+          Move
+        </button>
+        <button type="button"
+          class="mode-option"
+          class:active={postMode === 'copy'}
+          aria-pressed={postMode === 'copy'}
+          onclick={() => setPostMode('copy')}
+        >
+          Keep a copy
+        </button>
+      </div>
       {#if willArchive}
         <p class="note">{archiveNote}</p>
       {/if}
 
-      {#if !isPosted || movingCalendars}
-        <button type="button" class="btn-primary" disabled={!canPost} onclick={post}>
-          {movingCalendars
-            ? 'Move to this calendar'
-            : kind === 'task'
-              ? 'Add task'
-              : 'Add to calendar'}
-        </button>
-      {/if}
+      <button type="button" class="btn-primary" disabled={!canPost} onclick={post}>
+        {kind === 'task' ? 'Add task' : 'Add to calendar'}
+      </button>
       <button type="button" class="btn-ghost" disabled={saving} onclick={handleDownload}>
         Download .ics
       </button>
-      {#if isPosted && item.archived}
-        <button type="button" class="btn-ghost" disabled={saving} onclick={reEnable}>
-          Re-enable in {isTodoish ? 'Todos' : item.collectionId ? 'this collection' : 'the Inbox'}
-        </button>
-        <p class="note">
-          Brings it back under this app's management. The calendar entry is
-          not touched.
-        </p>
-      {/if}
     {:else}
       <p class="hint">
         No calendar connected yet. Connect an account once and cards post
@@ -387,6 +394,14 @@
 
   .zone:hover {
     border-color: var(--accent);
+  }
+
+  .zone.static {
+    cursor: default;
+  }
+
+  .zone.static:hover {
+    border-color: var(--border);
   }
 
   .zone .dot {

--- a/packages/web/src/components/AddToCalendarSheet.svelte
+++ b/packages/web/src/components/AddToCalendarSheet.svelte
@@ -16,7 +16,7 @@
   import {
     addItemToCalendar,
     recordCalendarUse,
-    removeItemFromCalendar,
+    reEnableFromCalendar,
   } from '../lib/schedule-sync';
   import { updateUserSettings, userSettings } from '../lib/stores';
   import { showToast } from '../lib/toast';
@@ -26,9 +26,11 @@
    * Publishing a timed card to a calendar — the counterpart to the
    * calendar-free time sheet. Only reachable once a time is set. Posting in
    * 'move' mode (the default) archives the item — any kind — into its
-   * surface's collapsed "On calendar" section; the calendar owns it now,
-   * and removing the entry brings it back. 'Keep a copy' posts without
-   * archiving. The choice is remembered in user settings.
+   * surface's collapsed "On calendar" section; the calendar owns it now.
+   * 'Keep a copy' posts without archiving. Re-enabling a moved item is
+   * local-only (it becomes a copy); this sheet never deletes calendar
+   * entries — that's the calendar's business, not ours. The move/copy
+   * choice is remembered in user settings.
    */
   let {
     item,
@@ -59,10 +61,10 @@
   const willArchive = $derived(!isPosted && postMode === 'move');
   const archiveNote = $derived(
     isTodoish
-      ? "The todo moves to the Todos page's “On calendar” section once it's on your calendar. Removing the entry brings it back."
+      ? "The todo moves to the Todos page's “On calendar” section once it's on your calendar. You can re-enable it from there anytime."
       : item.collectionId
-        ? "The card moves to its collection's “On calendar” section once it's on your calendar. Removing the entry brings it back."
-        : "The card moves to the Inbox's archived section once it's on your calendar. Removing the entry brings it back.",
+        ? "The card moves to its collection's “On calendar” section once it's on your calendar. You can re-enable it from there anytime."
+        : "The card moves to the Inbox's archived section once it's on your calendar. You can re-enable it from there anytime.",
   );
 
   const eventHome = choiceForEventUrl(item.eventUrl);
@@ -158,14 +160,16 @@
     }
   }
 
-  async function remove() {
+  // Local-only: clears the archive state, never touches the calendar.
+  async function reEnable() {
     saving = true;
     try {
-      await removeItemFromCalendar(item);
+      await reEnableFromCalendar(item);
+      showToast('Re-enabled — the calendar entry stays put');
       onclose();
     } catch (err) {
-      console.error('Calendar delete failed', err);
-      showToast(`Still on your calendar — ${friendly(err)}`);
+      console.error('Re-enable failed', err);
+      showToast("Couldn't re-enable — try again");
     } finally {
       saving = false;
     }
@@ -259,10 +263,14 @@
       <button type="button" class="btn-ghost" disabled={saving} onclick={handleDownload}>
         Download .ics
       </button>
-      {#if isPosted}
-        <button type="button" class="btn-remove" disabled={saving} onclick={remove}>
-          Remove from calendar
+      {#if isPosted && item.archived}
+        <button type="button" class="btn-ghost" disabled={saving} onclick={reEnable}>
+          Re-enable in {isTodoish ? 'Todos' : item.collectionId ? 'this collection' : 'the Inbox'}
         </button>
+        <p class="note">
+          Brings it back under this app's management. The calendar entry is
+          not touched.
+        </p>
       {/if}
     {:else}
       <p class="hint">
@@ -481,8 +489,7 @@
     cursor: default;
   }
 
-  .btn-ghost,
-  .btn-remove {
+  .btn-ghost {
     display: block;
     width: 100%;
     margin-top: 0.35rem;
@@ -501,16 +508,7 @@
     background: var(--surface-hover);
   }
 
-  .btn-remove {
-    color: var(--danger);
-  }
-
-  .btn-remove:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--danger) 10%, transparent);
-  }
-
-  .btn-ghost:disabled,
-  .btn-remove:disabled {
+  .btn-ghost:disabled {
     opacity: 0.5;
     cursor: default;
   }

--- a/packages/web/src/components/AlertsPermissionBanner.svelte
+++ b/packages/web/src/components/AlertsPermissionBanner.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  import { alertPermission, requestAlertPermission } from '../lib/alerts';
+  import { eligibleForAlert } from '../lib/alerts-core';
+  import { allTodos } from '../lib/stores';
+
+  /**
+   * One-time nudge to enable OS notifications for due items. Shown only when
+   * permission hasn't been decided, something schedulable actually exists,
+   * and the user hasn't dismissed it — never requested on app load; the
+   * browser prompt fires from the button's user gesture. In-app toasts work
+   * regardless, so dismissing this loses nothing essential.
+   */
+
+  const DISMISSED_KEY = 'inbox-rs:alerts:banner-dismissed';
+
+  function loadDismissed(): boolean {
+    try {
+      return localStorage.getItem(DISMISSED_KEY) === '1';
+    } catch {
+      return true; // storage unavailable — can't persist a dismissal, don't nag
+    }
+  }
+
+  let dismissed = $state(loadDismissed());
+  let requesting = $state(false);
+
+  const hasSchedulable = $derived($allTodos.some(eligibleForAlert));
+  const visible = $derived(
+    !dismissed && $alertPermission === 'default' && hasSchedulable,
+  );
+
+  async function enable() {
+    requesting = true;
+    try {
+      await requestAlertPermission();
+    } finally {
+      requesting = false;
+    }
+  }
+
+  function dismiss() {
+    dismissed = true;
+    try {
+      localStorage.setItem(DISMISSED_KEY, '1');
+    } catch {
+      // session-only dismissal is fine
+    }
+  }
+</script>
+
+{#if visible}
+  <div class="alerts-banner" role="status">
+    <div class="banner-content">
+      <strong>Get notified when items are due</strong>
+      <p>Allow notifications and scheduled todos alert you at their deadline.</p>
+    </div>
+    <div class="banner-actions">
+      <button type="button" class="btn-enable" onclick={enable} disabled={requesting}>
+        {requesting ? 'Asking…' : 'Enable alerts'}
+      </button>
+      <button type="button" class="btn-dismiss" onclick={dismiss} aria-label="Dismiss">
+        <svg aria-hidden="true" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="18" y1="6" x2="6" y2="18"></line>
+          <line x1="6" y1="6" x2="18" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .alerts-banner {
+    background: var(--accent-subtler);
+    border: 1px solid var(--accent);
+    border-radius: var(--radius);
+    padding: 0.75rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .banner-content {
+    flex: 1;
+    min-width: 200px;
+  }
+
+  .banner-content strong {
+    font-size: 0.85rem;
+  }
+
+  .banner-content p {
+    margin: 0.2rem 0 0;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+  }
+
+  .banner-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .btn-enable {
+    background: var(--accent);
+    border: none;
+    color: white;
+    padding: 0.35rem 0.75rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.8rem;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+
+  .btn-enable:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  .btn-enable:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+
+  .btn-dismiss {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: color 0.12s, background 0.12s;
+  }
+
+  .btn-dismiss:hover {
+    color: var(--text);
+    background: var(--surface-hover);
+  }
+</style>

--- a/packages/web/src/components/CollectionView.svelte
+++ b/packages/web/src/components/CollectionView.svelte
@@ -10,6 +10,7 @@
   import { makeTodo } from '../lib/item-utils';
   import {
     filterCompletedTodos,
+    filterOnCalendarItems,
     filterOpenTodos,
     filterReferenceItems,
     filterTodos,
@@ -46,6 +47,15 @@
     sortCompletedTodosByCompletedAt(filterCompletedTodos(todoItems))
   );
   const referenceItems = $derived(filterReferenceItems(items));
+
+  // Items moved to a calendar (todos and cards alike) — one combined
+  // collapsed section; the calendar owns them until the entry is removed.
+  const onCalendarItems = $derived(filterOnCalendarItems(items));
+  const onCalendarTodos = $derived(filterTodos(onCalendarItems));
+  const onCalendarRefs = $derived(
+    onCalendarItems.filter((i) => !i.isTodo && i.type !== 'todo'),
+  );
+  let onCalendarExpanded = $state(false);
 
   // Shared group lookup for TodoRow styling — collection's own color takes
   // priority, but we also supply the group so the pill colour degrades
@@ -368,6 +378,43 @@
           <p class="section-empty">No references yet.</p>
         {/if}
       </section>
+
+      {#if onCalendarItems.length > 0}
+        <section class="on-calendar-section" aria-label="On calendar in {collection.name}">
+          <button type="button"
+            class="btn-completed-toggle"
+            onclick={() => (onCalendarExpanded = !onCalendarExpanded)}
+            aria-expanded={onCalendarExpanded}
+          >
+            <svg aria-hidden="true" class="chevron-sm" class:open={onCalendarExpanded} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+            {onCalendarItems.length} on calendar
+          </button>
+          {#if onCalendarExpanded}
+            <div class="on-calendar-body" transition:slide={{ duration: isTouchDevice ? 0 : 200 }}>
+              {#if onCalendarTodos.length > 0}
+                <ul class="todo-list completed-list" role="list">
+                  {#each onCalendarTodos as todo (todo.id)}
+                    <div in:fade={{ duration: 150 }}>
+                      <TodoRow {todo} {collection} {group} {onselect} />
+                    </div>
+                  {/each}
+                </ul>
+              {/if}
+              {#if onCalendarRefs.length > 0}
+                <div class="grid on-calendar-grid">
+                  {#each onCalendarRefs as item (item.id)}
+                    <div class="grid-card-wrapper">
+                      <InboxCard {item} {onselect} />
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+          {/if}
+        </section>
+      {/if}
     </div>
   {/if}
 </div>
@@ -688,6 +735,23 @@
   }
 
   .completed-list {
+    margin-top: 0.4rem;
+    opacity: 0.75;
+  }
+
+  .on-calendar-section {
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px dashed var(--border);
+  }
+
+  .on-calendar-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .on-calendar-grid {
     margin-top: 0.4rem;
     opacity: 0.75;
   }

--- a/packages/web/src/components/CollectionView.svelte
+++ b/packages/web/src/components/CollectionView.svelte
@@ -396,9 +396,7 @@
               {#if onCalendarTodos.length > 0}
                 <ul class="todo-list completed-list" role="list">
                   {#each onCalendarTodos as todo (todo.id)}
-                    <div in:fade={{ duration: 150 }}>
-                      <TodoRow {todo} readonly {collection} {group} {onselect} />
-                    </div>
+                    <TodoRow {todo} readonly {collection} {group} {onselect} />
                   {/each}
                 </ul>
               {/if}

--- a/packages/web/src/components/CollectionView.svelte
+++ b/packages/web/src/components/CollectionView.svelte
@@ -397,7 +397,7 @@
                 <ul class="todo-list completed-list" role="list">
                   {#each onCalendarTodos as todo (todo.id)}
                     <div in:fade={{ duration: 150 }}>
-                      <TodoRow {todo} {collection} {group} {onselect} />
+                      <TodoRow {todo} readonly {collection} {group} {onselect} />
                     </div>
                   {/each}
                 </ul>

--- a/packages/web/src/components/InboxCard.svelte
+++ b/packages/web/src/components/InboxCard.svelte
@@ -7,6 +7,7 @@
   import DocumentCard from './DocumentCard.svelte';
   import EmailCard from './EmailCard.svelte';
   import { draggingItemId, DRAG_MIME } from '../lib/drag';
+  import { now } from '../lib/now';
   import { formatScheduled, isOverdue, isPast } from '../lib/schedule';
 
   let { item, onselect }: { item: InboxItem; onselect: (item: InboxItem) => void } = $props();
@@ -121,8 +122,8 @@
   }
 
   const scheduledLabel = $derived(item.startsAt ? formatScheduled(item) : '');
-  const scheduleOverdue = $derived(isOverdue(item));
-  const schedulePast = $derived(isPast(item));
+  const scheduleOverdue = $derived(isOverdue(item, $now));
+  const schedulePast = $derived(isPast(item, $now));
 </script>
 
 <article class="card" role="button" tabindex="0"

--- a/packages/web/src/components/ScheduleSheet.svelte
+++ b/packages/web/src/components/ScheduleSheet.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { InboxItem } from '@inbox-rs/rs-module';
   import { trapFocus } from '../lib/actions';
-  import { CaldavError } from '../lib/caldav';
   import { cleanForStorage } from '../lib/clean-for-storage';
   import {
     applySchedule,
@@ -14,8 +13,6 @@
     toDateInputValue,
     toTimeInputValue,
   } from '../lib/schedule';
-  import { postScheduledItem, removePostedEntry } from '../lib/schedule-sync';
-  import { choiceForEventUrl } from '../lib/calendar-accounts';
   import { showToast } from '../lib/toast';
   import { storeItem } from '../lib/stores';
 
@@ -138,9 +135,10 @@
   }
 
   /**
-   * Save the time. When the card is already on a calendar, the posted entry
-   * is updated in the same gesture (local-first: a failed sync keeps the
-   * local time and toasts why — the projection catches up on the next save).
+   * Save the time — local-only, always. Publishing is one-shot: a posted
+   * calendar entry is a frozen snapshot, so a time edit changes the card
+   * but never the calendar. The toast says so, once, so the drift isn't
+   * mysterious in the other direction.
    */
   async function save() {
     if (pickMode) {
@@ -151,37 +149,18 @@
     const updated = scheduledItem();
     if (!updated) return;
     if (!(await persist(updated, 'Failed to save time'))) return;
-    const home = choiceForEventUrl(updated.eventUrl);
-    if (updated.eventUrl && home) {
-      saving = true;
-      try {
-        const posted = await postScheduledItem(updated, home.calendar.id);
-        await storeItem(cleanForStorage(posted));
-      } catch (err) {
-        console.error('Calendar sync failed', err);
-        const reason =
-          err instanceof CaldavError
-            ? err.message
-            : 'the calendar relay is unreachable';
-        showToast(`Time saved — calendar copy not updated: ${reason}`);
-      } finally {
-        saving = false;
-      }
-    } else if (updated.eventUrl) {
-      // Posted, but its calendar account is gone (removed in settings) —
-      // the doc contract says a skipped sync must say why.
-      console.error('Calendar sync skipped: no account for', updated.eventUrl);
-      showToast(
-        'Time saved — calendar copy not updated: its calendar account was removed',
-      );
+    if (updated.eventUrl) {
+      showToast('Time saved — the calendar entry keeps its original time');
     }
     onclose();
   }
 
   /**
-   * Removing the time also removes the posted calendar entry (an entry
-   * can't exist without its time). If the server refuses, keep everything
-   * so card and calendar don't silently diverge.
+   * Removing the time also drops the calendar receipt, locally: without its
+   * time the card no longer matches what was posted, so it stops claiming
+   * to be on a calendar (and un-archives). The calendar keeps its entry —
+   * inbox-rs never deletes there. clearSchedule clears the receipt fields
+   * along with the time.
    */
   async function remove() {
     if (pickMode) {
@@ -189,23 +168,11 @@
       return;
     }
     if (!item) return;
-    if (item.eventUrl) {
-      saving = true;
-      try {
-        await removePostedEntry(item);
-      } catch (err) {
-        console.error('Calendar delete failed', err);
-        const reason =
-          err instanceof CaldavError
-            ? err.message
-            : 'the calendar relay is unreachable';
-        showToast(`Still on your calendar — ${reason}`);
-        saving = false;
-        return;
-      }
-      saving = false;
-    }
+    const wasPosted = !!item.eventUrl;
     if (await persist(clearSchedule(item), 'Failed to remove time')) {
+      if (wasPosted) {
+        showToast('Time removed — the calendar entry stays put');
+      }
       onclose();
     }
   }

--- a/packages/web/src/components/TodoRow.svelte
+++ b/packages/web/src/components/TodoRow.svelte
@@ -19,8 +19,8 @@
     onaddincollection?: (collectionId: string | undefined) => void;
     /** Receipt mode for "On calendar" sections: the todo is managed
         elsewhere now, so no completion checkbox — a calendar marker instead.
-        The row still opens the card, where "Remove from calendar" brings it
-        back under the app's management. */
+        The row still opens the card, where "Re-enable" brings it back under
+        the app's management (without touching the calendar). */
     readonly?: boolean;
   } = $props();
 

--- a/packages/web/src/components/TodoRow.svelte
+++ b/packages/web/src/components/TodoRow.svelte
@@ -6,7 +6,7 @@
   import { now } from '../lib/now';
   import { formatScheduled, isOverdue } from '../lib/schedule';
 
-  let { todo, collection, group, onselect, onaddincollection }: {
+  let { todo, collection, group, onselect, onaddincollection, readonly = false }: {
     todo: InboxItem;
     /** The collection this todo belongs to, or null when unfiled. */
     collection: Collection | null;
@@ -17,6 +17,11 @@
         this row's collection. Unfiled rows pass `undefined` so the follow-up
         stays unfiled too. Omit the handler to hide the affordance. */
     onaddincollection?: (collectionId: string | undefined) => void;
+    /** Receipt mode for "On calendar" sections: the todo is managed
+        elsewhere now, so no completion checkbox — a calendar marker instead.
+        The row still opens the card, where "Remove from calendar" brings it
+        back under the app's management. */
+    readonly?: boolean;
   } = $props();
 
   // Show the underlying item type as an icon for items that are "todos by flag"
@@ -134,14 +139,25 @@
   onkeydown={handleKey}
   style="--group-color: {groupColor}; --collection-color: {collectionColor}"
 >
-  <input
-    type="checkbox"
-    class="checkbox"
-    checked={todo.completed}
-    onclick={(e) => e.stopPropagation()}
-    onchange={toggleCompleted}
-    aria-label="Mark {todo.title} as {todo.completed ? 'incomplete' : 'complete'}"
-  />
+  {#if readonly}
+    <span class="cal-marker" title="On calendar" aria-label="On calendar">
+      <svg aria-hidden="true" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="3" y="4" width="18" height="18" rx="2"></rect>
+        <line x1="16" y1="2" x2="16" y2="6"></line>
+        <line x1="8" y1="2" x2="8" y2="6"></line>
+        <line x1="3" y1="10" x2="21" y2="10"></line>
+      </svg>
+    </span>
+  {:else}
+    <input
+      type="checkbox"
+      class="checkbox"
+      checked={todo.completed}
+      onclick={(e) => e.stopPropagation()}
+      onchange={toggleCompleted}
+      aria-label="Mark {todo.title} as {todo.completed ? 'incomplete' : 'complete'}"
+    />
+  {/if}
 
   <span class="title">{todo.title}</span>
 
@@ -238,6 +254,17 @@
        signal available for this individual todo. */
     accent-color: var(--collection-color);
     cursor: pointer;
+  }
+
+  /* Receipt marker in place of the checkbox for on-calendar rows. */
+  .cal-marker {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+    color: var(--text-muted);
   }
 
   .title {

--- a/packages/web/src/components/TodoRow.svelte
+++ b/packages/web/src/components/TodoRow.svelte
@@ -94,6 +94,11 @@
   // The pill (not the whole row) is the handle so it doesn't fight the
   // svelte-dnd-action reorder gesture, which owns row-body drags.
   function onFileDragStart(e: DragEvent) {
+    // Receipt rows are read-only end to end — no re-filing from here.
+    if (readonly) {
+      e.preventDefault();
+      return;
+    }
     if (!e.dataTransfer) return;
     e.dataTransfer.setData(DRAG_MIME, todo.id);
     e.dataTransfer.setData('text/plain', todo.title || todo.id);
@@ -140,7 +145,7 @@
   style="--group-color: {groupColor}; --collection-color: {collectionColor}"
 >
   {#if readonly}
-    <span class="cal-marker" title="On calendar" aria-label="On calendar">
+    <span class="cal-marker" title="On calendar" role="img" aria-label="On calendar">
       <svg aria-hidden="true" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <rect x="3" y="4" width="18" height="18" rx="2"></rect>
         <line x1="16" y1="2" x2="16" y2="6"></line>
@@ -179,9 +184,11 @@
       class="collection-pill"
       type="button"
       tabindex="-1"
-      draggable="true"
-      title="Drag to refile · {collectionName}"
-      aria-label="Drag {todo.title} onto a collection to refile it"
+      draggable={!readonly}
+      title={readonly ? collectionName : `Drag to refile · ${collectionName}`}
+      aria-label={readonly
+        ? `Filed in ${collectionName}`
+        : `Drag ${todo.title} onto a collection to refile it`}
       onpointerdown={(e) => e.stopPropagation()}
       ondragstart={onFileDragStart}
       ondragend={onFileDragEnd}

--- a/packages/web/src/components/TodoRow.svelte
+++ b/packages/web/src/components/TodoRow.svelte
@@ -3,6 +3,7 @@
   import { setItemCompleted } from '../lib/schedule-sync';
   import { typeIconPath } from '../lib/item-utils';
   import { draggingItemId, DRAG_MIME } from '../lib/drag';
+  import { now } from '../lib/now';
   import { formatScheduled, isOverdue } from '../lib/schedule';
 
   let { todo, collection, group, onselect, onaddincollection }: {
@@ -56,7 +57,7 @@
   const createdTitle = $derived(new Date(todo.createdAt).toLocaleString());
 
   const scheduledLabel = $derived(todo.startsAt ? formatScheduled(todo) : '');
-  const scheduleOverdue = $derived(isOverdue(todo));
+  const scheduleOverdue = $derived(isOverdue(todo, $now));
 
   async function toggleCompleted(e: Event) {
     e.stopPropagation();

--- a/packages/web/src/components/TodosPage.svelte
+++ b/packages/web/src/components/TodosPage.svelte
@@ -4,9 +4,12 @@
   import { flip } from 'svelte/animate';
   import { slide, fade } from 'svelte/transition';
   import {
-    visibleTodos, reorderTodosGlobal,
+    visibleTodos, visibleOnCalendarTodos, reorderTodosGlobal,
     collections, sortedGroups, appConfig, updateConfig,
   } from '../lib/stores';
+  import { isDueTodayOrOverdue } from '../lib/schedule';
+  import { todayStart } from '../lib/now';
+  import AlertsPermissionBanner from './AlertsPermissionBanner.svelte';
   import TodoRow from './TodoRow.svelte';
   import TodoQuickAdd from './TodoQuickAdd.svelte';
   import Fab from './Fab.svelte';
@@ -25,6 +28,15 @@
 
   const todos = $derived($visibleTodos);
   const openTodos = $derived(todos.filter(t => !t.completed));
+  // The store pins due todos first (earliest due leading); the page renders
+  // them as a separate non-draggable band so manual ordering stays meaningful
+  // for everything below.
+  const dueTodos = $derived(
+    openTodos.filter(t => isDueTodayOrOverdue(t, $todayStart)),
+  );
+  const restOpenTodos = $derived(
+    openTodos.filter(t => !isDueTodayOrOverdue(t, $todayStart)),
+  );
   // Completed todos are sorted newest-first by completedAt for the collapsed
   // section — the global order only governs open todos.
   const completedTodos = $derived(
@@ -45,6 +57,11 @@
 
   const completedExpanded = $derived($appConfig.completedTodosExpanded === true);
 
+  // Todos moved to a calendar — the calendar owns them now. Collapsed by
+  // default; local state only (unlike completed, no cross-device flag yet).
+  const onCalendarTodos = $derived($visibleOnCalendarTodos);
+  let onCalendarExpanded = $state(false);
+
   let isTouchDevice = $state(false);
 
   $effect(() => {
@@ -60,7 +77,7 @@
   // where `handleDndConsider` is authoritative.
   let dndOpen = $state<Array<InboxItem & { id: string }>>([]);
   $effect(() => {
-    dndOpen = openTodos.map(t => ({ ...t }));
+    dndOpen = restOpenTodos.map(t => ({ ...t }));
   });
 
   function handleDndConsider(e: CustomEvent<{ items: Array<InboxItem & { id: string }> }>) {
@@ -68,12 +85,17 @@
   }
 
   async function handleDndFinalize(e: CustomEvent<{ items: Array<InboxItem & { id: string }> }>) {
-    const previous = openTodos.map(t => ({ ...t }));
+    const previous = restOpenTodos.map(t => ({ ...t }));
     dndOpen = e.detail.items;
     try {
       // Persist just the open ids — completed todos fall back to completedAt
       // ordering on re-render, so we don't need to thread them through config.
-      await reorderTodosGlobal(dndOpen.map(t => t.id));
+      // Due-band todos lead the persisted order so they resume a sane manual
+      // slot once their due date passes out of the band.
+      await reorderTodosGlobal([
+        ...dueTodos.map(t => t.id),
+        ...dndOpen.map(t => t.id),
+      ]);
     } catch (error) {
       console.error('Failed to reorder todos', error);
       dndOpen = previous;
@@ -101,6 +123,7 @@
 </script>
 
 <div class="todos-page">
+  <AlertsPermissionBanner />
   <!--
     Toolbar: count + Fab (the Fab is an inline pill on desktop, position:fixed
     and out of flow on mobile). Rendered BELOW the quick-add in the populated
@@ -116,7 +139,7 @@
     </div>
   {/snippet}
 
-  {#if openTodos.length === 0 && completedTodos.length === 0}
+  {#if openTodos.length === 0 && completedTodos.length === 0 && onCalendarTodos.length === 0}
     <!-- Lead with the composer so its input lines up with the inbox capture
          bar. The toolbar's Fab is hidden on desktop (the input + ⌘↵ handle
          capture) and a floating + circle on mobile. -->
@@ -132,6 +155,26 @@
   {:else}
     <TodoQuickAdd hideOnMobile compact focusOnMount onopenmodal={(t, c) => onaddtodo(t, c)} />
     {@render todoToolbar()}
+
+    {#if dueTodos.length > 0}
+      <div class="due-band">
+        <div class="due-header">Due</div>
+        <ul class="todo-list" role="list">
+          {#each dueTodos as todo (todo.id)}
+            <div in:fade={{ duration: 180 }} out:fade={{ duration: 120 }}>
+              <TodoRow
+                {todo}
+                collection={lookupCollection(todo.collectionId)}
+                group={lookupGroup(todo.collectionId)}
+                {onselect}
+                onaddincollection={onaddtodoincollection}
+              />
+            </div>
+          {/each}
+        </ul>
+      </div>
+    {/if}
+
     <ul
       class="todo-list" role="list"
       use:dndzone={{
@@ -195,6 +238,41 @@
         {/if}
       </div>
     {/if}
+
+    {#if onCalendarTodos.length > 0}
+      <div class="completed-section">
+        <button type="button"
+          class="btn-completed-toggle"
+          onclick={() => (onCalendarExpanded = !onCalendarExpanded)}
+          aria-expanded={onCalendarExpanded}
+        >
+          <svg aria-hidden="true" class="chevron" class:open={onCalendarExpanded} width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="6 9 12 15 18 9"></polyline>
+          </svg>
+          {onCalendarTodos.length} on calendar
+        </button>
+
+        {#if onCalendarExpanded}
+          <ul
+            class="todo-list completed-list"
+            role="list"
+            transition:slide={{ duration: isTouchDevice ? 0 : 200 }}
+          >
+            {#each onCalendarTodos as todo (todo.id)}
+              <div in:fade={{ duration: 150 }}>
+                <TodoRow
+                  {todo}
+                  collection={lookupCollection(todo.collectionId)}
+                  group={lookupGroup(todo.collectionId)}
+                  {onselect}
+                  onaddincollection={onaddtodoincollection}
+                />
+              </div>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+    {/if}
   {/if}
 </div>
 
@@ -228,6 +306,23 @@
     display: flex;
     flex-direction: column;
     gap: 0.35rem;
+  }
+
+  .due-band {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px dashed var(--border);
+  }
+
+  .due-header {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--danger);
+    padding: 0 0.25rem;
   }
 
   .completed-section {

--- a/packages/web/src/components/TodosPage.svelte
+++ b/packages/web/src/components/TodosPage.svelte
@@ -159,17 +159,18 @@
     {#if dueTodos.length > 0}
       <div class="due-band">
         <div class="due-header">Due</div>
+        <!-- TodoRow renders its own <li>, so rows sit directly in the list —
+             no transition wrapper (a div between ul and li breaks list
+             semantics for assistive tech). -->
         <ul class="todo-list" role="list">
           {#each dueTodos as todo (todo.id)}
-            <div in:fade={{ duration: 180 }} out:fade={{ duration: 120 }}>
-              <TodoRow
-                {todo}
-                collection={lookupCollection(todo.collectionId)}
-                group={lookupGroup(todo.collectionId)}
-                {onselect}
-                onaddincollection={onaddtodoincollection}
-              />
-            </div>
+            <TodoRow
+              {todo}
+              collection={lookupCollection(todo.collectionId)}
+              group={lookupGroup(todo.collectionId)}
+              {onselect}
+              onaddincollection={onaddtodoincollection}
+            />
           {/each}
         </ul>
       </div>
@@ -259,15 +260,13 @@
             transition:slide={{ duration: isTouchDevice ? 0 : 200 }}
           >
             {#each onCalendarTodos as todo (todo.id)}
-              <div in:fade={{ duration: 150 }}>
-                <TodoRow
-                  {todo}
-                  readonly
-                  collection={lookupCollection(todo.collectionId)}
-                  group={lookupGroup(todo.collectionId)}
-                  {onselect}
-                />
-              </div>
+              <TodoRow
+                {todo}
+                readonly
+                collection={lookupCollection(todo.collectionId)}
+                group={lookupGroup(todo.collectionId)}
+                {onselect}
+              />
             {/each}
           </ul>
         {/if}

--- a/packages/web/src/components/TodosPage.svelte
+++ b/packages/web/src/components/TodosPage.svelte
@@ -262,10 +262,10 @@
               <div in:fade={{ duration: 150 }}>
                 <TodoRow
                   {todo}
+                  readonly
                   collection={lookupCollection(todo.collectionId)}
                   group={lookupGroup(todo.collectionId)}
                   {onselect}
-                  onaddincollection={onaddtodoincollection}
                 />
               </div>
             {/each}

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -15,7 +15,6 @@
   import ScheduleSheet from './ScheduleSheet.svelte';
   import AddToCalendarSheet from './AddToCalendarSheet.svelte';
   import { formatScheduled, isOverdue } from '../lib/schedule';
-  import { removePostedEntry } from '../lib/schedule-sync';
   import BookmarkView from './view-card/BookmarkView.svelte';
   import NoteView from './view-card/NoteView.svelte';
   import ImageView from './view-card/ImageView.svelte';
@@ -60,22 +59,17 @@
 
   /**
    * A todo↔reference conversion changes the card's kind, so a posted
-   * calendar entry no longer matches its projection (a VEVENT for what is
-   * now a task, or vice versa) — and archive state belongs to the calendar
-   * ownership that conversion breaks. Detach the entry (best-effort server
-   * delete — a failure only orphans a calendar entry, never blocks the
-   * conversion), strip the pointer + archive flags, and keep the time,
-   * flipping its kind to match.
+   * calendar entry no longer matches what the receipt claims (a VEVENT for
+   * what is now a task, or vice versa) — and archive state belongs to the
+   * calendar ownership that conversion breaks. Drop the receipt + archive
+   * flags locally and keep the time, flipping its kind to match. The
+   * calendar keeps its entry untouched: publishing is one-shot, inbox-rs
+   * never updates or deletes there.
    */
   function detachCalendarOnConversion(
     updated: Record<string, unknown>,
     newKind: 'event' | 'task',
   ) {
-    if (item.eventUrl) {
-      void removePostedEntry(item).catch((error) => {
-        console.warn('Calendar entry not removed on conversion', error);
-      });
-    }
     delete updated.eventUrl;
     delete updated.eventEtag;
     delete updated.archived;

--- a/packages/web/src/lib/alerts-core.test.ts
+++ b/packages/web/src/lib/alerts-core.test.ts
@@ -95,6 +95,17 @@ describe('collectDueAlerts', () => {
     ]);
   });
 
+  it('re-arms when allDay flips with an unchanged startsAt — the effective time moved', () => {
+    const t = todo('a', { startsAt: new Date(NOW - 5_000).toISOString() });
+    const fired = new Set([alertKey(t)]);
+    const flipped = { ...t, allDay: true };
+    expect(alertKey(flipped)).not.toBe(alertKey(t));
+    // The 09:00 all-day alert is its own key, so the timed alert's fired
+    // entry no longer suppresses it (generous grace keeps it in `fire`).
+    const { fire } = collectDueAlerts([flipped], fired, NOW, 12 * 60 * 60_000);
+    expect(fire.map((i) => i.id)).toEqual(['a']);
+  });
+
   it('ignores ineligible items even when due', () => {
     const moved = todo('moved', {
       startsAt: new Date(NOW - 5_000).toISOString(),
@@ -122,7 +133,7 @@ describe('pruneFiredKeys', () => {
     const items: Record<string, InboxItem> = { b: rearmed, c: ancient };
     const keys = [
       'gone@2026-08-04T00:00:00.000Z',
-      `b@${new Date(NOW - 60_000).toISOString()}`, // old schedule, item moved on
+      `b@${new Date(NOW - 60_000).getTime()}`, // old effective time, item moved on
       alertKey(ancient),
       'no-separator',
     ];

--- a/packages/web/src/lib/alerts-core.test.ts
+++ b/packages/web/src/lib/alerts-core.test.ts
@@ -1,0 +1,127 @@
+import type { InboxItem, TodoItem } from '@inbox-rs/rs-module';
+import { describe, expect, it } from 'vitest';
+import {
+  ALERT_GRACE_MS,
+  ALL_DAY_ALERT_HOUR,
+  alertKey,
+  alertTimeFor,
+  collectDueAlerts,
+  eligibleForAlert,
+  pruneFiredKeys,
+} from './alerts-core';
+
+function todo(id: string, overrides: Partial<TodoItem> = {}): TodoItem {
+  return {
+    id,
+    type: 'todo',
+    title: id,
+    completed: false,
+    createdAt: '2026-07-01T00:00:00.000Z',
+    scheduleKind: 'task',
+    ...overrides,
+  } as TodoItem;
+}
+
+const NOW = new Date('2026-08-04T12:00:00').getTime();
+
+describe('alertTimeFor', () => {
+  it('uses the exact startsAt moment for timed items', () => {
+    const t = todo('a', { startsAt: '2026-08-04T13:30:00.000Z' });
+    expect(alertTimeFor(t)).toBe(new Date('2026-08-04T13:30:00.000Z').getTime());
+  });
+
+  it(`resolves all-day items to ${ALL_DAY_ALERT_HOUR}:00 local on their day`, () => {
+    const t = todo('a', { startsAt: '2026-08-04T00:00:00', allDay: true });
+    const expected = new Date('2026-08-04T00:00:00');
+    expected.setHours(ALL_DAY_ALERT_HOUR, 0, 0, 0);
+    expect(alertTimeFor(t)).toBe(expected.getTime());
+  });
+
+  it('returns null without a startsAt or for an unparseable one', () => {
+    expect(alertTimeFor(todo('a'))).toBeNull();
+    expect(alertTimeFor(todo('a', { startsAt: 'not-a-date' }))).toBeNull();
+  });
+});
+
+describe('eligibleForAlert', () => {
+  const base = { startsAt: '2026-08-04T13:00:00.000Z' };
+
+  it('accepts an open, unposted, scheduled item', () => {
+    expect(eligibleForAlert(todo('a', base))).toBe(true);
+  });
+
+  it('rejects completed, archived, calendar-posted, and unscheduled items', () => {
+    expect(eligibleForAlert(todo('a', { ...base, completed: true }))).toBe(false);
+    expect(eligibleForAlert(todo('a', { ...base, archived: true }))).toBe(false);
+    expect(
+      eligibleForAlert(todo('a', { ...base, eventUrl: 'https://cal/x.ics' })),
+    ).toBe(false);
+    expect(eligibleForAlert(todo('a'))).toBe(false);
+  });
+});
+
+describe('collectDueAlerts', () => {
+  it('fires due items within the grace window, oldest due first', () => {
+    const items = [
+      todo('late', { startsAt: new Date(NOW - 60_000).toISOString() }),
+      todo('later', { startsAt: new Date(NOW - 10_000).toISOString() }),
+      todo('future', { startsAt: new Date(NOW + 60_000).toISOString() }),
+    ];
+    const { fire, expire } = collectDueAlerts(items, new Set(), NOW);
+    expect(fire.map((i) => i.id)).toEqual(['late', 'later']);
+    expect(expire).toEqual([]);
+  });
+
+  it('expires items due before the grace window instead of firing', () => {
+    const stale = todo('stale', {
+      startsAt: new Date(NOW - ALERT_GRACE_MS - 1000).toISOString(),
+    });
+    const { fire, expire } = collectDueAlerts([stale], new Set(), NOW);
+    expect(fire).toEqual([]);
+    expect(expire).toEqual([alertKey(stale)]);
+  });
+
+  it('skips already-fired keys, and a moved time re-arms', () => {
+    const t = todo('a', { startsAt: new Date(NOW - 5_000).toISOString() });
+    const fired = new Set([alertKey(t)]);
+    expect(collectDueAlerts([t], fired, NOW).fire).toEqual([]);
+
+    const moved = { ...t, startsAt: new Date(NOW - 1_000).toISOString() };
+    expect(collectDueAlerts([moved], fired, NOW).fire.map((i) => i.id)).toEqual([
+      'a',
+    ]);
+  });
+
+  it('ignores ineligible items even when due', () => {
+    const posted = todo('posted', {
+      startsAt: new Date(NOW - 5_000).toISOString(),
+      eventUrl: 'https://cal/x.ics',
+    });
+    const { fire, expire } = collectDueAlerts([posted], new Set(), NOW);
+    expect(fire).toEqual([]);
+    expect(expire).toEqual([]);
+  });
+});
+
+describe('pruneFiredKeys', () => {
+  it('keeps keys for live items with an unchanged recent schedule', () => {
+    const t = todo('a', { startsAt: new Date(NOW - 60_000).toISOString() });
+    const items: Record<string, InboxItem> = { a: t };
+    expect(pruneFiredKeys([alertKey(t)], items, NOW)).toEqual([alertKey(t)]);
+  });
+
+  it('drops keys for deleted items, rescheduled items, old alerts, and junk', () => {
+    const rearmed = todo('b', { startsAt: new Date(NOW).toISOString() });
+    const ancient = todo('c', {
+      startsAt: new Date(NOW - 8 * 24 * 60 * 60_000).toISOString(),
+    });
+    const items: Record<string, InboxItem> = { b: rearmed, c: ancient };
+    const keys = [
+      'gone@2026-08-04T00:00:00.000Z',
+      `b@${new Date(NOW - 60_000).toISOString()}`, // old schedule, item moved on
+      alertKey(ancient),
+      'no-separator',
+    ];
+    expect(pruneFiredKeys(keys, items, NOW)).toEqual([]);
+  });
+});

--- a/packages/web/src/lib/alerts-core.test.ts
+++ b/packages/web/src/lib/alerts-core.test.ts
@@ -50,13 +50,16 @@ describe('eligibleForAlert', () => {
     expect(eligibleForAlert(todo('a', base))).toBe(true);
   });
 
-  it('rejects completed, archived, calendar-posted, and unscheduled items', () => {
+  it('rejects completed, archived (moved), and unscheduled items', () => {
     expect(eligibleForAlert(todo('a', { ...base, completed: true }))).toBe(false);
     expect(eligibleForAlert(todo('a', { ...base, archived: true }))).toBe(false);
+    expect(eligibleForAlert(todo('a'))).toBe(false);
+  });
+
+  it('accepts calendar copies — a copy with a time alerts like anything else', () => {
     expect(
       eligibleForAlert(todo('a', { ...base, eventUrl: 'https://cal/x.ics' })),
-    ).toBe(false);
-    expect(eligibleForAlert(todo('a'))).toBe(false);
+    ).toBe(true);
   });
 });
 
@@ -93,11 +96,12 @@ describe('collectDueAlerts', () => {
   });
 
   it('ignores ineligible items even when due', () => {
-    const posted = todo('posted', {
+    const moved = todo('moved', {
       startsAt: new Date(NOW - 5_000).toISOString(),
       eventUrl: 'https://cal/x.ics',
+      archived: true,
     });
-    const { fire, expire } = collectDueAlerts([posted], new Set(), NOW);
+    const { fire, expire } = collectDueAlerts([moved], new Set(), NOW);
     expect(fire).toEqual([]);
     expect(expire).toEqual([]);
   });

--- a/packages/web/src/lib/alerts-core.ts
+++ b/packages/web/src/lib/alerts-core.ts
@@ -40,12 +40,16 @@ export function eligibleForAlert(item: InboxItem): boolean {
   return !!item.startsAt && !item.completed && !item.archived;
 }
 
-/** Dedup key: one alert per (item, scheduled moment) — editing the time
- *  re-arms the alert. */
+/**
+ * Dedup key: one alert per (item, effective alert moment) — editing the
+ * time OR toggling all-day re-arms the alert, since both change when it
+ * fires. Derived from alertTimeFor, not raw startsAt, so a timed→all-day
+ * flip with the same startsAt still gets its 09:00 alert.
+ */
 export function alertKey(
-  item: Pick<InboxItem, 'id' | 'startsAt'>,
+  item: Pick<InboxItem, 'id' | 'startsAt' | 'allDay'>,
 ): string {
-  return `${item.id}@${item.startsAt}`;
+  return `${item.id}@${alertTimeFor(item) ?? 'unscheduled'}`;
 }
 
 /**
@@ -78,8 +82,8 @@ export function collectDueAlerts(
 
 /**
  * Drop fired keys that can never matter again: the item is gone, its
- * schedule moved (a fresh key guards the new time), or the key is older
- * than the retention window.
+ * effective alert moment moved (a fresh key guards the new time), or the
+ * key is older than the retention window.
  */
 export function pruneFiredKeys(
   keys: string[],
@@ -90,10 +94,10 @@ export function pruneFiredKeys(
     const at = key.lastIndexOf('@');
     if (at <= 0) return false;
     const id = key.slice(0, at);
-    const startsAt = key.slice(at + 1);
     const item = items[id];
-    if (!item || item.startsAt !== startsAt) return false;
+    if (!item) return false;
     const due = alertTimeFor(item);
-    return due !== null && nowMs - due < FIRED_RETENTION_MS;
+    if (due === null || key.slice(at + 1) !== String(due)) return false;
+    return nowMs - due < FIRED_RETENTION_MS;
   });
 }

--- a/packages/web/src/lib/alerts-core.ts
+++ b/packages/web/src/lib/alerts-core.ts
@@ -31,14 +31,13 @@ export function alertTimeFor(
 }
 
 /**
- * Whether this item participates in in-app alerting at all. Items posted to
- * a calendar (`eventUrl`) are excluded even in copy mode — the calendar owns
- * alerting for them, and double notifications are worse than none.
+ * Whether this item participates in in-app alerting: anything open with a
+ * time. Moved items are excluded via `archived` (the calendar owns them);
+ * copies alert like any other item — it has a date on it, you expect an
+ * alert, no assumptions about what the calendar does with its copy.
  */
 export function eligibleForAlert(item: InboxItem): boolean {
-  return (
-    !!item.startsAt && !item.completed && !item.archived && !item.eventUrl
-  );
+  return !!item.startsAt && !item.completed && !item.archived;
 }
 
 /** Dedup key: one alert per (item, scheduled moment) — editing the time

--- a/packages/web/src/lib/alerts-core.ts
+++ b/packages/web/src/lib/alerts-core.ts
@@ -1,0 +1,100 @@
+import type { InboxItem } from '@inbox-rs/rs-module';
+
+/**
+ * Pure decision logic for in-app due alerts. The side-effectful scheduler
+ * (alerts.ts) feeds it the item map, the fired-key set, and the clock; this
+ * module owns *what* fires, *when*, and dedup key semantics — all unit
+ * testable with an injected now.
+ */
+
+/** All-day items alert at this local hour of their day. */
+export const ALL_DAY_ALERT_HOUR = 9;
+
+/** Alerts that became due while the app was closed still fire within this
+ *  window; older ones are marked fired silently (they're visible in the due
+ *  band — a stale notification flood after reopening helps nobody). */
+export const ALERT_GRACE_MS = 30 * 60_000;
+
+/** Fired keys older than this are pruned from storage. */
+const FIRED_RETENTION_MS = 7 * 24 * 60 * 60_000;
+
+/** The moment this item's alert should fire, in epoch ms. */
+export function alertTimeFor(
+  item: Pick<InboxItem, 'startsAt' | 'allDay'>,
+): number | null {
+  if (!item.startsAt) return null;
+  const d = new Date(item.startsAt);
+  if (Number.isNaN(d.getTime())) return null;
+  // Same local-time convention as isOverdue/isPast in schedule.ts.
+  if (item.allDay) d.setHours(ALL_DAY_ALERT_HOUR, 0, 0, 0);
+  return d.getTime();
+}
+
+/**
+ * Whether this item participates in in-app alerting at all. Items posted to
+ * a calendar (`eventUrl`) are excluded even in copy mode — the calendar owns
+ * alerting for them, and double notifications are worse than none.
+ */
+export function eligibleForAlert(item: InboxItem): boolean {
+  return (
+    !!item.startsAt && !item.completed && !item.archived && !item.eventUrl
+  );
+}
+
+/** Dedup key: one alert per (item, scheduled moment) — editing the time
+ *  re-arms the alert. */
+export function alertKey(
+  item: Pick<InboxItem, 'id' | 'startsAt'>,
+): string {
+  return `${item.id}@${item.startsAt}`;
+}
+
+/**
+ * Partition currently-due, un-fired alerts into `fire` (due within the grace
+ * window — deliver now) and `expire` (due longer ago — mark fired silently).
+ */
+export function collectDueAlerts(
+  items: InboxItem[],
+  fired: ReadonlySet<string>,
+  nowMs: number,
+  graceMs: number = ALERT_GRACE_MS,
+): { fire: InboxItem[]; expire: string[] } {
+  const fire: InboxItem[] = [];
+  const expire: string[] = [];
+  for (const item of items) {
+    if (!eligibleForAlert(item)) continue;
+    const due = alertTimeFor(item);
+    if (due === null || due > nowMs) continue;
+    const key = alertKey(item);
+    if (fired.has(key)) continue;
+    if (nowMs - due <= graceMs) {
+      fire.push(item);
+    } else {
+      expire.push(key);
+    }
+  }
+  fire.sort((a, b) => (alertTimeFor(a) ?? 0) - (alertTimeFor(b) ?? 0));
+  return { fire, expire };
+}
+
+/**
+ * Drop fired keys that can never matter again: the item is gone, its
+ * schedule moved (a fresh key guards the new time), or the key is older
+ * than the retention window.
+ */
+export function pruneFiredKeys(
+  keys: string[],
+  items: Record<string, InboxItem>,
+  nowMs: number,
+): string[] {
+  return keys.filter((key) => {
+    const at = key.lastIndexOf('@');
+    if (at <= 0) return false;
+    const id = key.slice(0, at);
+    const startsAt = key.slice(at + 1);
+    const item = items[id];
+    if (!item || item.startsAt !== startsAt) return false;
+    const due = alertTimeFor(item);
+    return due !== null && nowMs - due < FIRED_RETENTION_MS;
+  });
+}

--- a/packages/web/src/lib/alerts.ts
+++ b/packages/web/src/lib/alerts.ts
@@ -1,0 +1,166 @@
+import type { InboxItem } from '@inbox-rs/rs-module';
+import { get, writable } from 'svelte/store';
+import {
+  ALERT_GRACE_MS,
+  alertKey,
+  collectDueAlerts,
+  pruneFiredKeys,
+} from './alerts-core';
+import { now } from './now';
+import { formatScheduled } from './schedule';
+import { items } from './stores';
+import { showToast } from './toast';
+
+/**
+ * The in-app due-alert scheduler. Watches the global `items` store (not any
+ * view-filtered derivation) so a due todo alerts even when the active filter
+ * hides it, and delivers on the shared `now` heartbeat: a toast always, plus
+ * an OS notification when permission is granted. Client-side only — alerts
+ * fire while a tab or installed PWA is open; there is no push server.
+ *
+ * Dedup state is device-local localStorage. It is re-read on every check
+ * (and re-checked right before each write), so two open tabs converge on the
+ * same fired set without a dedicated cross-tab channel; the OS-notification
+ * `tag` collapses the residual race to a single banner.
+ */
+
+const FIRED_KEY = 'inbox-rs:alerts:fired';
+
+function notificationsSupported(): boolean {
+  return typeof window !== 'undefined' && 'Notification' in window;
+}
+
+export const alertPermission = writable<NotificationPermission | 'unsupported'>(
+  notificationsSupported() ? Notification.permission : 'unsupported',
+);
+
+export async function requestAlertPermission(): Promise<
+  NotificationPermission | 'unsupported'
+> {
+  if (!notificationsSupported()) return 'unsupported';
+  const result = await Notification.requestPermission();
+  alertPermission.set(result);
+  return result;
+}
+
+type OpenHandler = (item: InboxItem) => void;
+let openHandler: OpenHandler | null = null;
+
+/** App registers its card-modal opener so a toast's View action can jump
+ *  straight to the due item. */
+export function setAlertOpenHandler(fn: OpenHandler): void {
+  openHandler = fn;
+}
+
+function loadFired(): Set<string> {
+  try {
+    const raw = localStorage.getItem(FIRED_KEY);
+    if (!raw) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    return new Set(Array.isArray(parsed) ? parsed.filter((k) => typeof k === 'string') : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function saveFired(fired: Set<string>): void {
+  try {
+    localStorage.setItem(FIRED_KEY, JSON.stringify([...fired]));
+  } catch {
+    // Storage unavailable — alerts may repeat next session; better than none.
+  }
+}
+
+async function osNotify(item: InboxItem): Promise<void> {
+  if (get(alertPermission) !== 'granted') return;
+  const title = item.title || 'Untitled';
+  const options = {
+    body: `Due now · ${formatScheduled(item)}`,
+    tag: alertKey(item),
+  };
+  // Prefer the SW registration (required on Android; works with the
+  // generateSW worker since the call comes from the page), fall back to the
+  // constructor where no registration exists (e.g. dev without SW).
+  try {
+    const reg = await navigator.serviceWorker?.getRegistration();
+    if (reg) {
+      await reg.showNotification(title, options);
+      return;
+    }
+  } catch {
+    // fall through to the constructor
+  }
+  try {
+    new Notification(title, options);
+  } catch {
+    // Notification constructor throws on some platforms (Android) — the
+    // toast already delivered the alert in-app.
+  }
+}
+
+function deliver(due: InboxItem[]): void {
+  if (due.length === 1) {
+    const item = due[0];
+    showToast(`Due now: ${item.title || 'Untitled'}`, {
+      label: 'View',
+      run: () => openHandler?.(item),
+    });
+  } else {
+    showToast(`${due.length} items due now`, {
+      label: 'View',
+      run: () => {
+        window.location.hash = '#/todos';
+      },
+    });
+  }
+  for (const item of due) void osNotify(item);
+}
+
+function check(): void {
+  const map = get(items);
+  const fired = loadFired();
+  const { fire, expire } = collectDueAlerts(
+    Object.values(map),
+    fired,
+    Date.now(),
+    ALERT_GRACE_MS,
+  );
+  if (fire.length === 0 && expire.length === 0) return;
+
+  // Re-read right before writing: another tab may have fired these between
+  // our load and now.
+  const fresh = loadFired();
+  const deliverable = fire.filter((item) => !fresh.has(alertKey(item)));
+  for (const item of deliverable) fresh.add(alertKey(item));
+  for (const key of expire) fresh.add(key);
+  saveFired(fresh);
+
+  if (deliverable.length > 0) deliver(deliverable);
+}
+
+let initialized = false;
+
+/**
+ * Start the scheduler. Idempotent; call once from the app shell. Subscribes
+ * to `items` (new/edited schedules re-check immediately) and `now` (the 30s
+ * heartbeat, which also ticks on visibilitychange → visible).
+ */
+export function initAlerts(): void {
+  if (initialized) return;
+  initialized = true;
+
+  // One-time hygiene: drop fired keys for deleted/rescheduled/ancient items.
+  // Deferred until items actually load — at startup the store is empty, and
+  // pruning against it would wipe every key and re-fire old alerts.
+  let pruned = false;
+  items.subscribe((map) => {
+    if (!pruned && Object.keys(map).length > 0) {
+      pruned = true;
+      const fired = loadFired();
+      const kept = pruneFiredKeys([...fired], map, Date.now());
+      if (kept.length !== fired.size) saveFired(new Set(kept));
+    }
+    check();
+  });
+  now.subscribe(check);
+}

--- a/packages/web/src/lib/caldav.test.ts
+++ b/packages/web/src/lib/caldav.test.ts
@@ -3,11 +3,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   CaldavError,
   createEntry,
-  deleteEntry,
   fetchCalendars,
   itemToCalendarObject,
   uidFor,
-  updateEntry,
 } from './caldav';
 
 const ENDPOINT = 'https://sockethub.test/sockethub-http';
@@ -210,75 +208,7 @@ describe('mutations', () => {
     expect(body[1].object.uid).toBe(uidFor(note()));
   });
 
-  it('update sends id + etag alongside the object', async () => {
-    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      ndjson({
-        type: 'update',
-        object: { id: `${CAL}x.ics`, etag: '"e2"' },
-      }),
-    );
-    const scheduled = note({ eventUrl: `${CAL}x.ics`, eventEtag: '"e1"' });
-    const posted = await updateEntry(CREDS, CAL, scheduled, ENDPOINT);
-    expect(posted.eventEtag).toBe('"e2"');
-    const body = JSON.parse(
-      (fetchMock.mock.calls[0][1] as RequestInit).body as string,
-    );
-    expect(body[1].object.id).toBe(`${CAL}x.ics`);
-    expect(body[1].object.etag).toBe('"e1"');
-    expect(body[1].object.uid).toBe('item-1@inbox-rs');
-  });
-
-  it('update refuses items without a posted entry', async () => {
-    await expect(updateEntry(CREDS, CAL, note(), ENDPOINT)).rejects.toThrow(
-      /no posted entry/,
-    );
-  });
-
-  it('delete sends the required id/type/etag triple', async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(
-        ndjson({ type: 'delete', object: { id: `${CAL}x.ics` } }),
-      );
-    await deleteEntry(
-      CREDS,
-      CAL,
-      note({
-        eventUrl: `${CAL}x.ics`,
-        eventEtag: '"e1"',
-        scheduleKind: 'task',
-      }),
-      ENDPOINT,
-    );
-    const body = JSON.parse(
-      (fetchMock.mock.calls[0][1] as RequestInit).body as string,
-    );
-    expect(body[1].object).toEqual({
-      id: `${CAL}x.ics`,
-      type: 'task',
-      etag: '"e1"',
-    });
-  });
-
-  it('delete throws (not no-ops) when a posted entry has no etag', async () => {
-    const stranded = note({ eventUrl: `${CAL}x.ics`, eventEtag: undefined });
-    await expect(deleteEntry(CREDS, CAL, stranded, ENDPOINT)).rejects.toThrow(
-      /no stored etag/,
-    );
-    // Never-posted items are still a clean no-op.
-    await expect(
-      deleteEntry(CREDS, CAL, note(), ENDPOINT),
-    ).resolves.toBeUndefined();
-  });
-
-  it('surfaces conflicts with their code', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      ndjson({ type: 'error', error: 'caldav:conflict' }),
-    );
-    const scheduled = note({ eventUrl: `${CAL}x.ics`, eventEtag: '"stale"' });
-    const err = await updateEntry(CREDS, CAL, scheduled, ENDPOINT).catch(
-      (e) => e,
-    );
-    expect(err.code).toBe('caldav:conflict');
-  });
+  // No update/delete tests: those operations were removed from the client
+  // on purpose — publishing is one-shot, and inbox-rs never modifies the
+  // user's calendar after the create.
 });

--- a/packages/web/src/lib/caldav.ts
+++ b/packages/web/src/lib/caldav.ts
@@ -10,10 +10,11 @@
  * Contract (see sockethub packages/platform-caldav):
  * - timed values must carry a UTC offset — our ISO `...Z` strings qualify
  * - all-day values must be date-only `YYYY-MM-DD` in the user's local day
- * - `update` requires id + etag + uid; `delete` requires id + type + etag
- * - client-supplied UIDs are allowed — we always use `<itemId>@inbox-rs`,
- *   so the uid needed for updates is derivable from the item alone
+ * - client-supplied UIDs are allowed — we always use `<itemId>@inbox-rs`
  * - failures arrive as machine-readable `caldav:*` codes
+ *
+ * This client only discovers calendars and CREATES entries. Publishing is
+ * one-shot by design — no updates, no deletes (see note at end of file).
  */
 import type { InboxItem } from '@inbox-rs/rs-module';
 import { toDateInputValue } from './schedule';
@@ -249,57 +250,8 @@ export async function createEntry(
   return mutationResult(result);
 }
 
-/** Replace the item's existing entry (requires the stored href + etag). */
-export async function updateEntry(
-  creds: CaldavCredentials,
-  calendarId: string,
-  item: InboxItem,
-  endpoint: string,
-): Promise<PostedEntry> {
-  const object = itemToCalendarObject(item);
-  if (!object || !item.eventUrl || !item.eventEtag) {
-    throw new CaldavError('item has no posted entry to update');
-  }
-  const result = await send(
-    creds,
-    {
-      type: 'update',
-      target: { id: calendarId, type: 'calendar' },
-      object: { ...object, id: item.eventUrl, etag: item.eventEtag },
-    },
-    ['update'],
-    endpoint,
-  );
-  return mutationResult(result);
-}
-
-/** Delete the item's entry from its calendar. */
-export async function deleteEntry(
-  creds: CaldavCredentials,
-  calendarId: string,
-  item: InboxItem,
-  endpoint: string,
-): Promise<void> {
-  // Never posted → nothing to delete. But a posted entry without its etag
-  // is a failure, not a no-op: the platform's delete requires the etag, and
-  // silently returning would strand the entry on the calendar (e.g. as a
-  // stale duplicate after a calendar move).
-  if (!item.eventUrl) return;
-  if (!item.eventEtag) {
-    throw new CaldavError('posted entry has no stored etag — cannot delete');
-  }
-  await send(
-    creds,
-    {
-      type: 'delete',
-      target: { id: calendarId, type: 'calendar' },
-      object: {
-        id: item.eventUrl,
-        type: item.scheduleKind === 'task' ? 'task' : 'event',
-        etag: item.eventEtag,
-      },
-    },
-    ['delete'],
-    endpoint,
-  );
-}
+// There are deliberately no update or delete operations here. Publishing is
+// one-shot: inbox-rs only ever ADDS entries to the user's calendar, and only
+// on explicit request. Entries must never change or disappear because a card
+// was edited in the app. (The sockethub platform supports update/delete; this
+// client intentionally does not.)

--- a/packages/web/src/lib/collection-todos.test.ts
+++ b/packages/web/src/lib/collection-todos.test.ts
@@ -2,6 +2,7 @@ import type { InboxItem, NoteItem, TodoItem } from '@inbox-rs/rs-module';
 import { describe, expect, it } from 'vitest';
 import {
   filterCompletedTodos,
+  filterOnCalendarItems,
   filterOpenTodos,
   filterReferenceItems,
   filterTodos,
@@ -67,6 +68,16 @@ describe('filterOpenTodos / filterCompletedTodos', () => {
     expect(filterOpenTodos(todos).map((t) => t.id)).toEqual(['t1', 't3']);
     expect(filterCompletedTodos(todos).map((t) => t.id)).toEqual(['t2']);
   });
+
+  it('excludes calendar-archived todos from both partitions', () => {
+    const todos: InboxItem[] = [
+      todo('t1', false),
+      { ...todo('t2', false), archived: true },
+      { ...todo('t3', true, '2026-04-02T00:00:00.000Z'), archived: true },
+    ];
+    expect(filterOpenTodos(todos).map((t) => t.id)).toEqual(['t1']);
+    expect(filterCompletedTodos(todos)).toEqual([]);
+  });
 });
 
 describe('filterReferenceItems', () => {
@@ -78,6 +89,37 @@ describe('filterReferenceItems', () => {
       ref('r2'),
     ];
     expect(filterReferenceItems(items).map((i) => i.id)).toEqual(['r1', 'r2']);
+  });
+
+  it('excludes calendar-archived reference items', () => {
+    const items: InboxItem[] = [ref('r1'), { ...ref('r2'), archived: true }];
+    expect(filterReferenceItems(items).map((i) => i.id)).toEqual(['r1']);
+  });
+});
+
+describe('filterOnCalendarItems', () => {
+  it('returns only archived items of any kind, newest move first', () => {
+    const items: InboxItem[] = [
+      ref('r1'),
+      { ...ref('r2'), archived: true, archivedAt: '2026-04-02T00:00:00.000Z' },
+      todo('t1', false),
+      {
+        ...todo('t2', false),
+        archived: true,
+        archivedAt: '2026-04-03T00:00:00.000Z',
+      },
+      // archived + completed: archived wins — it belongs here
+      {
+        ...todo('t3', true, '2026-04-01T00:00:00.000Z'),
+        archived: true,
+        archivedAt: '2026-04-01T00:00:00.000Z',
+      },
+    ];
+    expect(filterOnCalendarItems(items).map((i) => i.id)).toEqual([
+      't2',
+      'r2',
+      't3',
+    ]);
   });
 });
 

--- a/packages/web/src/lib/collection-todos.ts
+++ b/packages/web/src/lib/collection-todos.ts
@@ -5,15 +5,30 @@ export function filterTodos(items: InboxItem[]): InboxItem[] {
 }
 
 export function filterOpenTodos(todos: InboxItem[]): InboxItem[] {
-  return todos.filter((t) => !t.completed);
+  return todos.filter((t) => !t.completed && !t.archived);
 }
 
 export function filterCompletedTodos(todos: InboxItem[]): InboxItem[] {
-  return todos.filter((t) => t.completed);
+  return todos.filter((t) => t.completed && !t.archived);
 }
 
 export function filterReferenceItems(items: InboxItem[]): InboxItem[] {
-  return items.filter((i) => !i.isTodo && i.type !== 'todo');
+  return items.filter((i) => !i.isTodo && i.type !== 'todo' && !i.archived);
+}
+
+/**
+ * Items moved to a calendar (any kind), for a collection's collapsed
+ * "on calendar" section — newest move first. Archived wins over completed:
+ * an archived+completed todo lives here, not in the completed section.
+ */
+export function filterOnCalendarItems(items: InboxItem[]): InboxItem[] {
+  return items
+    .filter((i) => !!i.archived)
+    .sort(
+      (a, b) =>
+        new Date(b.archivedAt ?? b.createdAt).getTime() -
+        new Date(a.archivedAt ?? a.createdAt).getTime(),
+    );
 }
 
 export function sortCompletedTodosByCompletedAt(

--- a/packages/web/src/lib/now.ts
+++ b/packages/web/src/lib/now.ts
@@ -1,0 +1,48 @@
+import { readable } from 'svelte/store';
+
+/**
+ * A shared wall-clock heartbeat. Everything time-reactive (overdue styling,
+ * the due band, the alert scheduler) hangs off this one store instead of
+ * running its own interval. 30s is deliberate: alerts may land up to 30s
+ * late, which nobody notices, and recomputing from the wall clock each tick
+ * makes device sleep and clock changes non-issues.
+ */
+const TICK_MS = 30_000;
+
+export const now = readable(new Date(), (set) => {
+  const tick = () => set(new Date());
+  const interval = setInterval(tick, TICK_MS);
+  // A backgrounded tab throttles intervals; refresh immediately on return
+  // so stale "due in 5 min" states don't linger after a long sleep.
+  const onVisibility = () => {
+    if (document.visibilityState === 'visible') tick();
+  };
+  document.addEventListener('visibilitychange', onVisibility);
+  return () => {
+    clearInterval(interval);
+    document.removeEventListener('visibilitychange', onVisibility);
+  };
+});
+
+function startOfDay(d: Date): number {
+  const t = new Date(d);
+  t.setHours(0, 0, 0, 0);
+  return t.getTime();
+}
+
+/**
+ * Local midnight of the current day, in epoch ms. Emits only when the date
+ * actually changes, so derived stores (the due band) can depend on "today"
+ * without re-deriving every 30 seconds.
+ */
+export const todayStart = readable(startOfDay(new Date()), (set) => {
+  let current = startOfDay(new Date());
+  set(current);
+  return now.subscribe((d) => {
+    const next = startOfDay(d);
+    if (next !== current) {
+      current = next;
+      set(next);
+    }
+  });
+});

--- a/packages/web/src/lib/schedule-sync.test.ts
+++ b/packages/web/src/lib/schedule-sync.test.ts
@@ -20,7 +20,8 @@ vi.mock('./caldav', async (importOriginal) => {
 });
 
 import { calendarAccounts } from './calendar-accounts';
-import { addItemToCalendar, removeItemFromCalendar } from './schedule-sync';
+import { deleteEntry } from './caldav';
+import { addItemToCalendar, reEnableFromCalendar } from './schedule-sync';
 import { storeItem } from './stores';
 
 const CAL = {
@@ -109,19 +110,22 @@ describe('addItemToCalendar — the archive ownership rule', () => {
   });
 });
 
-describe('removeItemFromCalendar', () => {
-  it('clears the entry pointer and un-archives, keeping the time', async () => {
+describe('reEnableFromCalendar', () => {
+  it('un-archives locally, keeping the entry link and the time — the calendar is never touched', async () => {
     const archived = note({
       eventUrl: `${CAL.id}x.ics`,
       eventEtag: '"e1"',
       archived: true,
       archivedAt: '2026-08-01T00:00:00Z',
     });
-    const result = await removeItemFromCalendar(archived);
-    expect(result.eventUrl).toBeUndefined();
-    expect(result.eventEtag).toBeUndefined();
+    const result = await reEnableFromCalendar(archived);
     expect(result.archived).toBeUndefined();
     expect(result.archivedAt).toBeUndefined();
+    // The link survives: the item is a copy now, still syncing to its entry.
+    expect(result.eventUrl).toBe(archived.eventUrl);
+    expect(result.eventEtag).toBe(archived.eventEtag);
     expect(result.startsAt).toBe(archived.startsAt);
+    // No server call of any kind.
+    expect(vi.mocked(deleteEntry)).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/lib/schedule-sync.test.ts
+++ b/packages/web/src/lib/schedule-sync.test.ts
@@ -64,14 +64,14 @@ function lastStored(): Record<string, unknown> {
 }
 
 describe('addItemToCalendar — the archive ownership rule', () => {
-  it('archives an Inbox reference card on first post', async () => {
+  it('archives an Inbox reference card on first post (move is the default)', async () => {
     const result = await addItemToCalendar(note(), CAL.id);
     expect(result.archived).toBe(true);
     expect(result.archivedAt).toBeTruthy();
     expect(lastStored().archived).toBe(true);
   });
 
-  it('never archives todos — they complete instead', async () => {
+  it('archives todos in move mode — the calendar owns them now', async () => {
     const todo: TodoItem = {
       id: 't1',
       type: 'todo',
@@ -81,14 +81,22 @@ describe('addItemToCalendar — the archive ownership rule', () => {
       startsAt: '2026-08-03T13:00:00.000Z',
       scheduleKind: 'task',
     };
-    const result = await addItemToCalendar(todo, CAL.id);
-    expect(result.archived).toBeUndefined();
+    const result = await addItemToCalendar(todo, CAL.id, 'move');
+    expect(result.archived).toBe(true);
+    expect(result.archivedAt).toBeTruthy();
   });
 
-  it('does not archive filed cards — they are already triaged', async () => {
+  it('archives filed cards in move mode', async () => {
     const filed = note({ collectionId: 'col-1' });
     const result = await addItemToCalendar(filed, CAL.id);
+    expect(result.archived).toBe(true);
+  });
+
+  it('never archives in copy mode — the item stays active in the app', async () => {
+    const result = await addItemToCalendar(note(), CAL.id, 'copy');
     expect(result.archived).toBeUndefined();
+    expect(result.archivedAt).toBeUndefined();
+    expect(result.eventUrl).toBeTruthy();
   });
 
   it('does not re-archive on subsequent posts (calendar move keeps state)', async () => {

--- a/packages/web/src/lib/schedule-sync.test.ts
+++ b/packages/web/src/lib/schedule-sync.test.ts
@@ -11,17 +11,16 @@ vi.mock('./caldav', async (importOriginal) => {
       eventUrl: 'https://cal.example.org/nick/personal/x.ics',
       eventEtag: '"e1"',
     })),
-    updateEntry: vi.fn(async () => ({
-      eventUrl: 'https://cal.example.org/nick/personal/x.ics',
-      eventEtag: '"e2"',
-    })),
-    deleteEntry: vi.fn(async () => {}),
   };
 });
 
 import { calendarAccounts } from './calendar-accounts';
-import { deleteEntry } from './caldav';
-import { addItemToCalendar, reEnableFromCalendar } from './schedule-sync';
+import { createEntry } from './caldav';
+import {
+  addItemToCalendar,
+  detachFromCalendar,
+  reEnableFromCalendar,
+} from './schedule-sync';
 import { storeItem } from './stores';
 
 const CAL = {
@@ -100,18 +99,20 @@ describe('addItemToCalendar — the archive ownership rule', () => {
     expect(result.eventUrl).toBeTruthy();
   });
 
-  it('does not re-archive on subsequent posts (calendar move keeps state)', async () => {
+  it('refuses to post an already-posted item — publishing is one-shot', async () => {
     const posted = note({
       eventUrl: `${CAL.id}x.ics`,
       eventEtag: '"e1"',
     });
-    const result = await addItemToCalendar(posted, CAL.id);
-    expect(result.archived).toBeUndefined();
+    await expect(addItemToCalendar(posted, CAL.id)).rejects.toThrow(
+      /one-shot/,
+    );
+    expect(vi.mocked(createEntry)).not.toHaveBeenCalled();
   });
 });
 
 describe('reEnableFromCalendar', () => {
-  it('un-archives locally, keeping the entry link and the time — the calendar is never touched', async () => {
+  it('un-archives locally, keeping the receipt and the time — the calendar is never touched', async () => {
     const archived = note({
       eventUrl: `${CAL.id}x.ics`,
       eventEtag: '"e1"',
@@ -121,11 +122,29 @@ describe('reEnableFromCalendar', () => {
     const result = await reEnableFromCalendar(archived);
     expect(result.archived).toBeUndefined();
     expect(result.archivedAt).toBeUndefined();
-    // The link survives: the item is a copy now, still syncing to its entry.
+    // The receipt survives: the item reads as a copy of the calendar entry.
     expect(result.eventUrl).toBe(archived.eventUrl);
     expect(result.eventEtag).toBe(archived.eventEtag);
     expect(result.startsAt).toBe(archived.startsAt);
     // No server call of any kind.
-    expect(vi.mocked(deleteEntry)).not.toHaveBeenCalled();
+    expect(vi.mocked(createEntry)).not.toHaveBeenCalled();
+  });
+});
+
+describe('detachFromCalendar', () => {
+  it('drops the receipt and archive state locally, keeping the time — no server call', async () => {
+    const archived = note({
+      eventUrl: `${CAL.id}x.ics`,
+      eventEtag: '"e1"',
+      archived: true,
+      archivedAt: '2026-08-01T00:00:00Z',
+    });
+    const result = await detachFromCalendar(archived);
+    expect(result.eventUrl).toBeUndefined();
+    expect(result.eventEtag).toBeUndefined();
+    expect(result.archived).toBeUndefined();
+    expect(result.archivedAt).toBeUndefined();
+    expect(result.startsAt).toBe(archived.startsAt);
+    expect(vi.mocked(createEntry)).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/lib/schedule-sync.ts
+++ b/packages/web/src/lib/schedule-sync.ts
@@ -1,98 +1,30 @@
 /**
- * Orchestrates posting a card's schedule to a CalDAV calendar via the
- * sockethub relay: create vs update vs move, entry removal, and best-effort
- * completion sync for tasks. The card is always the source of truth — these
- * helpers only maintain the calendar-side projection and the stored
- * eventUrl/eventEtag pointing at it.
+ * One-shot calendar publishing via the sockethub relay. Posting CREATES an
+ * entry and stores eventUrl/eventEtag as a receipt — which calendar the item
+ * went to, and that it's there. After that, inbox-rs NEVER updates or
+ * deletes the entry, no matter what happens to the card: the user's
+ * calendar is theirs, and entries must not change or vanish because
+ * someone was editing cards in this app. All detach/re-enable operations
+ * are local-only.
  */
 import type { InboxItem } from '@inbox-rs/rs-module';
-import { CaldavError, createEntry, deleteEntry, updateEntry } from './caldav';
+import { CaldavError, createEntry } from './caldav';
 import {
   accountEndpoint,
-  choiceForEventUrl,
   findCalendarChoice,
   recordCalendarUse,
 } from './calendar-accounts';
 import { cleanForStorage } from './clean-for-storage';
-import { applySchedule, type PendingSchedule } from './schedule';
+import {
+  applySchedule,
+  clearPostedEntry,
+  type PendingSchedule,
+} from './schedule';
 import { storeItem } from './stores';
 
 /**
- * Post the (already locally saved) scheduled item to `calendarId`. Handles
- * all three shapes: first post (create), same-calendar change (update), and
- * calendar move (delete from the old calendar, create in the new one).
- * Returns the item with its eventUrl/eventEtag refreshed — the caller
- * persists it.
- */
-export async function postScheduledItem(
-  item: InboxItem,
-  calendarId: string,
-): Promise<InboxItem> {
-  const target = findCalendarChoice(calendarId);
-  if (!target) throw new CaldavError('caldav:invalid-calendar');
-
-  const current = choiceForEventUrl(item.eventUrl);
-  if (item.eventUrl && current && current.calendar.id === calendarId) {
-    const posted = await updateEntry(
-      current.account,
-      calendarId,
-      item,
-      accountEndpoint(current.account),
-    );
-    return { ...item, ...posted };
-  }
-  if (item.eventUrl && current) {
-    // Moving calendars: remove the old projection first. A vanished entry
-    // (deleted out-of-band in the calendar app) is fine — the goal state is
-    // "not there", and create below still runs.
-    try {
-      await deleteEntry(
-        current.account,
-        current.calendar.id,
-        item,
-        accountEndpoint(current.account),
-      );
-    } catch (err) {
-      if (!(err instanceof CaldavError && err.code === 'caldav:not-found')) {
-        throw err;
-      }
-    }
-  }
-  const posted = await createEntry(
-    target.account,
-    calendarId,
-    item,
-    accountEndpoint(target.account),
-  );
-  return { ...item, ...posted };
-}
-
-/**
- * Delete the item's posted entry. Resolves (with no value) once the calendar
- * no longer has the entry — deleted now, already gone, or never posted;
- * throws only when the server refused and the entry may still exist.
- */
-export async function removePostedEntry(item: InboxItem): Promise<void> {
-  const current = choiceForEventUrl(item.eventUrl);
-  if (!item.eventUrl || !current) return;
-  try {
-    await deleteEntry(
-      current.account,
-      current.calendar.id,
-      item,
-      accountEndpoint(current.account),
-    );
-  } catch (err) {
-    if (err instanceof CaldavError && err.code === 'caldav:not-found') return;
-    throw err;
-  }
-}
-
-/**
- * The shared completion toggle: persists the flip locally, then — for tasks
- * with a posted entry — syncs STATUS:COMPLETED to the calendar best-effort.
- * Calendar failures never block or revert the local toggle; the next
- * successful post refreshes the projection.
+ * The shared completion toggle — local-only. Completing a todo here never
+ * touches a posted calendar entry; the calendar's copy is a frozen snapshot.
  */
 export async function setItemCompleted(
   item: InboxItem,
@@ -105,23 +37,6 @@ export async function setItemCompleted(
     completedAt: completed ? new Date().toISOString() : undefined,
   };
   await storeItem(cleanForStorage(updated));
-
-  if (item.scheduleKind !== 'task' || !item.eventUrl || !item.eventEtag) {
-    return;
-  }
-  const current = choiceForEventUrl(item.eventUrl);
-  if (!current) return;
-  try {
-    const posted = await updateEntry(
-      current.account,
-      current.calendar.id,
-      updated,
-      accountEndpoint(current.account),
-    );
-    await storeItem(cleanForStorage({ ...updated, ...posted }));
-  } catch (err) {
-    console.warn('Calendar completion sync failed (kept local state)', err);
-  }
 }
 
 /**
@@ -138,21 +53,32 @@ export async function applyPendingSchedule(
 }
 
 /**
- * Post the item to a calendar and apply the ownership rule: in 'move' mode
- * (the default) the calendar owns the item now, so it is archived out of
- * its surface's active lists — any kind, filed or not. 'copy' mode posts
- * without archiving. Only the first post can archive; relocating an
- * already-posted entry between calendars never changes archive state.
- * Returns the stored item.
+ * Create the item's calendar entry (one shot — an already-posted item can
+ * never be posted again) and apply the ownership rule: in 'move' mode (the
+ * default) the calendar owns the item now, so it is archived out of its
+ * surface's active lists — any kind, filed or not. 'copy' mode posts
+ * without archiving. Returns the stored item.
  */
 export async function addItemToCalendar(
   item: InboxItem,
   calendarId: string,
   mode: 'move' | 'copy' = 'move',
 ): Promise<InboxItem> {
-  const firstPost = !item.eventUrl;
-  let posted = await postScheduledItem(item, calendarId);
-  if (firstPost && mode === 'move') {
+  if (item.eventUrl) {
+    throw new Error(
+      'Item is already on a calendar — posting is one-shot and never updates entries.',
+    );
+  }
+  const target = findCalendarChoice(calendarId);
+  if (!target) throw new CaldavError('caldav:invalid-calendar');
+  const receipt = await createEntry(
+    target.account,
+    calendarId,
+    item,
+    accountEndpoint(target.account),
+  );
+  let posted: InboxItem = { ...item, ...receipt };
+  if (mode === 'move') {
     posted = {
       ...posted,
       archived: true,
@@ -164,12 +90,9 @@ export async function addItemToCalendar(
 }
 
 /**
- * Bring a moved item back under the app's management WITHOUT touching the
- * calendar: only the archive state clears; the entry link stays, so the
- * item becomes a copy (time edits and completion keep syncing, and it
- * alerts in-app again). What happens to the calendar's copy is the
- * calendar's business — inbox-rs never deletes entries on the user's
- * behalf outside its own sync maintenance.
+ * Bring a moved item back under the app's management: only the archive
+ * state clears. The receipt (eventUrl) stays, so the item reads as a copy,
+ * and the calendar entry is not touched.
  */
 export async function reEnableFromCalendar(
   item: InboxItem,
@@ -179,6 +102,20 @@ export async function reEnableFromCalendar(
     archived: undefined,
     archivedAt: undefined,
   };
+  await storeItem(cleanForStorage(updated));
+  return updated;
+}
+
+/**
+ * Drop the item's calendar receipt entirely (link + archive state),
+ * local-only — the calendar keeps its entry. Used when the card diverges
+ * from what was posted beyond what a receipt should claim (e.g. its time
+ * was cleared, or it changed kind).
+ */
+export async function detachFromCalendar(
+  item: InboxItem,
+): Promise<InboxItem> {
+  const updated = clearPostedEntry(item);
   await storeItem(cleanForStorage(updated));
   return updated;
 }

--- a/packages/web/src/lib/schedule-sync.ts
+++ b/packages/web/src/lib/schedule-sync.ts
@@ -14,11 +14,7 @@ import {
   recordCalendarUse,
 } from './calendar-accounts';
 import { cleanForStorage } from './clean-for-storage';
-import {
-  applySchedule,
-  clearPostedEntry,
-  type PendingSchedule,
-} from './schedule';
+import { applySchedule, type PendingSchedule } from './schedule';
 import { storeItem } from './stores';
 
 /**
@@ -168,15 +164,21 @@ export async function addItemToCalendar(
 }
 
 /**
- * Detach the item from its calendar: delete the server entry, keep the
- * time, un-archive (the card returns to the Inbox queue). Throws when the
- * server refused and the entry may still exist — callers keep state as-is.
+ * Bring a moved item back under the app's management WITHOUT touching the
+ * calendar: only the archive state clears; the entry link stays, so the
+ * item becomes a copy (time edits and completion keep syncing, and it
+ * alerts in-app again). What happens to the calendar's copy is the
+ * calendar's business — inbox-rs never deletes entries on the user's
+ * behalf outside its own sync maintenance.
  */
-export async function removeItemFromCalendar(
+export async function reEnableFromCalendar(
   item: InboxItem,
 ): Promise<InboxItem> {
-  await removePostedEntry(item);
-  const updated = clearPostedEntry(item);
+  const updated: InboxItem = {
+    ...item,
+    archived: undefined,
+    archivedAt: undefined,
+  };
   await storeItem(cleanForStorage(updated));
   return updated;
 }

--- a/packages/web/src/lib/schedule-sync.ts
+++ b/packages/web/src/lib/schedule-sync.ts
@@ -142,20 +142,21 @@ export async function applyPendingSchedule(
 }
 
 /**
- * Post the item to a calendar and apply the ownership rule: adding an
- * *Inbox reference card* to a calendar completes its triage — the calendar
- * owns it now, so the card is archived out of the Inbox. Todos are never
- * archived (they still need completing in the app), and filed cards are
- * already triaged. Returns the stored item.
+ * Post the item to a calendar and apply the ownership rule: in 'move' mode
+ * (the default) the calendar owns the item now, so it is archived out of
+ * its surface's active lists — any kind, filed or not. 'copy' mode posts
+ * without archiving. Only the first post can archive; relocating an
+ * already-posted entry between calendars never changes archive state.
+ * Returns the stored item.
  */
 export async function addItemToCalendar(
   item: InboxItem,
   calendarId: string,
+  mode: 'move' | 'copy' = 'move',
 ): Promise<InboxItem> {
   const firstPost = !item.eventUrl;
   let posted = await postScheduledItem(item, calendarId);
-  const isTodoish = posted.isTodo || posted.type === 'todo';
-  if (firstPost && !isTodoish && !posted.collectionId) {
+  if (firstPost && mode === 'move') {
     posted = {
       ...posted,
       archived: true,

--- a/packages/web/src/lib/schedule-sync.ts
+++ b/packages/web/src/lib/schedule-sync.ts
@@ -53,6 +53,22 @@ export async function applyPendingSchedule(
 }
 
 /**
+ * The entry was created on the calendar, but persisting the receipt
+ * locally failed — the card will still offer "Add to calendar" even though
+ * the entry exists. Callers must not report this as "couldn't add".
+ * Retrying the same calendar is bounded: the entry href derives from the
+ * item's deterministic UID (`<id>@inbox-rs`), so a re-create targets the
+ * same resource rather than piling up duplicates.
+ */
+export class ReceiptWriteError extends Error {
+  constructor(cause: unknown) {
+    super('Calendar entry created, but saving its receipt failed');
+    this.name = 'ReceiptWriteError';
+    this.cause = cause;
+  }
+}
+
+/**
  * Create the item's calendar entry (one shot — an already-posted item can
  * never be posted again) and apply the ownership rule: in 'move' mode (the
  * default) the calendar owns the item now, so it is archived out of its
@@ -85,7 +101,11 @@ export async function addItemToCalendar(
       archivedAt: new Date().toISOString(),
     };
   }
-  await storeItem(cleanForStorage(posted));
+  try {
+    await storeItem(cleanForStorage(posted));
+  } catch (err) {
+    throw new ReceiptWriteError(err);
+  }
   return posted;
 }
 

--- a/packages/web/src/lib/schedule.test.ts
+++ b/packages/web/src/lib/schedule.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from 'vitest';
 import {
   applySchedule,
   clearSchedule,
+  compareByDueTime,
   formatScheduled,
   fromInputValues,
+  isDueTodayOrOverdue,
   isOverdue,
   isPast,
   nextRoundHour,
@@ -126,6 +128,51 @@ describe('isOverdue / isPast', () => {
     });
     expect(isPast(running, WED_1423)).toBe(false);
     expect(isPast(note({ startsAt: past }), WED_1423)).toBe(true);
+  });
+});
+
+describe('isDueTodayOrOverdue / compareByDueTime', () => {
+  // Local midnight of the reference Wednesday.
+  const TODAY_START = new Date(2026, 6, 29).getTime();
+
+  it('is date-based: earlier today, yesterday, and later today all count', () => {
+    const laterToday = new Date(2026, 6, 29, 23, 0).toISOString();
+    const yesterday = new Date(2026, 6, 28, 9, 0).toISOString();
+    const tomorrow = new Date(2026, 6, 30, 0, 30).toISOString();
+    expect(
+      isDueTodayOrOverdue(note({ startsAt: laterToday }), TODAY_START),
+    ).toBe(true);
+    expect(
+      isDueTodayOrOverdue(note({ startsAt: yesterday }), TODAY_START),
+    ).toBe(true);
+    expect(
+      isDueTodayOrOverdue(note({ startsAt: tomorrow }), TODAY_START),
+    ).toBe(false);
+  });
+
+  it('excludes completed, archived, and unscheduled items', () => {
+    const due = new Date(2026, 6, 29, 9, 0).toISOString();
+    expect(
+      isDueTodayOrOverdue(
+        note({ startsAt: due, completed: true }),
+        TODAY_START,
+      ),
+    ).toBe(false);
+    expect(
+      isDueTodayOrOverdue(note({ startsAt: due, archived: true }), TODAY_START),
+    ).toBe(false);
+    expect(isDueTodayOrOverdue(note(), TODAY_START)).toBe(false);
+  });
+
+  it('compareByDueTime sorts earliest first, undated last', () => {
+    const a = note({ startsAt: '2026-07-29T08:00:00.000Z' });
+    const b = note({ startsAt: '2026-07-29T10:00:00.000Z' });
+    const c = note();
+    expect([b, c, a].sort(compareByDueTime).map((i) => i.startsAt)).toEqual([
+      a.startsAt,
+      b.startsAt,
+      undefined,
+    ]);
   });
 });
 

--- a/packages/web/src/lib/schedule.ts
+++ b/packages/web/src/lib/schedule.ts
@@ -83,6 +83,34 @@ export function isOverdue(
   return due.getTime() < now.getTime();
 }
 
+/**
+ * Membership test for the Todos page's pinned "Due" band: an open,
+ * un-archived item whose scheduled *date* is today or earlier. Date-based on
+ * purpose — the band's contents only change at midnight or on edits, so
+ * derived stores can depend on a once-per-day `todayStart` instead of a
+ * ticking clock.
+ */
+export function isDueTodayOrOverdue(
+  item: Pick<InboxItem, 'startsAt' | 'completed' | 'archived'>,
+  todayStartMs: number,
+): boolean {
+  if (!item.startsAt || item.completed || item.archived) return false;
+  const d = new Date(item.startsAt);
+  if (Number.isNaN(d.getTime())) return false;
+  d.setHours(0, 0, 0, 0);
+  return d.getTime() <= todayStartMs;
+}
+
+/** Earliest due moment first; items without a time sort last. */
+export function compareByDueTime(
+  a: Pick<InboxItem, 'startsAt'>,
+  b: Pick<InboxItem, 'startsAt'>,
+): number {
+  const at = a.startsAt ? new Date(a.startsAt).getTime() : Infinity;
+  const bt = b.startsAt ? new Date(b.startsAt).getTime() : Infinity;
+  return at - bt;
+}
+
 /** The scheduled moment (or the event's end) is behind us. */
 export function isPast(
   item: Pick<InboxItem, 'startsAt' | 'endsAt' | 'allDay'>,

--- a/packages/web/src/lib/stores.test.ts
+++ b/packages/web/src/lib/stores.test.ts
@@ -94,6 +94,7 @@ import {
   toggleGroupFilter,
   userSettings,
   visibleGroupedCollections,
+  visibleOnCalendarTodos,
   visibleOpenTodos,
   visibleTodos,
 } from './stores';
@@ -1876,6 +1877,18 @@ describe('allTodos / openTodos', () => {
 
     expect(get(openTodos).map((t) => t.id)).toEqual(['open']);
   });
+
+  it('openTodos excludes calendar-archived todos', () => {
+    items.set({
+      open: makeTodo('open'),
+      moved: makeTodo('moved', {
+        archived: true,
+        archivedAt: '2026-01-02T00:00:00.000Z',
+      }),
+    });
+
+    expect(get(openTodos).map((t) => t.id)).toEqual(['open']);
+  });
 });
 
 describe('visibleTodos', () => {
@@ -1950,6 +1963,72 @@ describe('visibleTodos', () => {
     appConfig.set({ todosGlobalOrder: ['t2'] });
 
     expect(get(visibleTodos).map((t) => t.id)).toEqual(['t2', 't3', 't1']);
+  });
+
+  it('pins due todos above the manual order, earliest due first', () => {
+    const yesterday = new Date(Date.now() - 24 * 60 * 60_000).toISOString();
+    const earlierToday = new Date(Date.now() - 2 * 60 * 60_000).toISOString();
+    const nextWeek = new Date(Date.now() + 7 * 24 * 60 * 60_000).toISOString();
+    items.set({
+      plain: makeTodo('plain'),
+      dueOld: makeTodo('dueOld', {
+        startsAt: yesterday,
+        scheduleKind: 'task',
+      }),
+      dueToday: makeTodo('dueToday', {
+        startsAt: earlierToday,
+        scheduleKind: 'task',
+      }),
+      future: makeTodo('future', { startsAt: nextWeek, scheduleKind: 'task' }),
+    });
+    // Manual order puts the due items last — the band overrides it.
+    appConfig.set({
+      todosGlobalOrder: ['plain', 'future', 'dueToday', 'dueOld'],
+    });
+
+    expect(get(visibleTodos).map((t) => t.id)).toEqual([
+      'dueOld',
+      'dueToday',
+      'plain',
+      'future',
+    ]);
+  });
+
+  it('hides calendar-archived todos; visibleOnCalendarTodos lists them newest-move-first', () => {
+    items.set({
+      open: makeTodo('open'),
+      m1: makeTodo('m1', {
+        archived: true,
+        archivedAt: '2026-01-02T00:00:00.000Z',
+      }),
+      m2: makeTodo('m2', {
+        archived: true,
+        archivedAt: '2026-01-03T00:00:00.000Z',
+      }),
+    });
+
+    expect(get(visibleTodos).map((t) => t.id)).toEqual(['open']);
+    expect(get(visibleOnCalendarTodos).map((t) => t.id)).toEqual(['m2', 'm1']);
+  });
+
+  it('visibleOnCalendarTodos honours the group filter like visibleTodos', () => {
+    items.set({
+      filedMoved: makeTodo('filedMoved', {
+        collectionId: 'col-hidden',
+        archived: true,
+        archivedAt: '2026-01-02T00:00:00.000Z',
+      }),
+    });
+    collections.set({
+      'col-hidden': makeCollection('col-hidden', 'g-hidden'),
+    });
+    groups.set({
+      'g-active': makeGroup('g-active', []),
+      'g-hidden': makeGroup('g-hidden', ['col-hidden']),
+    });
+    appConfig.set({ activeGroupFilters: ['g-active'] });
+
+    expect(get(visibleOnCalendarTodos)).toEqual([]);
   });
 });
 

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -9,7 +9,9 @@ import { migrator, wrapCodeBlock } from '@inbox-rs/rs-module';
 import type { Readable, Writable } from 'svelte/store';
 import { derived, get, writable } from 'svelte/store';
 import { cleanForStorage } from './clean-for-storage';
+import { todayStart } from './now';
 import rs, { fetchFileBlobUrl } from './rs';
+import { compareByDueTime, isDueTodayOrOverdue } from './schedule';
 
 function getInbox() {
   return rs.inbox;
@@ -718,16 +720,22 @@ export const archivedItems = derived(items, ($items) => {
  * Named `todoItems` for backwards compatibility with callers
  * (CollectionItemPicker, test suite) that use this store for unfiled todos.
  */
-export const todoItems = derived([items, appConfig], ([$items, $config]) => {
+export const todoItems = derived(
+  [items, appConfig, todayStart],
+  ([$items, $config, $todayStart]) => {
   const all = Object.values($items).filter(
-    (i) => (i.isTodo || i.type === 'todo') && !i.collectionId,
+    (i) => (i.isTodo || i.type === 'todo') && !i.collectionId && !i.archived,
   );
   const completed = all.filter((i) => i.completed);
 
-  const open = sortWithConfiguredOrder(
-    all.filter((i) => !i.completed),
-    $config.todosGlobalOrder,
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  const open = pinDueTodos(
+    sortWithConfiguredOrder(
+      all.filter((i) => !i.completed),
+      $config.todosGlobalOrder,
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    ),
+    $todayStart,
   );
 
   // Completed sorted by completedAt desc
@@ -1731,10 +1739,30 @@ export const allTodos = derived(items, ($items) => {
   return Object.values($items).filter((i) => i.isTodo || i.type === 'todo');
 });
 
-/** Convenience: open todos across all collections, for badges/counts. */
+/** Convenience: open todos across all collections, for badges/counts.
+ *  Excludes todos moved to a calendar — the calendar owns those. */
 export const openTodos = derived(allTodos, ($allTodos) =>
-  $allTodos.filter((t) => !t.completed),
+  $allTodos.filter((t) => !t.completed && !t.archived),
 );
+
+/**
+ * The group-filter rule for the flat Todos page: unfiled todos are always
+ * visible; filed todos require their collection's group to be active and
+ * the collection not individually filtered out.
+ */
+function todoPassesGroupFilter(
+  todo: InboxItem,
+  $collections: Record<string, Collection>,
+  $activeGroupIds: Set<string>,
+  $inactiveCollectionIds: Set<string>,
+): boolean {
+  if (!todo.collectionId) return true;
+  const col = $collections[todo.collectionId];
+  if (!col) return true;
+  if (!col.groupId) return false;
+  if (!$activeGroupIds.has(col.groupId)) return false;
+  return !$inactiveCollectionIds.has(col.id);
+}
 
 /**
  * Todos visible on the flat Todos page. Unfiled todos are always visible;
@@ -1743,30 +1771,83 @@ export const openTodos = derived(allTodos, ($allTodos) =>
  * and open todos are mixed — the page splits them at render time.
  */
 export const visibleTodos = derived(
-  [allTodos, collections, activeGroupIds, inactiveCollectionIds, appConfig],
+  [
+    allTodos,
+    collections,
+    activeGroupIds,
+    inactiveCollectionIds,
+    appConfig,
+    todayStart,
+  ],
   ([
     $allTodos,
     $collections,
     $activeGroupIds,
     $inactiveCollectionIds,
     $config,
+    $todayStart,
   ]) => {
-    const filtered = $allTodos.filter((todo) => {
-      if (!todo.collectionId) return true;
-      const col = $collections[todo.collectionId];
-      if (!col) return true;
-      if (!col.groupId) return false;
-      if (!$activeGroupIds.has(col.groupId)) return false;
-      return !$inactiveCollectionIds.has(col.id);
-    });
+    const filtered = $allTodos.filter(
+      (todo) =>
+        !todo.archived &&
+        todoPassesGroupFilter(
+          todo,
+          $collections,
+          $activeGroupIds,
+          $inactiveCollectionIds,
+        ),
+    );
 
-    return sortWithConfiguredOrder(
+    const sorted = sortWithConfiguredOrder(
       filtered,
       $config.todosGlobalOrder,
       (a, b) =>
         new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
     );
+
+    return pinDueTodos(sorted, $todayStart);
   },
+);
+
+/**
+ * Due/overdue todos float in a band above the manual order, earliest due
+ * first; everything else keeps its configured position. Completed todos are
+ * never band members (isDueTodayOrOverdue excludes them), so the page's
+ * render-time open/completed split is unaffected.
+ */
+function pinDueTodos(sorted: InboxItem[], todayStartMs: number): InboxItem[] {
+  const due = sorted
+    .filter((t) => isDueTodayOrOverdue(t, todayStartMs))
+    .sort(compareByDueTime);
+  if (due.length === 0) return sorted;
+  const rest = sorted.filter((t) => !isDueTodayOrOverdue(t, todayStartMs));
+  return [...due, ...rest];
+}
+
+/**
+ * Todos moved to a calendar, for the Todos page's collapsed "on calendar"
+ * section. Honours the same group filter as `visibleTodos`; newest move
+ * first. Removing the calendar entry returns a todo to the open list.
+ */
+export const visibleOnCalendarTodos = derived(
+  [allTodos, collections, activeGroupIds, inactiveCollectionIds],
+  ([$allTodos, $collections, $activeGroupIds, $inactiveCollectionIds]) =>
+    $allTodos
+      .filter(
+        (todo) =>
+          !!todo.archived &&
+          todoPassesGroupFilter(
+            todo,
+            $collections,
+            $activeGroupIds,
+            $inactiveCollectionIds,
+          ),
+      )
+      .sort(
+        (a, b) =>
+          new Date(b.archivedAt ?? b.createdAt).getTime() -
+          new Date(a.archivedAt ?? a.createdAt).getTime(),
+      ),
 );
 
 /**


### PR DESCRIPTION
Implements two product decisions: **inbox-rs is not a calendar** (posting = moving), and **items that stay need their own alerting**.

> Stacked on #194 (targets `fix/calendar-ux`); retarget to `master` once that merges.

## Post to calendar = move

- `addItemToCalendar` archives on first post in **move** mode for every kind — todos and collection-filed cards included (previously only unfiled reference cards archived). Copy mode never archives; relocating between calendars never changes archive state.
- The Add-to-calendar sheet gains a **Move / Keep a copy** segmented control; the choice is remembered in synced `UserSettings.calendarPostMode` (default move). The archive note and success toast are surface-aware.
- Per-surface collapsed **"On calendar"** sections: Inbox keeps its archived section; the Todos page and collection views get their own (todos as rows, filed cards as grid cards).
- **Publishing is one-shot — inbox-rs never updates or deletes calendar entries, full stop.** Posting creates the entry; `eventUrl`/`eventEtag` are kept purely as a receipt (which calendar it went to, shown read-only on the sheet). Removed entirely: time-edit sync, `STATUS:COMPLETED` completion sync, calendar-to-calendar move, and every delete path — `updateEntry`/`deleteEntry` were deleted from the CalDAV client so the forbidden verbs don't exist in the codebase. Clearing a time or converting event↔task now detaches locally (receipt + archive state clear, the calendar keeps its entry) with a toast saying the calendar copy is untouched. Bringing a moved item back is **"Re-enable in Todos/Inbox/collection"**: local-only un-archive keeping the receipt.
- All live todo surfaces (`visibleTodos`, `openTodos` badge, `todoItems`, collection filters) now exclude archived todos so moved items can't leak into open lists.

## In-app due alerts

- New global scheduler (`lib/alerts.ts` over pure `lib/alerts-core.ts`) watches the **full** items store — alerts fire regardless of the active group/collection filter — on a shared 30s `now` heartbeat that also drives live overdue styling.
- Fires at `startsAt` for tasks **and** events; all-day items at 09:00 local. Always an in-app toast with a View action; plus an OS notification (SW-registration path, `tag`-deduped) when permission is granted. Permission is requested only from a dismissible Todos-page banner — never on load.
- **Moved** items never alert (the calendar owns them), but **copies do**: a copy with a date on it alerts like any other timed item — no assumptions about what the calendar does with its copy.
- "On calendar" todo rows are read-only receipts — a calendar marker replaces the completion checkbox (the todo is managed elsewhere now); opening the card and removing the calendar entry re-enables it in the app.
- Dedup: device-local fired-key set, re-armed when a time is edited, 30-minute catch-up grace on wake (older missed alerts mark silently), pruned after 7 days. Prune is deferred until items load — pruning against the empty startup store would wipe keys and re-fire (caught in runtime verification).

## Due band

- Overdue + due-today todos pin in a red **Due** band above the manual drag order, earliest due first; the rest stays draggable and manual. Band membership is date-based via a once-per-day `todayStart` store, so derived stores don't churn every 30s. Drag persistence writes `[...dueIds, ...draggedIds]` so items keep a sane slot when leaving the band.

## Verification

- 561 unit tests pass (15 new: alerts-core eligibility/grace/re-arm/prune matrix, due-band pinning, archive-rule matrix incl. copy mode, on-calendar filters); svelte-check 0 errors; production build clean.
- Playwright runtime: scheduled a todo 10 min in the past → "Due now" toast with View action + red Due band; reload does **not** re-fire; seeded a calendar account → sheet shows Move/Keep-a-copy defaulting to Move with the todo-specific note, copy mode clears it.

## Deferred (flagged in plan)

Lead-time offsets and snooze; notification-click deep links (needs injectManifest custom SW); VALARM on posted entries; BroadcastChannel tab election; collection-tile due sorting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added calendar posting modes: **Move** or **Keep a copy**, with persistent selection.
  * Calendar-posted items now appear as read-only receipts with calendar details and ICS download options.
  * Added due and overdue task prioritization, plus calendar-item sections in Todos and collections.
  * Added in-app and system alerts for scheduled items, including notification permission controls.
* **Bug Fixes**
  * Improved overdue status updates and calendar visibility.
  * Local changes no longer remove or modify existing calendar entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->