### PR TITLE
Flag important todos and references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9204,7 +9204,7 @@
     },
     "packages/extension": {
       "name": "@inbox-rs/extension",
-      "version": "2.3.5",
+      "version": "2.4.2",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "remotestoragejs": "^2.0.0-beta.9",
@@ -9261,7 +9261,7 @@
     },
     "packages/rs-module": {
       "name": "@inbox-rs/rs-module",
-      "version": "2.3.5",
+      "version": "2.4.4",
       "dependencies": {
         "remotestoragejs": "^2.0.0-beta.9",
         "rs-migrate": "^1.0.2"
@@ -9273,7 +9273,7 @@
     },
     "packages/thunderbird": {
       "name": "@inbox-rs/thunderbird",
-      "version": "2.3.5",
+      "version": "2.4.2",
       "dependencies": {
         "@inbox-rs/rs-module": "*"
       },
@@ -9327,7 +9327,7 @@
     },
     "packages/web": {
       "name": "@inbox-rs/web",
-      "version": "2.3.5",
+      "version": "2.4.4",
       "dependencies": {
         "@inbox-rs/rs-module": "*",
         "@tiptap/core": "^3.22.1",
@@ -9401,7 +9401,7 @@
     },
     "scripts": {
       "name": "@inbox-rs/scripts",
-      "version": "2.3.5",
+      "version": "2.4.4",
       "devDependencies": {
         "vitest": "^4.1.2"
       }

--- a/packages/rs-module/src/schemas.ts
+++ b/packages/rs-module/src/schemas.ts
@@ -5,6 +5,11 @@ const todoFields = {
   completedAt: { type: 'string' },
 };
 
+// Shared priority field — any active todo or reference can be pinned first.
+const priorityFields = {
+  pinned: { type: 'boolean' },
+};
+
 // Shared collection field — any item can belong to a collection.
 const collectionFields = {
   collectionId: { type: 'string' },
@@ -44,6 +49,7 @@ export const bookmarkSchema = {
     mimeType: { type: 'string' },
     createdAt: { type: 'string' },
     ...todoFields,
+    ...priorityFields,
     ...scheduleFields,
     ...collectionFields,
     ...migrateFields,
@@ -61,6 +67,7 @@ export const noteSchema = {
     body: { type: 'string' },
     createdAt: { type: 'string' },
     ...todoFields,
+    ...priorityFields,
     ...scheduleFields,
     ...collectionFields,
     ...migrateFields,
@@ -82,6 +89,7 @@ export const imageMetaSchema = {
     thumbMimeType: { type: 'string' },
     createdAt: { type: 'string' },
     ...todoFields,
+    ...priorityFields,
     ...scheduleFields,
     ...collectionFields,
     ...migrateFields,
@@ -103,6 +111,7 @@ export const audioMetaSchema = {
     transcribed: { type: 'boolean' },
     createdAt: { type: 'string' },
     ...todoFields,
+    ...priorityFields,
     ...scheduleFields,
     ...collectionFields,
     ...migrateFields,
@@ -123,6 +132,7 @@ export const videoMetaSchema = {
     body: { type: 'string' },
     createdAt: { type: 'string' },
     ...todoFields,
+    ...priorityFields,
     ...scheduleFields,
     ...collectionFields,
     ...migrateFields,
@@ -143,6 +153,7 @@ export const documentMetaSchema = {
     fileName: { type: 'string' },
     createdAt: { type: 'string' },
     ...todoFields,
+    ...priorityFields,
     ...scheduleFields,
     ...collectionFields,
     ...migrateFields,
@@ -163,6 +174,7 @@ export const emailSchema = {
     messageUrl: { type: 'string' },
     createdAt: { type: 'string' },
     ...todoFields,
+    ...priorityFields,
     ...scheduleFields,
     ...collectionFields,
     ...migrateFields,
@@ -205,6 +217,7 @@ export const todoSchema = {
     body: { type: 'string' },
     completed: { type: 'boolean' },
     completedAt: { type: 'string' },
+    ...priorityFields,
     createdAt: { type: 'string' },
     ...scheduleFields,
     ...collectionFields,

--- a/packages/rs-module/src/types.ts
+++ b/packages/rs-module/src/types.ts
@@ -18,6 +18,8 @@ export interface InboxItemBase {
   isTodo?: boolean;
   completed?: boolean;
   completedAt?: string;
+  /** Keeps an active todo or reference at the top of its list. */
+  pinned?: boolean;
   collectionId?: string; // undefined = Inbox for refs, unfiled for todos
   /**
    * Scheduling. The card is the editor — a calendar entry (once posted) is

--- a/packages/web/src/components/InboxCard.favicon.svelte.test.ts
+++ b/packages/web/src/components/InboxCard.favicon.svelte.test.ts
@@ -153,4 +153,24 @@ describe('InboxCard bookmark favicon decorator', () => {
     expect(img).not.toBeNull();
     expect(img?.src).toBe('https://example.com/favicon.ico');
   });
+
+  it('uses a native selection button without making the card interactive', () => {
+    const onselect = vi.fn();
+    const item = bookmark();
+    component = mount(InboxCard, {
+      target: host,
+      props: { item, onselect },
+    });
+    flushSync();
+
+    const card = host.querySelector('article.card');
+    const select = host.querySelector<HTMLButtonElement>('button.card-select');
+    expect(card?.hasAttribute('role')).toBe(false);
+    expect(card?.hasAttribute('tabindex')).toBe(false);
+    expect(select?.ariaLabel).toBe('Open Example');
+
+    select?.click();
+    expect(onselect).toHaveBeenCalledOnce();
+    expect(onselect).toHaveBeenCalledWith(item);
+  });
 });

--- a/packages/web/src/components/InboxCard.svelte
+++ b/packages/web/src/components/InboxCard.svelte
@@ -8,7 +8,9 @@
   import EmailCard from './EmailCard.svelte';
   import { draggingItemId, DRAG_MIME } from '../lib/drag';
   import { now } from '../lib/now';
+  import { animatePriorityChange } from '../lib/priority-motion';
   import { formatScheduled, isOverdue, isPast } from '../lib/schedule';
+  import { setItemPinned } from '../lib/stores';
 
   let { item, onselect }: { item: InboxItem; onselect: (item: InboxItem) => void } = $props();
 
@@ -124,9 +126,25 @@
   const scheduledLabel = $derived(item.startsAt ? formatScheduled(item) : '');
   const scheduleOverdue = $derived(isOverdue(item, $now));
   const schedulePast = $derived(isPast(item, $now));
+
+  async function togglePinned(e: MouseEvent) {
+    e.stopPropagation();
+    try {
+      const card = (e.currentTarget as HTMLElement).closest<HTMLElement>(
+        '[data-priority-item]',
+      );
+      await animatePriorityChange(card, () =>
+        setItemPinned(item, !item.pinned),
+      );
+    } catch (error) {
+      console.error('Failed to update reference priority:', error);
+    }
+  }
 </script>
 
 <article class="card" role="button" tabindex="0"
+  class:pinned={item.pinned}
+  data-priority-item
   draggable="true"
   ondragstart={onDragStart}
   ondragend={onDragEnd}
@@ -139,6 +157,20 @@
     if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onselect(item); }
   }}>
   <div class="card-body">
+    <button
+      type="button"
+      class="pin-button"
+      class:active={item.pinned}
+      aria-pressed={item.pinned === true}
+      aria-label={item.pinned ? `Remove important flag from ${item.title}` : `Flag ${item.title} as important`}
+      title={item.pinned ? 'Remove important flag' : 'Flag as important'}
+      onclick={togglePinned}
+    >
+      <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path fill={item.pinned ? 'currentColor' : 'none'} d="M5 4s1.5-1 4-1 4 2 7 2 4-1 4-1v10s-1 1-4 1-4-2-7-2-4 1-4 1z"></path>
+        <path d="M5 22V4"></path>
+      </svg>
+    </button>
     <div class="card-kind">
       <span class="kind-ic" style="--kc:{kind.color}" aria-hidden="true">
         {#if item.type === 'note'}
@@ -237,6 +269,58 @@
     box-shadow: 0 0 0 1px var(--accent), 0 4px 16px var(--shadow);
   }
 
+  .card.pinned {
+    border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  }
+
+  .pin-button {
+    position: absolute;
+    top: 0.65rem;
+    right: 0.65rem;
+    z-index: 2;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: 0;
+    border-radius: 999px;
+    color: var(--text-muted);
+    background: color-mix(in srgb, var(--surface) 90%, transparent);
+    cursor: pointer;
+    opacity: 0;
+    transition: color 150ms, background 150ms, opacity 150ms;
+  }
+
+  .card:hover .pin-button,
+  .card:focus-within .pin-button,
+  .pin-button.active {
+    opacity: 1;
+  }
+
+  .pin-button:hover,
+  .pin-button:focus-visible,
+  .pin-button.active {
+    color: var(--accent);
+    background: var(--accent-subtler);
+  }
+
+  .pin-button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+
+  @media (hover: none) {
+    .pin-button {
+      width: 44px;
+      height: 44px;
+      top: 0.35rem;
+      right: 0.35rem;
+      opacity: 0.65;
+    }
+  }
+
   .card-body {
     padding: 1rem 1.1rem 1.1rem;
   }
@@ -248,6 +332,7 @@
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 0.7rem;
+    padding-right: 2rem;
   }
 
   .kind-ic {

--- a/packages/web/src/components/InboxCard.svelte
+++ b/packages/web/src/components/InboxCard.svelte
@@ -142,20 +142,22 @@
   }
 </script>
 
-<article class="card" role="button" tabindex="0"
+<article class="card"
   class:pinned={item.pinned}
   data-priority-item
   draggable="true"
   ondragstart={onDragStart}
   ondragend={onDragEnd}
-  onclick={(e) => {
-    const target = e.target as HTMLElement;
-    if (target.closest('a, button, input, audio, video')) return;
-    onselect(item);
-  }}
-  onkeydown={(e) => {
-    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onselect(item); }
-  }}>
+>
+  <!-- A native button supplies whole-card mouse and keyboard selection without
+       making the article itself interactive. Real card controls sit above this
+       overlay, so the flag, links, and media remain independent siblings. -->
+  <button
+    type="button"
+    class="card-select"
+    aria-label="Open {item.title}"
+    onclick={() => onselect(item)}
+  ></button>
   <div class="card-body">
     <button
       type="button"
@@ -271,6 +273,34 @@
 
   .card.pinned {
     border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  }
+
+  .card-select {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border: 0;
+    border-radius: inherit;
+    background: transparent;
+    cursor: pointer;
+  }
+
+  .card-select:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -3px;
+  }
+
+  /* Keep genuine card controls above the full-card selection surface. */
+  .card :global(a),
+  .card :global(button:not(.card-select)),
+  .card :global(input),
+  .card :global(audio),
+  .card :global(video) {
+    position: relative;
+    z-index: 2;
   }
 
   .pin-button {

--- a/packages/web/src/components/TodoRow.svelte
+++ b/packages/web/src/components/TodoRow.svelte
@@ -4,7 +4,9 @@
   import { typeIconPath } from '../lib/item-utils';
   import { draggingItemId, DRAG_MIME } from '../lib/drag';
   import { now } from '../lib/now';
+  import { animatePriorityChange } from '../lib/priority-motion';
   import { formatScheduled, isOverdue } from '../lib/schedule';
+  import { setItemPinned } from '../lib/stores';
 
   let { todo, collection, group, onselect, onaddincollection, readonly = false }: {
     todo: InboxItem;
@@ -76,6 +78,20 @@
     }
   }
 
+  async function togglePinned(e: Event) {
+    e.stopPropagation();
+    try {
+      const row = (e.currentTarget as HTMLElement).closest<HTMLElement>(
+        '[data-priority-item]',
+      );
+      await animatePriorityChange(row, () =>
+        setItemPinned(todo, !todo.pinned),
+      );
+    } catch (err) {
+      console.error('Failed to update todo priority:', err);
+    }
+  }
+
   function handleClick(e: MouseEvent) {
     // Don't open the view modal when clicking the checkbox or its label.
     const target = e.target as HTMLElement;
@@ -138,6 +154,7 @@
   class="todo-row"
   class:completed={todo.completed}
   class:unfiled={isUnfiled}
+  data-priority-item
   role="button"
   tabindex="0"
   onclick={handleClick}
@@ -165,6 +182,23 @@
   {/if}
 
   <span class="title">{todo.title}</span>
+
+  {#if !readonly && !todo.completed}
+    <button
+      type="button"
+      class="pin-button"
+      class:active={todo.pinned}
+      aria-pressed={todo.pinned === true}
+      aria-label={todo.pinned ? `Remove important flag from ${todo.title}` : `Flag ${todo.title} as important`}
+      title={todo.pinned ? 'Remove important flag' : 'Flag as important'}
+      onclick={togglePinned}
+    >
+      <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path fill={todo.pinned ? 'currentColor' : 'none'} d="M5 4s1.5-1 4-1 4 2 7 2 4-1 4-1v10s-1 1-4 1-4-2-7-2-4 1-4 1z"></path>
+        <path d="M5 22V4"></path>
+      </svg>
+    </button>
+  {/if}
 
   <!-- The meta block collapses to line 2 on narrow screens via CSS;
        on desktop it sits inline on the right side of the row. -->
@@ -282,6 +316,44 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .pin-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+    padding: 0;
+    border: 0;
+    border-radius: 999px;
+    color: var(--text-muted);
+    background: transparent;
+    cursor: pointer;
+    opacity: 0.35;
+    transition: color 150ms, background 150ms, opacity 150ms, transform 150ms;
+  }
+
+  .todo-row:hover .pin-button,
+  .pin-button:focus-visible,
+  .pin-button.active {
+    opacity: 1;
+  }
+
+  .pin-button:hover,
+  .pin-button:focus-visible {
+    color: var(--accent);
+    background: var(--accent-subtler);
+  }
+
+  .pin-button.active {
+    color: var(--accent);
+  }
+
+  .pin-button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
   }
 
   .todo-row.completed .title {
@@ -441,6 +513,12 @@
      alternative — but touch users already have the page-level "Add todo"
      button, so hide instead of clutter every row. */
   @media (hover: none) {
+    .pin-button {
+      width: 44px;
+      height: 44px;
+      opacity: 0.65;
+    }
+
     .btn-quick-add {
       display: none;
     }
@@ -452,7 +530,7 @@
   @media (max-width: 600px) {
     .todo-row {
       display: grid;
-      grid-template-columns: auto 1fr;
+      grid-template-columns: auto 1fr auto;
       grid-template-rows: auto auto;
       column-gap: 0.6rem;
       row-gap: 0.25rem;
@@ -470,6 +548,12 @@
       grid-column: 2;
       grid-row: 1;
       font-size: 0.9rem;
+    }
+
+    .pin-button {
+      grid-column: 3;
+      grid-row: 1 / span 2;
+      align-self: center;
     }
 
     .meta {

--- a/packages/web/src/lib/alerts-core.test.ts
+++ b/packages/web/src/lib/alerts-core.test.ts
@@ -27,7 +27,9 @@ const NOW = new Date('2026-08-04T12:00:00').getTime();
 describe('alertTimeFor', () => {
   it('uses the exact startsAt moment for timed items', () => {
     const t = todo('a', { startsAt: '2026-08-04T13:30:00.000Z' });
-    expect(alertTimeFor(t)).toBe(new Date('2026-08-04T13:30:00.000Z').getTime());
+    expect(alertTimeFor(t)).toBe(
+      new Date('2026-08-04T13:30:00.000Z').getTime(),
+    );
   });
 
   it(`resolves all-day items to ${ALL_DAY_ALERT_HOUR}:00 local on their day`, () => {
@@ -51,8 +53,12 @@ describe('eligibleForAlert', () => {
   });
 
   it('rejects completed, archived (moved), and unscheduled items', () => {
-    expect(eligibleForAlert(todo('a', { ...base, completed: true }))).toBe(false);
-    expect(eligibleForAlert(todo('a', { ...base, archived: true }))).toBe(false);
+    expect(eligibleForAlert(todo('a', { ...base, completed: true }))).toBe(
+      false,
+    );
+    expect(eligibleForAlert(todo('a', { ...base, archived: true }))).toBe(
+      false,
+    );
     expect(eligibleForAlert(todo('a'))).toBe(false);
   });
 
@@ -90,9 +96,9 @@ describe('collectDueAlerts', () => {
     expect(collectDueAlerts([t], fired, NOW).fire).toEqual([]);
 
     const moved = { ...t, startsAt: new Date(NOW - 1_000).toISOString() };
-    expect(collectDueAlerts([moved], fired, NOW).fire.map((i) => i.id)).toEqual([
-      'a',
-    ]);
+    expect(collectDueAlerts([moved], fired, NOW).fire.map((i) => i.id)).toEqual(
+      ['a'],
+    );
   });
 
   it('re-arms when allDay flips with an unchanged startsAt — the effective time moved', () => {

--- a/packages/web/src/lib/alerts.ts
+++ b/packages/web/src/lib/alerts.ts
@@ -57,7 +57,9 @@ function loadFired(): Set<string> {
     const raw = localStorage.getItem(FIRED_KEY);
     if (!raw) return new Set();
     const parsed: unknown = JSON.parse(raw);
-    return new Set(Array.isArray(parsed) ? parsed.filter((k) => typeof k === 'string') : []);
+    return new Set(
+      Array.isArray(parsed) ? parsed.filter((k) => typeof k === 'string') : [],
+    );
   } catch {
     return new Set();
   }

--- a/packages/web/src/lib/collection-todos.test.ts
+++ b/packages/web/src/lib/collection-todos.test.ts
@@ -6,6 +6,7 @@ import {
   filterOpenTodos,
   filterReferenceItems,
   filterTodos,
+  pinItemsFirst,
   sortCompletedTodosByCompletedAt,
   spliceOpenTodoOrder,
 } from './collection-todos';
@@ -94,6 +95,24 @@ describe('filterReferenceItems', () => {
   it('excludes calendar-archived reference items', () => {
     const items: InboxItem[] = [ref('r1'), { ...ref('r2'), archived: true }];
     expect(filterReferenceItems(items).map((i) => i.id)).toEqual(['r1']);
+  });
+});
+
+describe('pinItemsFirst', () => {
+  it('moves pinned items first without disturbing either manual-order band', () => {
+    const items = [
+      ref('a'),
+      { ...ref('b'), pinned: true },
+      ref('c'),
+      { ...ref('d'), pinned: true },
+    ];
+
+    expect(pinItemsFirst(items).map((entry) => entry.id)).toEqual([
+      'b',
+      'd',
+      'a',
+      'c',
+    ]);
   });
 });
 

--- a/packages/web/src/lib/collection-todos.ts
+++ b/packages/web/src/lib/collection-todos.ts
@@ -5,7 +5,7 @@ export function filterTodos(items: InboxItem[]): InboxItem[] {
 }
 
 export function filterOpenTodos(todos: InboxItem[]): InboxItem[] {
-  return todos.filter((t) => !t.completed && !t.archived);
+  return pinItemsFirst(todos.filter((t) => !t.completed && !t.archived));
 }
 
 export function filterCompletedTodos(todos: InboxItem[]): InboxItem[] {
@@ -13,7 +13,16 @@ export function filterCompletedTodos(todos: InboxItem[]): InboxItem[] {
 }
 
 export function filterReferenceItems(items: InboxItem[]): InboxItem[] {
-  return items.filter((i) => !i.isTodo && i.type !== 'todo' && !i.archived);
+  return pinItemsFirst(
+    items.filter((i) => !i.isTodo && i.type !== 'todo' && !i.archived),
+  );
+}
+
+/** Stable priority partition: preserve manual/natural order within each band. */
+export function pinItemsFirst(items: InboxItem[]): InboxItem[] {
+  const pinned = items.filter((item) => item.pinned);
+  if (pinned.length === 0) return items;
+  return [...pinned, ...items.filter((item) => !item.pinned)];
 }
 
 /**

--- a/packages/web/src/lib/priority-motion.ts
+++ b/packages/web/src/lib/priority-motion.ts
@@ -1,0 +1,38 @@
+import { tick } from 'svelte';
+
+/**
+ * Animate an item from its old list position to the position produced by an
+ * update. This is a small FLIP transition that also works in masonry grids.
+ */
+export async function animatePriorityChange(
+  element: HTMLElement | null,
+  update: () => Promise<void>,
+): Promise<void> {
+  const reduceMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)',
+  ).matches;
+  const before =
+    !reduceMotion && element?.isConnected
+      ? element.getBoundingClientRect()
+      : null;
+
+  await update();
+  if (!before || !element?.isConnected) return;
+
+  await tick();
+  const after = element.getBoundingClientRect();
+  const deltaX = before.left - after.left;
+  const deltaY = before.top - after.top;
+  if (Math.abs(deltaX) < 1 && Math.abs(deltaY) < 1) return;
+
+  element.animate(
+    [
+      { transform: `translate(${deltaX}px, ${deltaY}px)`, opacity: 0.88 },
+      { transform: 'translate(0, 0)', opacity: 1 },
+    ],
+    {
+      duration: 190,
+      easing: 'cubic-bezier(0.2, 0.8, 0.2, 1)',
+    },
+  );
+}

--- a/packages/web/src/lib/schedule-sync.test.ts
+++ b/packages/web/src/lib/schedule-sync.test.ts
@@ -14,8 +14,8 @@ vi.mock('./caldav', async (importOriginal) => {
   };
 });
 
-import { calendarAccounts } from './calendar-accounts';
 import { createEntry } from './caldav';
+import { calendarAccounts } from './calendar-accounts';
 import {
   addItemToCalendar,
   detachFromCalendar,
@@ -104,9 +104,7 @@ describe('addItemToCalendar — the archive ownership rule', () => {
       eventUrl: `${CAL.id}x.ics`,
       eventEtag: '"e1"',
     });
-    await expect(addItemToCalendar(posted, CAL.id)).rejects.toThrow(
-      /one-shot/,
-    );
+    await expect(addItemToCalendar(posted, CAL.id)).rejects.toThrow(/one-shot/);
     expect(vi.mocked(createEntry)).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/lib/schedule-sync.ts
+++ b/packages/web/src/lib/schedule-sync.ts
@@ -132,9 +132,7 @@ export async function reEnableFromCalendar(
  * from what was posted beyond what a receipt should claim (e.g. its time
  * was cleared, or it changed kind).
  */
-export async function detachFromCalendar(
-  item: InboxItem,
-): Promise<InboxItem> {
+export async function detachFromCalendar(item: InboxItem): Promise<InboxItem> {
   const updated = clearPostedEntry(item);
   await storeItem(cleanForStorage(updated));
   return updated;

--- a/packages/web/src/lib/schedule.test.ts
+++ b/packages/web/src/lib/schedule.test.ts
@@ -145,9 +145,9 @@ describe('isDueTodayOrOverdue / compareByDueTime', () => {
     expect(
       isDueTodayOrOverdue(note({ startsAt: yesterday }), TODAY_START),
     ).toBe(true);
-    expect(
-      isDueTodayOrOverdue(note({ startsAt: tomorrow }), TODAY_START),
-    ).toBe(false);
+    expect(isDueTodayOrOverdue(note({ startsAt: tomorrow }), TODAY_START)).toBe(
+      false,
+    );
   });
 
   it('excludes completed, archived, and unscheduled items', () => {

--- a/packages/web/src/lib/stores.ts
+++ b/packages/web/src/lib/stores.ts
@@ -9,6 +9,7 @@ import { migrator, wrapCodeBlock } from '@inbox-rs/rs-module';
 import type { Readable, Writable } from 'svelte/store';
 import { derived, get, writable } from 'svelte/store';
 import { cleanForStorage } from './clean-for-storage';
+import { pinItemsFirst } from './collection-todos';
 import { todayStart } from './now';
 import rs, { fetchFileBlobUrl } from './rs';
 import { compareByDueTime, isDueTodayOrOverdue } from './schedule';
@@ -681,14 +682,16 @@ function sortWithConfiguredOrder<T extends { id: string }>(
 
 /** Inbox reference items: non-todos with no collectionId. */
 export const sortedItems = derived(items, ($items) => {
-  return Object.values($items)
-    .filter(
-      (i) => !i.isTodo && i.type !== 'todo' && !i.collectionId && !i.archived,
-    )
-    .sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    );
+  return pinItemsFirst(
+    Object.values($items)
+      .filter(
+        (i) => !i.isTodo && i.type !== 'todo' && !i.collectionId && !i.archived,
+      )
+      .sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      ),
+  );
 });
 
 /**
@@ -723,30 +726,33 @@ export const archivedItems = derived(items, ($items) => {
 export const todoItems = derived(
   [items, appConfig, todayStart],
   ([$items, $config, $todayStart]) => {
-  const all = Object.values($items).filter(
-    (i) => (i.isTodo || i.type === 'todo') && !i.collectionId && !i.archived,
-  );
-  const completed = all.filter((i) => i.completed);
+    const all = Object.values($items).filter(
+      (i) => (i.isTodo || i.type === 'todo') && !i.collectionId && !i.archived,
+    );
+    const completed = all.filter((i) => i.completed);
 
-  const open = pinDueTodos(
-    sortWithConfiguredOrder(
-      all.filter((i) => !i.completed),
-      $config.todosGlobalOrder,
+    const open = pinDueTodos(
+      pinItemsFirst(
+        sortWithConfiguredOrder(
+          all.filter((i) => !i.completed),
+          $config.todosGlobalOrder,
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        ),
+      ),
+      $todayStart,
+    );
+
+    // Completed sorted by completedAt desc
+    completed.sort(
       (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    ),
-    $todayStart,
-  );
+        new Date(b.completedAt ?? b.createdAt).getTime() -
+        new Date(a.completedAt ?? a.createdAt).getTime(),
+    );
 
-  // Completed sorted by completedAt desc
-  completed.sort(
-    (a, b) =>
-      new Date(b.completedAt ?? b.createdAt).getTime() -
-      new Date(a.completedAt ?? a.createdAt).getTime(),
-  );
-
-  return [...open, ...completed];
-});
+    return [...open, ...completed];
+  },
+);
 
 export const collectionItems = derived(
   [items, collections],
@@ -963,6 +969,11 @@ export async function storeItem(
     [cleanItem.id]: cleanItem as object,
   }));
   items.update((current) => ({ ...current, [cleanItem.id]: cleanItem }));
+}
+
+/** Toggle an item's top-of-list priority while preserving every other field. */
+export async function setItemPinned(item: InboxItem, pinned: boolean) {
+  await storeItem({ ...item, pinned });
 }
 
 /**
@@ -1805,7 +1816,9 @@ export const visibleTodos = derived(
         new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
     );
 
-    return pinDueTodos(sorted, $todayStart);
+    // Deadlines remain the strongest signal. Pinned items lead the manually
+    // ordered band immediately below them.
+    return pinDueTodos(pinItemsFirst(sorted), $todayStart);
   },
 );
 


### PR DESCRIPTION
## What changed

- add a persisted `pinned` flag for todos and reference items
- add a clear flag control to todo rows and reference cards
- keep flagged items at the top while preserving order within flagged and unflagged groups
- keep due and overdue todos ahead of manually flagged todos
- animate items briefly into their new position, with reduced-motion support
- synchronize workspace versions in `package-lock.json`
- apply required Biome formatting and import-order fixes

## Why

Important references and next-up todos previously had no lightweight way to remain visible. Flagging provides a fast, reversible priority signal without introducing another filter mode or disrupting existing manual ordering.

## User impact

Users can flag or unflag any active todo or reference directly from its row/card. Flagged items move to the top with a short visual transition, and the control remains keyboard, screen-reader, and touch accessible.

## Validation

- `npm run check` (passes with two existing non-blocking warnings)
- `npm run test` (789 tests pass)
- Svelte autofixer on the changed components (only pre-existing component warnings reported)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to pin bookmarks, notes, media, documents, emails, and todos.
  * Pinned items now appear at the top of relevant lists while preserving existing ordering.
  * Added accessible pin controls with responsive support for desktop and touch devices.
  * Added smooth visual transitions when item priority changes.

* **Bug Fixes**
  * Pinned states are now saved and retained across views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->