### PR TITLE
Unify full-featured content editing

### DIFF
--- a/packages/web/src/components/AddEntryModal.svelte
+++ b/packages/web/src/components/AddEntryModal.svelte
@@ -303,7 +303,7 @@
 <div class="overlay" onclick={onclose}>
   <div
     class="modal"
-    class:modal-note={type === 'note'}
+    class:modal-note={type === 'note' || type === 'todo'}
     role="dialog"
     aria-modal="true"
     aria-labelledby="modal-title"

--- a/packages/web/src/components/add-entry/AudioForm.svelte
+++ b/packages/web/src/components/add-entry/AudioForm.svelte
@@ -9,6 +9,7 @@
   import { buildAudioItem } from '../../lib/build-item';
   import { transcribeAudio } from '../../lib/transcribe';
   import OfflineTranscriptionAssets from '../OfflineTranscriptionAssets.svelte';
+  import MarkdownContentField from './MarkdownContentField.svelte';
 
   let {
     editItem,
@@ -214,12 +215,8 @@
   <span>Title</span>
   <input use:autofocus type="text" bind:value={title} placeholder="Memo title" />
 </label>
-<label class="field">
-  <span>Body</span>
-  <textarea
-    class="auto-expand"
-    bind:value={body}
-    rows="3"
-    placeholder="Transcription or notes..."
-  ></textarea>
-</label>
+<MarkdownContentField
+  bind:value={body}
+  label="Body"
+  placeholder="Transcription or notes..."
+/>

--- a/packages/web/src/components/add-entry/EmailForm.svelte
+++ b/packages/web/src/components/add-entry/EmailForm.svelte
@@ -3,6 +3,7 @@
   import { autofocus } from '../../lib/actions';
   import type { BuildItemFn } from '../../lib/add-entry-modal';
   import { buildEmailItem } from '../../lib/build-item';
+  import MarkdownContentField from './MarkdownContentField.svelte';
 
   let {
     editItem,
@@ -51,10 +52,7 @@
   <span>From</span>
   <input type="text" bind:value={from} placeholder="Sender" />
 </label>
-<label class="field">
-  <span>Body *</span>
-  <textarea bind:value={body} rows="6" placeholder="Email body..."></textarea>
-</label>
+<MarkdownContentField bind:value={body} label="Body *" placeholder="Email body..." />
 <label class="field">
   <span>Notes</span>
   <textarea bind:value={notes} rows="2" placeholder="Optional notes..."

--- a/packages/web/src/components/add-entry/MarkdownContentField.svelte
+++ b/packages/web/src/components/add-entry/MarkdownContentField.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+  import type { Component } from 'svelte';
+  import { autofocus } from '../../lib/actions';
+  import {
+    loadMarkdownEditorComponent,
+    type MarkdownEditorProps,
+  } from '../../lib/add-entry-modal';
+  import { createCodeKeydownHandler } from '../../lib/code-indent';
+  import { renderMarkdown } from '../../lib/markdown';
+
+  let {
+    value = $bindable(''),
+    label = 'Content',
+    placeholder = 'Write your note...',
+    focusOnMount = false,
+  }: {
+    value?: string;
+    label?: string;
+    placeholder?: string;
+    focusOnMount?: boolean;
+  } = $props();
+
+  let editorMode = $state<'visual' | 'write' | 'preview'>('visual');
+  let MarkdownEditorComponent = $state<Component<MarkdownEditorProps> | null>(
+    null,
+  );
+  let markdownEditorLoadError = $state('');
+  let previewHtml = $state('');
+
+  const handleCodeKeydown = createCodeKeydownHandler();
+
+  $effect(() => {
+    if (
+      editorMode !== 'visual' ||
+      MarkdownEditorComponent ||
+      markdownEditorLoadError
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    loadMarkdownEditorComponent()
+      .then((component) => {
+        if (!cancelled) MarkdownEditorComponent = component;
+      })
+      .catch((loadError) => {
+        console.error('Failed to load markdown editor:', loadError);
+        if (!cancelled) {
+          markdownEditorLoadError =
+            'Visual editor unavailable. Markdown mode is still available.';
+          editorMode = 'write';
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  $effect(() => {
+    if (editorMode !== 'preview') {
+      previewHtml = '';
+      return;
+    }
+
+    const currentValue = value;
+    let cancelled = false;
+    renderMarkdown(currentValue)
+      .then((html) => {
+        if (!cancelled && value === currentValue && editorMode === 'preview') {
+          previewHtml = html;
+        }
+      })
+      .catch(() => {
+        if (!cancelled) previewHtml = '';
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  });
+</script>
+
+<div class="field note-editor-field">
+  <div class="field-header">
+    <span>{label}</span>
+    <div class="editor-tabs">
+      <button type="button" class="tab" class:active={editorMode === 'visual'} onclick={() => (editorMode = 'visual')} disabled={!!markdownEditorLoadError}>Visual</button>
+      <button type="button" class="tab" class:active={editorMode === 'write'} onclick={() => (editorMode = 'write')}>Markdown</button>
+      <button type="button" class="tab" class:active={editorMode === 'preview'} onclick={() => (editorMode = 'preview')}>Preview</button>
+    </div>
+  </div>
+  {#if editorMode === 'visual'}
+    {#if MarkdownEditorComponent}
+      <MarkdownEditorComponent bind:value {placeholder} {focusOnMount} />
+    {:else if markdownEditorLoadError}
+      <textarea use:autofocus class="code-input" bind:value rows="10" placeholder="Write in Markdown..." onkeydown={handleCodeKeydown}></textarea>
+    {:else}
+      <div class="editor-loading" aria-live="polite">Loading visual editor…</div>
+    {/if}
+  {:else if editorMode === 'write'}
+    <textarea use:autofocus class="code-input" bind:value rows="10" placeholder="Write in Markdown..." onkeydown={handleCodeKeydown}></textarea>
+  {:else}
+    <div class="preview-wrap markdown-body">
+      {#if previewHtml}
+        {@html previewHtml}
+      {:else if value.trim()}
+        <span class="preview-empty">Preview unavailable</span>
+      {:else}
+        <span class="preview-empty">Nothing to preview</span>
+      {/if}
+    </div>
+  {/if}
+</div>
+{#if markdownEditorLoadError}
+  <p class="info-note">{markdownEditorLoadError}</p>
+{/if}

--- a/packages/web/src/components/add-entry/MarkdownContentField.svelte
+++ b/packages/web/src/components/add-entry/MarkdownContentField.svelte
@@ -94,12 +94,12 @@
     {#if MarkdownEditorComponent}
       <MarkdownEditorComponent bind:value {placeholder} {focusOnMount} />
     {:else if markdownEditorLoadError}
-      <textarea use:autofocus class="code-input" bind:value rows="10" placeholder="Write in Markdown..." onkeydown={handleCodeKeydown}></textarea>
+      <textarea use:autofocus class="code-input" bind:value rows="10" {placeholder} onkeydown={handleCodeKeydown}></textarea>
     {:else}
       <div class="editor-loading" aria-live="polite">Loading visual editor…</div>
     {/if}
   {:else if editorMode === 'write'}
-    <textarea use:autofocus class="code-input" bind:value rows="10" placeholder="Write in Markdown..." onkeydown={handleCodeKeydown}></textarea>
+    <textarea use:autofocus class="code-input" bind:value rows="10" {placeholder} onkeydown={handleCodeKeydown}></textarea>
   {:else}
     <div class="preview-wrap markdown-body">
       {#if previewHtml}

--- a/packages/web/src/components/add-entry/NoteForm.svelte
+++ b/packages/web/src/components/add-entry/NoteForm.svelte
@@ -1,16 +1,9 @@
 <script lang="ts">
-  import type { Component } from 'svelte';
   import type { InboxItem } from '@inbox-rs/rs-module';
-  import { autofocus, autofocusIf } from '../../lib/actions';
-  import {
-    type BuildItemFn,
-    loadMarkdownEditorComponent,
-    type MarkdownEditorProps,
-    shouldLoadMarkdownEditor,
-  } from '../../lib/add-entry-modal';
+  import { autofocusIf } from '../../lib/actions';
+  import type { BuildItemFn } from '../../lib/add-entry-modal';
   import { buildNoteItem } from '../../lib/build-item';
-  import { createCodeKeydownHandler } from '../../lib/code-indent';
-  import { renderMarkdown } from '../../lib/markdown';
+  import MarkdownContentField from './MarkdownContentField.svelte';
 
   let {
     editItem,
@@ -40,15 +33,6 @@
   );
   let description = $state(editItem?.description ?? '');
 
-  let editorMode = $state<'visual' | 'write' | 'preview'>('visual');
-  let MarkdownEditorComponent = $state<Component<MarkdownEditorProps> | null>(
-    null,
-  );
-  let markdownEditorLoadError = $state('');
-  let previewHtml = $state('');
-
-  const handleCodeKeydown = createCodeKeydownHandler();
-
   // A note is captureable as soon as the user has typed a title or any body.
   $effect(() => {
     canSubmit = !!(title || body);
@@ -60,72 +44,6 @@
       { title, body, description },
     );
 
-  // Lazy-load the visual editor on demand: it pulls in TipTap and friends
-  // (~hundreds of KB) and only ~60% of users open the note modal in any
-  // given session. Falls back to the markdown textarea if loading fails so
-  // the user can still capture content.
-  $effect(() => {
-    if (
-      !shouldLoadMarkdownEditor(
-        'note',
-        editorMode,
-        !!MarkdownEditorComponent,
-        !!markdownEditorLoadError,
-      )
-    ) {
-      return;
-    }
-
-    let cancelled = false;
-
-    loadMarkdownEditorComponent()
-      .then((component) => {
-        if (!cancelled) {
-          MarkdownEditorComponent = component;
-        }
-      })
-      .catch((loadError) => {
-        console.error('Failed to load markdown editor:', loadError);
-        if (!cancelled) {
-          markdownEditorLoadError =
-            'Visual editor unavailable. Markdown mode is still available.';
-          editorMode = 'write';
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  });
-
-  // Render markdown preview asynchronously. Re-checks `body === currentBody`
-  // before applying the rendered HTML so a stale render from a previous body
-  // value doesn't overwrite a fresher one.
-  $effect(() => {
-    if (editorMode !== 'preview') {
-      previewHtml = '';
-      return;
-    }
-
-    const currentBody = body;
-    let cancelled = false;
-
-    renderMarkdown(currentBody)
-      .then((html) => {
-        if (!cancelled && body === currentBody && editorMode === 'preview') {
-          previewHtml = html;
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          previewHtml = '';
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  });
 </script>
 
 <label class="field">
@@ -138,68 +56,4 @@
   -->
   <input use:autofocusIf={!prefillTitle} type="text" bind:value={title} placeholder="Note title" />
 </label>
-<div class="field note-editor-field">
-  <div class="field-header">
-    <span>Content</span>
-    <div class="editor-tabs">
-      <button
-        type="button"
-        class="tab"
-        class:active={editorMode === 'visual'}
-        onclick={() => (editorMode = 'visual')}
-        disabled={!!markdownEditorLoadError}>Visual</button
-      >
-      <button
-        type="button"
-        class="tab"
-        class:active={editorMode === 'write'}
-        onclick={() => (editorMode = 'write')}>Markdown</button
-      >
-      <button
-        type="button"
-        class="tab"
-        class:active={editorMode === 'preview'}
-        onclick={() => (editorMode = 'preview')}>Preview</button
-      >
-    </div>
-  </div>
-  {#if editorMode === 'visual'}
-    {#if MarkdownEditorComponent}
-      <MarkdownEditorComponent bind:value={body} placeholder="Write your note..." focusOnMount={!!prefillTitle} />
-    {:else if markdownEditorLoadError}
-      <textarea
-        use:autofocus
-        class="code-input"
-        bind:value={body}
-        rows="10"
-        placeholder="Write your note in Markdown..."
-        onkeydown={handleCodeKeydown}
-      ></textarea>
-    {:else}
-      <div class="editor-loading" aria-live="polite">Loading visual editor…</div>
-    {/if}
-  {:else if editorMode === 'write'}
-    <textarea
-      use:autofocus
-      class="code-input"
-      bind:value={body}
-      rows="10"
-      placeholder="Write your note in Markdown..."
-      onkeydown={handleCodeKeydown}
-    ></textarea>
-  {:else}
-    <div class="preview-wrap markdown-body">
-      {#if previewHtml}
-        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-        {@html previewHtml}
-      {:else if body.trim()}
-        <span class="preview-empty">Preview unavailable</span>
-      {:else}
-        <span class="preview-empty">Nothing to preview</span>
-      {/if}
-    </div>
-  {/if}
-</div>
-{#if markdownEditorLoadError}
-  <p class="info-note">{markdownEditorLoadError}</p>
-{/if}
+<MarkdownContentField bind:value={body} focusOnMount={!!prefillTitle} />

--- a/packages/web/src/components/add-entry/TodoForm.svelte
+++ b/packages/web/src/components/add-entry/TodoForm.svelte
@@ -6,7 +6,7 @@
     canCaptureTodo,
   } from '../../lib/add-entry-modal';
   import { buildTodoItem } from '../../lib/build-item';
-  import { createCodeKeydownHandler } from '../../lib/code-indent';
+  import MarkdownContentField from './MarkdownContentField.svelte';
 
   let {
     editItem,
@@ -38,8 +38,6 @@
     editItem && 'completed' in editItem ? !!editItem.completed : false,
   );
 
-  const handleCodeKeydown = createCodeKeydownHandler();
-
   $effect(() => {
     canSubmit = canCaptureTodo(title);
   });
@@ -60,15 +58,7 @@
     placeholder="What needs to be done?"
   />
 </label>
-<label class="field">
-  <span>Details</span>
-  <textarea
-    bind:value={body}
-    rows="3"
-    placeholder="Optional details..."
-    onkeydown={handleCodeKeydown}
-  ></textarea>
-</label>
+<MarkdownContentField bind:value={body} label="Details" placeholder="Add details..." />
 {#if isEdit}
   <label class="field checkbox-field">
     <input type="checkbox" bind:checked={completed} />

--- a/packages/web/src/components/view-card/AudioView.svelte
+++ b/packages/web/src/components/view-card/AudioView.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import type { AudioItem } from '@inbox-rs/rs-module';
+  import 'highlight.js/styles/github-dark.min.css';
+  import { renderMarkdown } from '../../lib/markdown';
   import { blobUrls, connected, loadFileBlobUrl, storeItem } from '../../lib/stores';
   import rs from '../../lib/rs';
   import { transcribeAudio } from '../../lib/transcribe';
@@ -10,6 +12,7 @@
   let audioError = $state(false);
   let transcribing = $state(false);
   let transcriptionError = $state(false);
+  let renderedBody = $state('');
 
   const audioSrc = $derived($blobUrls[item.filePath] || null);
 
@@ -24,6 +27,15 @@
     // offline-captured files still render; retries on reconnect.
     void $connected;
     if (item.filePath) loadFileBlobUrl(item.filePath, item.mimeType);
+  });
+
+  $effect(() => {
+    const currentItem = item;
+    renderedBody = '';
+    if (!currentItem.body) return;
+    renderMarkdown(currentItem.body).then((html) => {
+      if (item.id === currentItem.id) renderedBody = html;
+    });
   });
 
   function formatDuration(seconds?: number): string {
@@ -101,6 +113,10 @@
 {#if item.body}
   <div class="content-block">
     <span class="content-label">Transcription</span>
-    <p class="content-text">{item.body}</p>
+    {#if renderedBody}
+      <div class="markdown-body">{@html renderedBody}</div>
+    {:else}
+      <p class="content-text">{item.body}</p>
+    {/if}
   </div>
 {/if}

--- a/packages/web/src/components/view-card/AudioView.svelte
+++ b/packages/web/src/components/view-card/AudioView.svelte
@@ -33,8 +33,11 @@
     const currentItem = item;
     renderedBody = '';
     if (!currentItem.body) return;
-    renderMarkdown(currentItem.body).then((html) => {
-      if (item.id === currentItem.id) renderedBody = html;
+    const currentBody = currentItem.body;
+    renderMarkdown(currentBody).then((html) => {
+      if (item.id === currentItem.id && item.body === currentBody) {
+        renderedBody = html;
+      }
     });
   });
 

--- a/packages/web/src/components/view-card/EmailView.svelte
+++ b/packages/web/src/components/view-card/EmailView.svelte
@@ -1,7 +1,20 @@
 <script lang="ts">
   import type { EmailItem } from '@inbox-rs/rs-module';
+  import 'highlight.js/styles/github-dark.min.css';
+  import { renderMarkdown } from '../../lib/markdown';
 
   let { item, titleId }: { item: EmailItem; titleId: string } = $props();
+
+  let renderedBody = $state('');
+
+  $effect(() => {
+    const currentItem = item;
+    renderedBody = '';
+    if (!currentItem.body) return;
+    renderMarkdown(currentItem.body).then((html) => {
+      if (item.id === currentItem.id) renderedBody = html;
+    });
+  });
 </script>
 
 <h2 class="title" id={titleId}>
@@ -48,6 +61,10 @@
 {#if item.body}
   <div class="content-block">
     <span class="content-label">Body</span>
-    <p class="content-text">{item.body}</p>
+    {#if renderedBody}
+      <div class="markdown-body">{@html renderedBody}</div>
+    {:else}
+      <p class="content-text">{item.body}</p>
+    {/if}
   </div>
 {/if}

--- a/packages/web/src/components/view-card/EmailView.svelte
+++ b/packages/web/src/components/view-card/EmailView.svelte
@@ -11,8 +11,11 @@
     const currentItem = item;
     renderedBody = '';
     if (!currentItem.body) return;
-    renderMarkdown(currentItem.body).then((html) => {
-      if (item.id === currentItem.id) renderedBody = html;
+    const currentBody = currentItem.body;
+    renderMarkdown(currentBody).then((html) => {
+      if (item.id === currentItem.id && item.body === currentBody) {
+        renderedBody = html;
+      }
     });
   });
 </script>

--- a/packages/web/src/components/view-card/TodoView.svelte
+++ b/packages/web/src/components/view-card/TodoView.svelte
@@ -1,7 +1,20 @@
 <script lang="ts">
   import type { TodoItem } from '@inbox-rs/rs-module';
+  import 'highlight.js/styles/github-dark.min.css';
+  import { renderMarkdown } from '../../lib/markdown';
 
   let { item, titleId }: { item: TodoItem; titleId: string } = $props();
+
+  let renderedBody = $state('');
+
+  $effect(() => {
+    const currentItem = item;
+    renderedBody = '';
+    if (!currentItem.body) return;
+    renderMarkdown(currentItem.body).then((html) => {
+      if (item.id === currentItem.id) renderedBody = html;
+    });
+  });
 </script>
 
 <h2 class="title" id={titleId}>{item.title}</h2>
@@ -9,6 +22,10 @@
 {#if item.body}
   <div class="content-block">
     <span class="content-label">Body</span>
-    <p class="content-text">{item.body}</p>
+    {#if renderedBody}
+      <div class="markdown-body">{@html renderedBody}</div>
+    {:else}
+      <p class="content-text">{item.body}</p>
+    {/if}
   </div>
 {/if}

--- a/packages/web/src/components/view-card/TodoView.svelte
+++ b/packages/web/src/components/view-card/TodoView.svelte
@@ -11,8 +11,11 @@
     const currentItem = item;
     renderedBody = '';
     if (!currentItem.body) return;
-    renderMarkdown(currentItem.body).then((html) => {
-      if (item.id === currentItem.id) renderedBody = html;
+    const currentBody = currentItem.body;
+    renderMarkdown(currentBody).then((html) => {
+      if (item.id === currentItem.id && item.body === currentBody) {
+        renderedBody = html;
+      }
     });
   });
 </script>


### PR DESCRIPTION
## What changed

- Extract the note content UI into one shared full-featured editor.
- Use the shared Visual, Markdown, and Preview editor for note, todo, audio, and email bodies.
- Render Markdown consistently when viewing todo, audio, and email cards.
- Give todo editing the same expanded modal layout as note editing.

## Why

Todo, audio, and email bodies previously used basic textareas while normal note references had the richer editor. Sharing one component keeps the editing experience and fallback behavior consistent and prevents the implementations from drifting.

## User impact

Users can edit all long-form card bodies with the same visual and Markdown tools, preview formatting before saving, and see that formatting rendered in card views.

## Validation

- `npm run check` (passes with two pre-existing non-null-assertion warnings in `tests/e2e/desktop/navigation.spec.ts`)
- `npm run test` (795 tests passed)
- Svelte autofixer on every changed Svelte component


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared Markdown editor with visual editing, Markdown mode, preview, configurable labels, placeholders, and autofocus.
  * Notes, todos, audio entries, and emails now support Markdown-aware content editing.
  * Audio transcriptions, email bodies, and todo details display formatted Markdown with syntax highlighting and safe plain-text fallbacks.
* **Style**
  * Todo entry modals now use the same note-style layout as notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->