### PR TITLE
Make card editing inline and resilient

### DIFF
--- a/packages/web/src/App.svelte
+++ b/packages/web/src/App.svelte
@@ -357,12 +357,6 @@
     void loadViewCardModal();
   }
 
-  function openEditFromView(item: InboxItem) {
-    viewingItem = null;
-    editingItem = item;
-    activeModal = item.type;
-  }
-
   function closeViewModal() {
     viewingItem = null;
   }
@@ -501,7 +495,7 @@
       snapshot fallback covers the moment an item is deleted elsewhere
       while the modal is closing.
     -->
-    <ViewCardModalComponent item={$items[viewingItem.id] ?? viewingItem} onclose={closeViewModal} onedit={openEditFromView} />
+    <ViewCardModalComponent item={$items[viewingItem.id] ?? viewingItem} onclose={closeViewModal} />
   {/if}
 {/if}
 

--- a/packages/web/src/components/CardInlineEditor.harness.svelte
+++ b/packages/web/src/components/CardInlineEditor.harness.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { InboxItem } from '@inbox-rs/rs-module';
+  import { untrack } from 'svelte';
+  import CardInlineEditor from './CardInlineEditor.svelte';
+
+  let { initial }: { initial: InboxItem } = $props();
+  let item = $state(untrack(() => initial));
+  let flush = $state(async () => {});
+
+  export function updateItem(next: InboxItem) {
+    item = next;
+  }
+
+  export async function flushEdits() {
+    await flush();
+  }
+</script>
+
+<CardInlineEditor {item} bind:flush />

--- a/packages/web/src/components/CardInlineEditor.svelte
+++ b/packages/web/src/components/CardInlineEditor.svelte
@@ -5,8 +5,11 @@
     applyCardDraft,
     clearCardDraft,
     createCardDraft,
+    draftsEqual,
+    mergeExternalCardDraft,
     readCardDraft,
     writeCardDraft,
+    type CardDraft,
   } from '../lib/card-draft';
   import { storeItem } from '../lib/stores';
   import MarkdownContentField from './add-entry/MarkdownContentField.svelte';
@@ -28,6 +31,9 @@
   const initialItem = untrack(() => item);
   const recovered = readCardDraft(initialItem, localStorage);
   let draft = $state(recovered ?? createCardDraft(initialItem));
+  let syncedDraft = $state<CardDraft>(
+    untrack(() => structuredClone(createCardDraft(initialItem))),
+  );
   let revision = recovered ? 1 : 0;
   let persistedRevision = 0;
   let saveTimer: ReturnType<typeof setTimeout> | undefined;
@@ -62,6 +68,7 @@
     try {
       await savePromise;
       persistedRevision = savingRevision;
+      syncedDraft = structuredClone(snapshot);
       if (revision === savingRevision) {
         clearCardDraft(item.id, localStorage);
         status = 'saved';
@@ -87,6 +94,25 @@
 
   onDestroy(() => {
     if (saveTimer) clearTimeout(saveTimer);
+  });
+
+  // Background updates (bookmark enrichment, transcription, etc.) flow through
+  // the items store while the modal stays open. Merge them into the draft
+  // without clobbering fields the user has edited locally.
+  $effect(() => {
+    const external = item;
+    untrack(() => {
+      if (revision > persistedRevision) {
+        const merged = mergeExternalCardDraft(draft, syncedDraft, external);
+        if (merged) draft = merged;
+        return;
+      }
+      const next = createCardDraft(external);
+      if (!draftsEqual(draft, next)) {
+        draft = next;
+        syncedDraft = structuredClone(next);
+      }
+    });
   });
 
   const hasBody = $derived('body' in item && item.type !== 'bookmark');

--- a/packages/web/src/components/CardInlineEditor.svelte
+++ b/packages/web/src/components/CardInlineEditor.svelte
@@ -1,0 +1,340 @@
+<script lang="ts">
+  import type { InboxItem } from '@inbox-rs/rs-module';
+  import { onDestroy, untrack } from 'svelte';
+  import {
+    applyCardDraft,
+    clearCardDraft,
+    createCardDraft,
+    readCardDraft,
+    writeCardDraft,
+  } from '../lib/card-draft';
+  import { storeItem } from '../lib/stores';
+  import MarkdownContentField from './add-entry/MarkdownContentField.svelte';
+
+  export type SaveStatus = 'saved' | 'pending' | 'saving' | 'error' | 'restored';
+
+  let {
+    item,
+    status = $bindable<SaveStatus>('saved'),
+    flush = $bindable<() => Promise<void>>(async () => {}),
+    retry = $bindable<() => void>(() => {}),
+  }: {
+    item: InboxItem;
+    status?: SaveStatus;
+    flush?: () => Promise<void>;
+    retry?: () => void;
+  } = $props();
+
+  const initialItem = untrack(() => item);
+  const recovered = readCardDraft(initialItem, localStorage);
+  let draft = $state(recovered ?? createCardDraft(initialItem));
+  let revision = recovered ? 1 : 0;
+  let persistedRevision = 0;
+  let saveTimer: ReturnType<typeof setTimeout> | undefined;
+  let savePromise: Promise<void> | null = null;
+
+  status = recovered ? 'restored' : 'saved';
+
+  function scheduleSave() {
+    revision += 1;
+    status = 'pending';
+    writeCardDraft(draft, localStorage);
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => void persist().catch(() => {}), 700);
+  }
+
+  async function persist(): Promise<void> {
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = undefined;
+    }
+    if (revision <= persistedRevision) return;
+    if (savePromise) {
+      await savePromise;
+      if (revision > persistedRevision) await persist();
+      return;
+    }
+
+    const savingRevision = revision;
+    const snapshot = $state.snapshot(draft);
+    status = 'saving';
+    savePromise = storeItem(applyCardDraft(item, snapshot));
+    try {
+      await savePromise;
+      persistedRevision = savingRevision;
+      if (revision === savingRevision) {
+        clearCardDraft(item.id, localStorage);
+        status = 'saved';
+      } else {
+        status = 'pending';
+        saveTimer = setTimeout(() => void persist().catch(() => {}), 0);
+      }
+    } catch (error) {
+      console.error('Card autosave failed', error);
+      status = 'error';
+      throw error;
+    } finally {
+      savePromise = null;
+    }
+  }
+
+  flush = persist;
+  retry = () => void persist().catch(() => {});
+
+  if (recovered) {
+    saveTimer = setTimeout(() => void persist().catch(() => {}), 700);
+  }
+
+  onDestroy(() => {
+    if (saveTimer) clearTimeout(saveTimer);
+  });
+
+  const hasBody = $derived('body' in item && item.type !== 'bookmark');
+  const bodyLabel = $derived(
+    item.type === 'todo'
+      ? 'Details'
+      : item.type === 'audio' || item.type === 'video'
+        ? 'Transcription or notes'
+        : 'Content',
+  );
+  const bodyPlaceholder = $derived(
+    item.type === 'todo'
+      ? 'Add details…'
+      : item.type === 'email'
+        ? 'Email body…'
+        : item.type === 'audio' || item.type === 'video'
+          ? 'Add a transcription or notes…'
+          : 'Start writing…',
+  );
+  const descriptionIsPrimary = $derived(
+    item.type === 'image' || item.type === 'document',
+  );
+</script>
+
+<section class="editor" aria-label="Card content">
+  <div class="title-row">
+    {#if item.isTodo || item.type === 'todo'}
+      <label class="complete-toggle" title={draft.completed ? 'Mark open' : 'Mark complete'}>
+        <input type="checkbox" bind:checked={draft.completed} onchange={scheduleSave} />
+        <span aria-hidden="true"></span>
+        <span class="sr-only">Completed</span>
+      </label>
+    {/if}
+    <input
+      class="title-input"
+      bind:value={draft.title}
+      oninput={scheduleSave}
+      aria-label="Title"
+      placeholder="Untitled"
+    />
+    {#if item.type === 'bookmark' && draft.url}
+      <a class="source-link" href={draft.url} target="_blank" rel="noopener noreferrer">Open link ↗</a>
+    {:else if item.type === 'email' && item.messageUrl}
+      <a class="source-link" href={item.messageUrl}>Open email ↗</a>
+    {/if}
+  </div>
+
+  {#if item.type === 'bookmark'}
+    <label class="compact-field">
+      <span class="field-label">URL</span>
+      <input type="url" bind:value={draft.url} oninput={scheduleSave} placeholder="https://…" />
+    </label>
+  {:else if item.type === 'email'}
+    <label class="compact-field">
+      <span class="field-label">From</span>
+      <input bind:value={draft.from} oninput={scheduleSave} placeholder="Sender" />
+    </label>
+  {/if}
+
+  {#if hasBody}
+    <MarkdownContentField
+      bind:value={draft.body}
+      label={bodyLabel}
+      placeholder={bodyPlaceholder}
+      onchange={scheduleSave}
+    />
+  {/if}
+
+  {#if item.type === 'email'}
+    <label class="text-field">
+      <span class="field-label">Notes</span>
+      <textarea bind:value={draft.notes} oninput={scheduleSave} rows="3" placeholder="Your notes about this email…"></textarea>
+    </label>
+  {/if}
+
+  {#if descriptionIsPrimary}
+    <label class="text-field description-primary">
+      <span class="field-label">Description</span>
+      <textarea bind:value={draft.description} oninput={scheduleSave} rows="6" placeholder="Add a description…"></textarea>
+    </label>
+  {:else}
+    <details class="more-fields" open={!!draft.description}>
+      <summary>More details</summary>
+      <label class="text-field">
+        <span class="field-label">Description</span>
+        <textarea bind:value={draft.description} oninput={scheduleSave} rows="3" placeholder="Optional description…"></textarea>
+      </label>
+    </details>
+  {/if}
+</section>
+
+<style>
+  .editor {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 1rem;
+    min-height: 0;
+  }
+
+  .title-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .title-input {
+    min-width: 0;
+    flex: 1;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text);
+    font: inherit;
+    font-size: clamp(1.45rem, 3vw, 2.15rem);
+    font-weight: 650;
+    line-height: 1.2;
+    padding: 0.35rem 0.45rem;
+  }
+
+  .title-input:hover {
+    background: var(--surface-hover);
+  }
+
+  .title-input:focus {
+    border-color: var(--border);
+    background: var(--bg);
+    outline: none;
+  }
+
+  .source-link {
+    flex-shrink: 0;
+    color: var(--accent);
+    font-size: 0.8rem;
+  }
+
+  .complete-toggle {
+    position: relative;
+    display: grid;
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+    cursor: pointer;
+    place-items: center;
+  }
+
+  .complete-toggle input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+  }
+
+  .complete-toggle > span:not(.sr-only) {
+    width: 22px;
+    height: 22px;
+    border: 2px solid var(--text-muted);
+    border-radius: 50%;
+  }
+
+  .complete-toggle input:checked + span {
+    border-color: var(--accent);
+    background: var(--accent);
+    box-shadow: inset 0 0 0 4px var(--surface);
+  }
+
+  .complete-toggle input:focus-visible + span {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+  }
+
+  .compact-field,
+  .text-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .field-label {
+    color: var(--text-muted);
+    font-size: 0.78rem;
+    font-weight: 500;
+  }
+
+  .compact-field input,
+  .text-field textarea {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg);
+    color: var(--text);
+    font-family: inherit;
+    font-size: 1rem;
+    line-height: 1.5;
+    padding: 0.65rem 0.75rem;
+  }
+
+  .compact-field input:focus,
+  .text-field textarea:focus {
+    border-color: var(--accent);
+    outline: none;
+  }
+
+  .text-field textarea {
+    resize: vertical;
+  }
+
+  .description-primary {
+    flex: 1;
+  }
+
+  .description-primary textarea {
+    flex: 1;
+    min-height: 12rem;
+  }
+
+  .more-fields {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+  }
+
+  .more-fields summary {
+    width: max-content;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .more-fields .text-field {
+    margin-top: 0.65rem;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    clip-path: inset(50%);
+  }
+
+  @media (max-width: 600px) {
+    .title-row {
+      align-items: flex-start;
+      flex-wrap: wrap;
+    }
+
+    .source-link {
+      margin-left: 2.75rem;
+    }
+  }
+</style>

--- a/packages/web/src/components/CardInlineEditor.svelte
+++ b/packages/web/src/components/CardInlineEditor.svelte
@@ -67,9 +67,9 @@
     savePromise = storeItem(applyCardDraft(item, snapshot));
     try {
       await savePromise;
-      persistedRevision = savingRevision;
-      syncedDraft = structuredClone(snapshot);
       if (revision === savingRevision) {
+        persistedRevision = savingRevision;
+        syncedDraft = structuredClone(snapshot);
         clearCardDraft(item.id, localStorage);
         status = 'saved';
       } else {
@@ -96,6 +96,14 @@
     if (saveTimer) clearTimeout(saveTimer);
   });
 
+  function noteExternalDraftChange() {
+    revision += 1;
+    status = 'pending';
+    writeCardDraft(draft, localStorage);
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => void persist().catch(() => {}), 700);
+  }
+
   // Background updates (bookmark enrichment, transcription, etc.) flow through
   // the items store while the modal stays open. Merge them into the draft
   // without clobbering fields the user has edited locally.
@@ -104,7 +112,10 @@
     untrack(() => {
       if (revision > persistedRevision) {
         const merged = mergeExternalCardDraft(draft, syncedDraft, external);
-        if (merged) draft = merged;
+        if (merged) {
+          draft = merged;
+          noteExternalDraftChange();
+        }
         return;
       }
       const next = createCardDraft(external);

--- a/packages/web/src/components/CardInlineEditor.svelte.test.ts
+++ b/packages/web/src/components/CardInlineEditor.svelte.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import type { ImageItem } from '@inbox-rs/rs-module';
+import type { BookmarkItem, ImageItem } from '@inbox-rs/rs-module';
 import { flushSync, mount, unmount } from 'svelte';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -10,6 +10,7 @@ const { storeItem } = vi.hoisted(() => ({
 vi.mock('../lib/stores', () => ({ storeItem }));
 
 import { cardDraftKey, createCardDraft } from '../lib/card-draft';
+import Harness from './CardInlineEditor.harness.svelte';
 import CardInlineEditor from './CardInlineEditor.svelte';
 
 const item: ImageItem = {
@@ -77,5 +78,55 @@ describe('CardInlineEditor autosave', () => {
     expect(
       (host.querySelector('[aria-label="Title"]') as HTMLInputElement).value,
     ).toBe('Recovered after refresh');
+  });
+
+  it('keeps a merged external update pending when an older save is in flight', async () => {
+    let releaseSave: (() => void) | undefined;
+    const saveGate = new Promise<void>((resolve) => {
+      releaseSave = resolve;
+    });
+    storeItem.mockImplementationOnce(() => saveGate);
+
+    const bookmark: BookmarkItem = {
+      id: 'bookmark-1',
+      type: 'bookmark',
+      title: 'https://example.org',
+      url: 'https://example.org',
+      createdAt: '2026-08-01T10:00:00.000Z',
+    };
+    const harness = mount(Harness, {
+      target: host,
+      props: { initial: bookmark },
+    });
+    flushSync();
+
+    const title = host.querySelector(
+      '[aria-label="Title"]',
+    ) as HTMLInputElement;
+    title.value = 'My custom title';
+    title.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    flushSync();
+
+    const flushPromise = harness.flushEdits();
+    const enriched: BookmarkItem = {
+      ...bookmark,
+      title: 'Example Org',
+      description: 'Recovered metadata',
+    };
+    harness.updateItem(enriched);
+    flushSync();
+
+    releaseSave?.();
+    await flushPromise;
+    await new Promise((resolve) => setTimeout(resolve, 750));
+
+    unmount(harness);
+
+    expect(storeItem).toHaveBeenCalledTimes(2);
+    expect(storeItem.mock.calls[1]?.[0]).toMatchObject({
+      title: 'My custom title',
+      description: 'Recovered metadata',
+    });
+    expect(localStorage.getItem(cardDraftKey(bookmark.id))).toBeNull();
   });
 });

--- a/packages/web/src/components/CardInlineEditor.svelte.test.ts
+++ b/packages/web/src/components/CardInlineEditor.svelte.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import type { ImageItem } from '@inbox-rs/rs-module';
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { storeItem } = vi.hoisted(() => ({
+  storeItem: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../lib/stores', () => ({ storeItem }));
+
+import { cardDraftKey, createCardDraft } from '../lib/card-draft';
+import CardInlineEditor from './CardInlineEditor.svelte';
+
+const item: ImageItem = {
+  id: 'image-1',
+  type: 'image',
+  title: 'Original title',
+  description: 'Original description',
+  filePath: 'files/image-1.jpg',
+  mimeType: 'image/jpeg',
+  createdAt: '2026-08-01T10:00:00.000Z',
+  pinned: true,
+};
+
+describe('CardInlineEditor autosave', () => {
+  let host: HTMLElement;
+  let component: ReturnType<typeof mount> | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    host = document.createElement('div');
+    document.body.appendChild(host);
+  });
+
+  afterEach(() => {
+    if (component) unmount(component);
+    component = undefined;
+    host.remove();
+  });
+
+  function render() {
+    component = mount(CardInlineEditor, { target: host, props: { item } });
+    flushSync();
+  }
+
+  it('writes a recovery draft immediately and syncs after the debounce', async () => {
+    render();
+    const title = host.querySelector(
+      '[aria-label="Title"]',
+    ) as HTMLInputElement;
+    title.value = 'Autosaved title';
+    title.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    flushSync();
+
+    expect(
+      JSON.parse(localStorage.getItem(cardDraftKey(item.id)) ?? '{}').title,
+    ).toBe('Autosaved title');
+    expect(storeItem).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 750));
+    expect(storeItem).toHaveBeenCalledWith({
+      ...item,
+      title: 'Autosaved title',
+    });
+    expect(localStorage.getItem(cardDraftKey(item.id))).toBeNull();
+  });
+
+  it('restores a device-local draft before remote sync completes', () => {
+    const draft = createCardDraft(item);
+    draft.title = 'Recovered after refresh';
+    localStorage.setItem(cardDraftKey(item.id), JSON.stringify(draft));
+
+    render();
+
+    expect(
+      (host.querySelector('[aria-label="Title"]') as HTMLInputElement).value,
+    ).toBe('Recovered after refresh');
+  });
+});

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -86,6 +86,11 @@
 
   async function handleDelete() {
     deleting = true;
+    try {
+      await flushEdits();
+    } catch {
+      // The save attempt has settled. Deletion must now win.
+    }
     await deleteItem(item.id, item);
     clearCardDraft(item.id, localStorage);
     showDelete = false;
@@ -423,12 +428,14 @@
     </div>
 
     <h2 class="sr-only" id={TITLE_ID}>{item.title || 'Untitled card'}</h2>
-    <CardInlineEditor
-      {item}
-      bind:status={saveStatus}
-      bind:flush={flushEdits}
-      bind:retry={retrySave}
-    />
+    {#key item.id}
+      <CardInlineEditor
+        {item}
+        bind:status={saveStatus}
+        bind:flush={flushEdits}
+        bind:retry={retrySave}
+      />
+    {/key}
 
     <!-- Type-specific previews and file actions stay available beneath the
          always-editable content without duplicating title/body fields. -->

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { InboxItem } from '@inbox-rs/rs-module';
+  import { clearCardDraft } from '../lib/card-draft';
   import {
     collections,
     deleteItem,
@@ -16,21 +17,17 @@
   import AddToCalendarSheet from './AddToCalendarSheet.svelte';
   import { formatScheduled, isOverdue } from '../lib/schedule';
   import BookmarkView from './view-card/BookmarkView.svelte';
-  import NoteView from './view-card/NoteView.svelte';
   import ImageView from './view-card/ImageView.svelte';
   import AudioView from './view-card/AudioView.svelte';
   import DocumentView from './view-card/DocumentView.svelte';
-  import EmailView from './view-card/EmailView.svelte';
-  import TodoView from './view-card/TodoView.svelte';
+  import CardInlineEditor, { type SaveStatus } from './CardInlineEditor.svelte';
 
   let {
     item,
     onclose,
-    onedit,
   }: {
     item: InboxItem;
     onclose: () => void;
-    onedit: (item: InboxItem) => void;
   } = $props();
 
   const TITLE_ID = 'view-modal-title';
@@ -48,10 +45,49 @@
 
   let convertingTodo = $state(false);
   let convertingRef = $state(false);
+  let saveStatus = $state<SaveStatus>('saved');
+  let flushEdits = $state<() => Promise<void>>(async () => {});
+  let retrySave = $state<() => void>(() => {});
+  let closing = $state(false);
+
+  const saveLabel = $derived(
+    saveStatus === 'saving'
+      ? 'Saving…'
+      : saveStatus === 'pending'
+        ? 'Saved on this device'
+        : saveStatus === 'error'
+          ? 'Couldn’t sync · Retry'
+          : saveStatus === 'restored'
+            ? 'Draft restored'
+            : 'Saved',
+  );
+
+  async function prepareAction() {
+    try {
+      await flushEdits();
+    } catch {
+      showToast('Changes are safe on this device, but could not sync');
+      throw new Error('Pending card changes could not sync');
+    }
+  }
+
+  async function requestClose() {
+    if (closing) return;
+    closing = true;
+    try {
+      await flushEdits();
+    } catch {
+      // The immediate local draft survives navigation and refresh, so closing
+      // remains safe even when remoteStorage is temporarily unavailable.
+    } finally {
+      onclose();
+    }
+  }
 
   async function handleDelete() {
     deleting = true;
     await deleteItem(item.id, item);
+    clearCardDraft(item.id, localStorage);
     showDelete = false;
     deleting = false;
     onclose();
@@ -81,6 +117,7 @@
   async function convertToUnfiledTodo() {
     convertingTodo = true;
     try {
+      await prepareAction();
       const { completedAt: _, ...rest } = item;
       await moveItemToCollection(item.id, undefined);
       // Strip collectionId so the converted todo lands in Unfiled. Cast to
@@ -108,6 +145,7 @@
   async function convertToTodoInCollection(collectionId: string) {
     convertingTodo = true;
     try {
+      await prepareAction();
       // Snapshot the rest of the item BEFORE we do any writes — once we move
       // the item, the store reflects the new collectionId and the prop might
       // be re-read as a different object, so working off a local copy keeps
@@ -145,6 +183,7 @@
   async function convertToReference() {
     convertingRef = true;
     try {
+      await prepareAction();
       // Cast to Record<string,unknown> for the structural rewrite below —
       // we're deleting and re-typing fields, which the discriminated InboxItem
       // union actively prevents at the type level.
@@ -179,14 +218,14 @@
   }
 
   /** Route the picker's choice to the flow that opened it. */
-  function handlePick(collectionId: string | undefined) {
+  async function handlePick(collectionId: string | undefined) {
     if (pickerMode === 'todo') {
       // Conversion closes the picker + modal itself on success so a failure
       // can leave both open for a retry.
       if (collectionId) {
-        void convertToTodoInCollection(collectionId);
+        await convertToTodoInCollection(collectionId);
       } else {
-        void convertToUnfiledTodo();
+        await convertToUnfiledTodo();
       }
       return;
     }
@@ -194,15 +233,15 @@
     // Close only once the move settles — a failure leaves the card open (with
     // a toast) so the user can retry, matching the todo-conversion branches.
     // The write is a local-first IndexedDB store, so the await is cheap.
-    moveItemToCollection(item.id, collectionId)
-      .then(() => {
-        if (collectionId) recordCollectionUse(collectionId);
-        onclose();
-      })
-      .catch((e) => {
-        console.error('Move failed:', e);
-        showToast('Move failed');
-      });
+    try {
+      await prepareAction();
+      await moveItemToCollection(item.id, collectionId);
+      if (collectionId) recordCollectionUse(collectionId);
+      onclose();
+    } catch (e) {
+      console.error('Move failed:', e);
+      showToast('Move failed');
+    }
   }
 
   function formatDate(iso: string): string {
@@ -216,11 +255,6 @@
     });
   }
 
-  // The discriminated union narrows nicely on `item.type === 'X'`, but a few
-  // shared trailing sections (notes/description/share) want to peek at
-  // optional fields without forcing the per-type branches. Use a Record cast
-  // for those structural reads.
-  const description = $derived(item.description);
   const hasFile = $derived(
     'filePath' in item && !!(item as unknown as Record<string, unknown>).filePath,
   );
@@ -284,9 +318,32 @@
    * nested handlers will fire immediately after.
    */
   function handleWindowEscape(e: KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
+      e.preventDefault();
+      void flushEdits().catch(() => {});
+      return;
+    }
     if (e.key !== 'Escape') return;
     if (showDelete || showPicker || showSchedule || showCalendarSheet) return;
-    onclose();
+    void requestClose();
+  }
+
+  async function openSchedule() {
+    try {
+      await prepareAction();
+      showSchedule = true;
+    } catch {
+      // prepareAction already explains that the draft is safe locally.
+    }
+  }
+
+  async function openCalendar() {
+    try {
+      await prepareAction();
+      showCalendarSheet = true;
+    } catch {
+      // prepareAction already explains that the draft is safe locally.
+    }
   }
 </script>
 
@@ -294,7 +351,7 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" onclick={onclose}>
+<div class="overlay" onclick={() => void requestClose()}>
   <div
     class="modal"
     role="dialog"
@@ -305,6 +362,16 @@
     <div class="modal-header">
       <span class="type-badge">{item.type}</span>
       <time class="date">{formatDate(item.createdAt)}</time>
+      <button
+        type="button"
+        class="save-status"
+        class:error={saveStatus === 'error'}
+        onclick={() => saveStatus === 'error' && retrySave()}
+        disabled={saveStatus !== 'error'}
+        aria-live="polite"
+      >
+        <span class="save-dot" aria-hidden="true"></span>{saveLabel}
+      </button>
       <div class="header-actions">
         <button
           type="button"
@@ -335,7 +402,7 @@
           class="icon-btn"
           title="Close"
           aria-label="Close"
-          onclick={onclose}
+          onclick={() => void requestClose()}
         >
           <svg
             aria-hidden="true"
@@ -355,47 +422,27 @@
       </div>
     </div>
 
-    <!--
-      Per-type body. Each child renders the title (with type-specific link
-      icon for bookmark/email) plus its own meta and main content. Wrapping
-      in `{#key item.id}` resets per-type local state (audio transcribe
-      flags, document blob URL caches, image lightbox state, etc.) when the
-      user navigates between cards without forcing every child to write its
-      own reset effect.
-    -->
+    <h2 class="sr-only" id={TITLE_ID}>{item.title || 'Untitled card'}</h2>
+    <CardInlineEditor
+      {item}
+      bind:status={saveStatus}
+      bind:flush={flushEdits}
+      bind:retry={retrySave}
+    />
+
+    <!-- Type-specific previews and file actions stay available beneath the
+         always-editable content without duplicating title/body fields. -->
     {#key item.id}
       {#if item.type === 'bookmark'}
-        <BookmarkView {item} titleId={TITLE_ID} />
-      {:else if item.type === 'note'}
-        <NoteView {item} titleId={TITLE_ID} />
+        <BookmarkView {item} titleId={TITLE_ID} showTitle={false} beforeAction={prepareAction} />
       {:else if item.type === 'image'}
-        <ImageView {item} titleId={TITLE_ID} />
+        <ImageView {item} titleId={TITLE_ID} showTitle={false} />
       {:else if item.type === 'audio'}
-        <AudioView {item} titleId={TITLE_ID} />
+        <AudioView {item} titleId={TITLE_ID} showTitle={false} showBody={false} beforeAction={prepareAction} />
       {:else if item.type === 'document'}
-        <DocumentView {item} titleId={TITLE_ID} />
-      {:else if item.type === 'email'}
-        <EmailView {item} titleId={TITLE_ID} />
-      {:else if item.type === 'todo'}
-        <TodoView {item} titleId={TITLE_ID} />
-      {:else}
-        <!--
-          Generic fallback for item types without a dedicated view (e.g.
-          `video`, which the rs-module schema reserves but the web UI
-          doesn't yet render). Renders the title only so the modal still
-          presents something legible — and so `aria-labelledby` always
-          resolves to a real heading.
-        -->
-        <h2 class="title" id={TITLE_ID}>{item.title}</h2>
+        <DocumentView {item} titleId={TITLE_ID} showTitle={false} />
       {/if}
     {/key}
-
-    {#if description}
-      <div class="content-block">
-        <span class="content-label">Description</span>
-        <p class="content-text">{description}</p>
-      </div>
-    {/if}
 
     {#if hasFile}
       <div class="share-row">
@@ -558,7 +605,7 @@
       <button
         type="button"
         class="action-row"
-        onclick={() => (showSchedule = true)}
+        onclick={() => void openSchedule()}
       >
         <svg
           aria-hidden="true"
@@ -580,7 +627,7 @@
         <button
           type="button"
           class="action-row"
-          onclick={() => (showCalendarSheet = true)}
+          onclick={() => void openCalendar()}
         >
           <svg
             aria-hidden="true"
@@ -601,23 +648,6 @@
           {item.eventUrl ? 'On calendar — manage…' : 'Add to calendar…'}
         </button>
       {/if}
-      <button type="button" class="action-row" onclick={() => onedit(item)}>
-        <svg
-          aria-hidden="true"
-          width="15"
-          height="15"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <path d="M12 20h9"></path>
-          <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"></path>
-        </svg>
-        Edit
-      </button>
     </div>
 
     {#if showDelete}
@@ -652,21 +682,27 @@
     position: fixed;
     inset: 0;
     z-index: 200;
+    display: grid;
+    place-items: center;
     background: var(--overlay);
-    overflow-y: auto;
+    overflow: hidden;
     overscroll-behavior: contain;
-    padding: 3rem 1rem;
+    padding: 1.25rem;
   }
 
   .modal {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--radius);
     width: 100%;
-    max-width: 560px;
+    max-width: 1120px;
+    height: min(920px, calc(100dvh - 2.5rem));
+    overflow-y: auto;
     padding: 1.5rem;
-    margin-left: auto;
-    margin-right: auto;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
   }
 
   @media (max-width: 600px), (display-mode: standalone) {
@@ -678,9 +714,11 @@
 
     .modal {
       max-width: none;
-      min-height: 100%;
+      width: 100%;
+      height: 100dvh;
       border: none;
       border-radius: 0;
+      padding: 1rem;
     }
   }
 
@@ -688,7 +726,8 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    margin-bottom: 0.75rem;
+    flex-shrink: 0;
+    min-height: 36px;
   }
 
   .type-badge {
@@ -705,6 +744,41 @@
   .date {
     font-size: 0.75rem;
     color: var(--text-muted);
+  }
+
+  .save-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: 0.75rem;
+    padding: 0.25rem 0.4rem;
+  }
+
+  .save-status.error {
+    color: var(--danger);
+    cursor: pointer;
+  }
+
+  .save-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+    opacity: 0.65;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    clip-path: inset(50%);
   }
 
   /*
@@ -770,8 +844,8 @@
 
   .modal :global(.view-image) {
     width: 100%;
-    max-height: 300px;
-    object-fit: cover;
+    max-height: 42vh;
+    object-fit: contain;
     border-radius: var(--radius-sm);
     border: 1px solid var(--border);
   }
@@ -978,7 +1052,6 @@
   }
 
   .share-row {
-    margin-bottom: 0.75rem;
     padding-top: 0.5rem;
     border-top: 1px solid var(--border);
   }
@@ -1020,7 +1093,6 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.9rem;
-    margin-top: 1rem;
     padding-top: 0.75rem;
     border-top: 1px solid var(--border);
     font-size: 0.78rem;
@@ -1056,10 +1128,9 @@
     justify-content: center;
     gap: 0.45rem;
     width: 100%;
-    margin-top: 0.85rem;
-    background: var(--accent);
-    border: none;
-    color: white;
+    background: var(--accent-subtle);
+    border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border));
+    color: var(--accent);
     padding: 0.6rem 1rem;
     border-radius: var(--radius-sm);
     font-size: 0.9rem;
@@ -1077,15 +1148,15 @@
 
   .action-list {
     display: flex;
-    flex-direction: column;
-    margin-top: 0.5rem;
+    flex-wrap: wrap;
+    gap: 0.25rem;
   }
 
   .action-row {
     display: flex;
     align-items: center;
     gap: 0.55rem;
-    width: 100%;
+    width: auto;
     padding: 0.55rem 0.5rem;
     border: none;
     background: none;

--- a/packages/web/src/components/add-entry/MarkdownContentField.svelte
+++ b/packages/web/src/components/add-entry/MarkdownContentField.svelte
@@ -13,11 +13,13 @@
     label = 'Content',
     placeholder = 'Write your note...',
     focusOnMount = false,
+    onchange = undefined,
   }: {
     value?: string;
     label?: string;
     placeholder?: string;
     focusOnMount?: boolean;
+    onchange?: () => void;
   } = $props();
 
   let editorMode = $state<'visual' | 'write' | 'preview'>('visual');
@@ -28,6 +30,14 @@
   let previewHtml = $state('');
 
   const handleCodeKeydown = createCodeKeydownHandler();
+  let previousValue = value;
+
+  $effect(() => {
+    const currentValue = value;
+    if (currentValue === previousValue) return;
+    previousValue = currentValue;
+    onchange?.();
+  });
 
   $effect(() => {
     if (
@@ -115,3 +125,103 @@
 {#if markdownEditorLoadError}
   <p class="info-note">{markdownEditorLoadError}</p>
 {/if}
+
+<style>
+  .field {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 0.45rem;
+    min-height: 0;
+  }
+
+  .field-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .field-header > span {
+    color: var(--text-muted);
+    font-size: 0.78rem;
+    font-weight: 500;
+  }
+
+  .editor-tabs {
+    display: flex;
+    gap: 0.25rem;
+  }
+
+  .tab {
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    background: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 0.72rem;
+    padding: 0.2rem 0.55rem;
+  }
+
+  .tab:hover {
+    color: var(--text);
+  }
+
+  .tab.active {
+    border-color: var(--border);
+    background: var(--surface-hover);
+    color: var(--accent);
+  }
+
+  .tab:disabled {
+    cursor: default;
+    opacity: 0.45;
+  }
+
+  textarea {
+    flex: 1;
+    min-height: 16rem;
+    resize: vertical;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+    font-size: 1rem;
+    line-height: 1.55;
+    padding: 0.9rem;
+  }
+
+  textarea:focus {
+    border-color: var(--accent);
+    outline: none;
+  }
+
+  .editor-loading,
+  .preview-wrap {
+    flex: 1;
+    min-height: 16rem;
+    overflow-y: auto;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg);
+    padding: 0.9rem;
+  }
+
+  .editor-loading {
+    display: grid;
+    place-items: center;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+  }
+
+  .preview-empty,
+  .info-note {
+    color: var(--text-muted);
+    font-size: 0.82rem;
+  }
+
+  :global(.tiptap-wrap .tiptap-editor) {
+    min-height: 16rem;
+  }
+</style>

--- a/packages/web/src/components/view-card/AudioView.svelte
+++ b/packages/web/src/components/view-card/AudioView.svelte
@@ -7,7 +7,19 @@
   import { transcribeAudio } from '../../lib/transcribe';
   import OfflineTranscriptionAssets from '../OfflineTranscriptionAssets.svelte';
 
-  let { item, titleId }: { item: AudioItem; titleId: string } = $props();
+  let {
+    item,
+    titleId,
+    showTitle = true,
+    showBody = true,
+    beforeAction = async () => {},
+  }: {
+    item: AudioItem;
+    titleId: string;
+    showTitle?: boolean;
+    showBody?: boolean;
+    beforeAction?: () => Promise<void>;
+  } = $props();
 
   let audioError = $state(false);
   let transcribing = $state(false);
@@ -49,6 +61,7 @@
   }
 
   async function handleTranscribe() {
+    await beforeAction();
     // The parent's `{#key item.id}` block destroys this component if the
     // user navigates to a different audio mid-transcription, which cancels
     // any UI updates from the in-flight promise — Svelte simply stops
@@ -77,7 +90,7 @@
   }
 </script>
 
-<h2 class="title" id={titleId}>{item.title}</h2>
+{#if showTitle}<h2 class="title" id={titleId}>{item.title}</h2>{/if}
 
 <div class="player">
   {#if audioError}
@@ -113,7 +126,7 @@
   <OfflineTranscriptionAssets />
 </div>
 
-{#if item.body}
+{#if showBody && item.body}
   <div class="content-block">
     <span class="content-label">Transcription</span>
     {#if renderedBody}

--- a/packages/web/src/components/view-card/AudioView.svelte
+++ b/packages/web/src/components/view-card/AudioView.svelte
@@ -61,7 +61,11 @@
   }
 
   async function handleTranscribe() {
-    await beforeAction();
+    try {
+      await beforeAction();
+    } catch {
+      return;
+    }
     // The parent's `{#key item.id}` block destroys this component if the
     // user navigates to a different audio mid-transcription, which cancels
     // any UI updates from the in-flight promise — Svelte simply stops

--- a/packages/web/src/components/view-card/BookmarkView.svelte
+++ b/packages/web/src/components/view-card/BookmarkView.svelte
@@ -30,7 +30,11 @@
   // flow — the parent's `{#key item.id}` remount makes state resets and
   // stale-promise guards unnecessary.
   async function handleFetchPreview() {
-    await beforeAction();
+    try {
+      await beforeAction();
+    } catch {
+      return;
+    }
     fetchingPreview = true;
     previewStatus = '';
     try {

--- a/packages/web/src/components/view-card/BookmarkView.svelte
+++ b/packages/web/src/components/view-card/BookmarkView.svelte
@@ -9,7 +9,17 @@
   } from '../../lib/stores';
   import Lightbox from '../Lightbox.svelte';
 
-  let { item, titleId }: { item: BookmarkItem; titleId: string } = $props();
+  let {
+    item,
+    titleId,
+    showTitle = true,
+    beforeAction = async () => {},
+  }: {
+    item: BookmarkItem;
+    titleId: string;
+    showTitle?: boolean;
+    beforeAction?: () => Promise<void>;
+  } = $props();
 
   let showLightbox = $state(false);
   let fetchingPreview = $state(false);
@@ -20,6 +30,7 @@
   // flow — the parent's `{#key item.id}` remount makes state resets and
   // stale-promise guards unnecessary.
   async function handleFetchPreview() {
+    await beforeAction();
     fetchingPreview = true;
     previewStatus = '';
     try {
@@ -64,9 +75,10 @@
   });
 </script>
 
-<h2 class="title" id={titleId}>
-  <a href={item.url} target="_blank" rel="noopener noreferrer"
-    >{item.title}<svg
+{#if showTitle}
+  <h2 class="title" id={titleId}>
+    <a href={item.url} target="_blank" rel="noopener noreferrer"
+      >{item.title}<svg
       aria-hidden="true"
       class="link-icon"
       width="14"
@@ -84,9 +96,10 @@
         x2="21"
         y2="3"
       ></line></svg
-    ></a
-  >
-</h2>
+      ></a
+    >
+  </h2>
+{/if}
 
 <div class="meta-row">
   {#if item.favicon}

--- a/packages/web/src/components/view-card/DocumentView.svelte
+++ b/packages/web/src/components/view-card/DocumentView.svelte
@@ -3,7 +3,7 @@
   import type { DocumentItem } from '@inbox-rs/rs-module';
   import rs from '../../lib/rs';
 
-  let { item, titleId }: { item: DocumentItem; titleId: string } = $props();
+  let { item, titleId, showTitle = true }: { item: DocumentItem; titleId: string; showTitle?: boolean } = $props();
 
   let docBlobUrl = $state<string | null>(null);
   let docLoading = $state(false);
@@ -61,7 +61,7 @@
   }
 </script>
 
-<h2 class="title" id={titleId}>{item.title}</h2>
+{#if showTitle}<h2 class="title" id={titleId}>{item.title}</h2>{/if}
 
 {#if item.fileName}
   <p class="meta-text">{item.fileName}</p>

--- a/packages/web/src/components/view-card/ImageView.svelte
+++ b/packages/web/src/components/view-card/ImageView.svelte
@@ -3,7 +3,7 @@
   import { blobUrls, connected, loadFileBlobUrl } from '../../lib/stores';
   import Lightbox from '../Lightbox.svelte';
 
-  let { item, titleId }: { item: ImageItem; titleId: string } = $props();
+  let { item, titleId, showTitle = true }: { item: ImageItem; titleId: string; showTitle?: boolean } = $props();
 
   let showLightbox = $state(false);
 
@@ -23,7 +23,7 @@
   });
 </script>
 
-<h2 class="title" id={titleId}>{item.title}</h2>
+{#if showTitle}<h2 class="title" id={titleId}>{item.title}</h2>{/if}
 
 {#if imageSrc}
   <!-- svelte-ignore a11y_click_events_have_key_events -->

--- a/packages/web/src/lib/card-draft.test.ts
+++ b/packages/web/src/lib/card-draft.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import type { InboxItem, TodoItem } from '@inbox-rs/rs-module';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  applyCardDraft,
+  cardDraftKey,
+  clearCardDraft,
+  createCardDraft,
+  readCardDraft,
+  writeCardDraft,
+} from './card-draft';
+
+const note: InboxItem = {
+  id: 'note-1',
+  type: 'note',
+  title: 'Original',
+  body: 'Old body',
+  description: 'Old description',
+  createdAt: '2026-08-01T10:00:00.000Z',
+  pinned: true,
+};
+
+beforeEach(() => localStorage.clear());
+
+describe('card drafts', () => {
+  it('round-trips through per-card local storage', () => {
+    const draft = createCardDraft(note);
+    draft.body = 'Recovered body';
+    writeCardDraft(draft, localStorage);
+
+    expect(readCardDraft(note, localStorage)).toEqual(draft);
+    clearCardDraft(note.id, localStorage);
+    expect(localStorage.getItem(cardDraftKey(note.id))).toBeNull();
+  });
+
+  it('ignores malformed and mismatched drafts', () => {
+    localStorage.setItem(cardDraftKey(note.id), '{bad json');
+    expect(readCardDraft(note, localStorage)).toBeNull();
+
+    localStorage.setItem(
+      cardDraftKey(note.id),
+      JSON.stringify({ ...createCardDraft(note), type: 'email' }),
+    );
+    expect(readCardDraft(note, localStorage)).toBeNull();
+  });
+
+  it('applies editable fields without dropping external metadata', () => {
+    const draft = createCardDraft(note);
+    draft.title = 'Changed';
+    draft.body = 'Changed body';
+    draft.description = '';
+
+    expect(applyCardDraft(note, draft)).toEqual({
+      ...note,
+      title: 'Changed',
+      body: 'Changed body',
+      description: undefined,
+    });
+  });
+
+  it('stamps completion only on the open-to-done transition', () => {
+    const todo: TodoItem = {
+      id: 'todo-1',
+      type: 'todo',
+      title: 'Do it',
+      completed: false,
+      isTodo: true,
+      createdAt: note.createdAt,
+    };
+    const draft = createCardDraft(todo);
+    draft.completed = true;
+
+    const updated = applyCardDraft(
+      todo,
+      draft,
+      new Date('2026-08-08T12:00:00.000Z'),
+    ) as TodoItem;
+    expect(updated.completed).toBe(true);
+    expect(updated.completedAt).toBe('2026-08-08T12:00:00.000Z');
+  });
+});

--- a/packages/web/src/lib/card-draft.test.ts
+++ b/packages/web/src/lib/card-draft.test.ts
@@ -6,6 +6,8 @@ import {
   cardDraftKey,
   clearCardDraft,
   createCardDraft,
+  draftsEqual,
+  mergeExternalCardDraft,
   readCardDraft,
   writeCardDraft,
 } from './card-draft';
@@ -56,6 +58,29 @@ describe('card drafts', () => {
       body: 'Changed body',
       description: undefined,
     });
+  });
+
+  it('merges external updates only into untouched draft fields', () => {
+    const bookmark: InboxItem = {
+      id: 'bm-1',
+      type: 'bookmark',
+      title: 'https://example.org',
+      url: 'https://example.org',
+      createdAt: note.createdAt,
+    };
+    const synced = createCardDraft(bookmark);
+    const draft = { ...synced, title: 'My custom title' };
+    const enriched = {
+      ...bookmark,
+      title: 'Example Org',
+      description: 'Recovered metadata',
+    };
+
+    expect(mergeExternalCardDraft(draft, synced, enriched)).toEqual({
+      ...draft,
+      description: 'Recovered metadata',
+    });
+    expect(draftsEqual(synced, createCardDraft(bookmark))).toBe(true);
   });
 
   it('stamps completion only on the open-to-done transition', () => {

--- a/packages/web/src/lib/card-draft.ts
+++ b/packages/web/src/lib/card-draft.ts
@@ -1,0 +1,111 @@
+import type { InboxItem, InboxItemType } from '@inbox-rs/rs-module';
+
+export const CARD_DRAFT_PREFIX = 'inbox-rs:card-draft:';
+
+export interface CardDraft {
+  id: string;
+  type: InboxItemType;
+  title: string;
+  description: string;
+  body?: string;
+  url?: string;
+  from?: string;
+  notes?: string;
+  completed?: boolean;
+}
+
+export function createCardDraft(item: InboxItem): CardDraft {
+  const draft: CardDraft = {
+    id: item.id,
+    type: item.type,
+    title: item.title,
+    description: item.description ?? '',
+  };
+  if ('body' in item) draft.body = item.body ?? '';
+  if (item.type === 'bookmark') draft.url = item.url;
+  if (item.type === 'email') {
+    draft.from = item.from ?? '';
+    draft.notes = item.notes ?? '';
+  }
+  if (item.isTodo || item.type === 'todo') {
+    draft.completed = !!item.completed;
+  }
+  return draft;
+}
+
+export function applyCardDraft(
+  item: InboxItem,
+  draft: CardDraft,
+  now: Date = new Date(),
+): InboxItem {
+  const updated = {
+    ...item,
+    title: draft.title,
+    description: draft.description || undefined,
+  } as InboxItem;
+  const record = updated as unknown as Record<string, unknown>;
+
+  if ('body' in item) record.body = draft.body ?? '';
+  if (item.type === 'bookmark') record.url = draft.url ?? '';
+  if (item.type === 'email') {
+    record.from = draft.from || undefined;
+    record.notes = draft.notes || undefined;
+  }
+  if (item.isTodo || item.type === 'todo') {
+    const completed = !!draft.completed;
+    record.completed = completed;
+    record.isTodo = true;
+    if (completed && !item.completed) {
+      record.completedAt = now.toISOString();
+    }
+  }
+  return updated;
+}
+
+export function cardDraftKey(id: string): string {
+  return `${CARD_DRAFT_PREFIX}${id}`;
+}
+
+export function readCardDraft(
+  item: InboxItem,
+  storage: Pick<Storage, 'getItem'>,
+): CardDraft | null {
+  try {
+    const raw = storage.getItem(cardDraftKey(item.id));
+    if (!raw) return null;
+    const draft = JSON.parse(raw) as Partial<CardDraft>;
+    if (
+      draft.id !== item.id ||
+      draft.type !== item.type ||
+      typeof draft.title !== 'string' ||
+      typeof draft.description !== 'string'
+    ) {
+      return null;
+    }
+    return draft as CardDraft;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCardDraft(
+  draft: CardDraft,
+  storage: Pick<Storage, 'setItem'>,
+): void {
+  try {
+    storage.setItem(cardDraftKey(draft.id), JSON.stringify(draft));
+  } catch {
+    // Storage can be disabled or full. Autosave still proceeds normally.
+  }
+}
+
+export function clearCardDraft(
+  id: string,
+  storage: Pick<Storage, 'removeItem'>,
+): void {
+  try {
+    storage.removeItem(cardDraftKey(id));
+  } catch {
+    // Non-fatal: a successfully persisted card remains the source of truth.
+  }
+}

--- a/packages/web/src/lib/card-draft.ts
+++ b/packages/web/src/lib/card-draft.ts
@@ -109,3 +109,53 @@ export function clearCardDraft(
     // Non-fatal: a successfully persisted card remains the source of truth.
   }
 }
+
+const MERGEABLE_DRAFT_KEYS = [
+  'title',
+  'description',
+  'body',
+  'url',
+  'from',
+  'notes',
+  'completed',
+] as const satisfies readonly (keyof CardDraft)[];
+
+function draftField(
+  draft: CardDraft,
+  key: (typeof MERGEABLE_DRAFT_KEYS)[number],
+): string | boolean | undefined {
+  return draft[key];
+}
+
+/** True when two drafts carry the same editable field values. */
+export function draftsEqual(a: CardDraft, b: CardDraft): boolean {
+  return MERGEABLE_DRAFT_KEYS.every(
+    (key) => draftField(a, key) === draftField(b, key),
+  );
+}
+
+/**
+ * Pull externally-updated fields into a local draft without clobbering
+ * values the user has changed since the last persisted/synced snapshot.
+ */
+export function mergeExternalCardDraft(
+  draft: CardDraft,
+  synced: CardDraft,
+  item: InboxItem,
+): CardDraft | null {
+  const external = createCardDraft(item);
+  const merged = { ...draft };
+  let changed = false;
+
+  for (const key of MERGEABLE_DRAFT_KEYS) {
+    if (draftField(draft, key) === draftField(synced, key)) {
+      const next = draftField(external, key);
+      if (draftField(draft, key) !== next) {
+        (merged as Record<string, unknown>)[key] = next;
+        changed = true;
+      }
+    }
+  }
+
+  return changed ? merged : null;
+}

--- a/tests/e2e/desktop/bookmark-enrichment.spec.ts
+++ b/tests/e2e/desktop/bookmark-enrichment.spec.ts
@@ -210,9 +210,10 @@ test('a failed metadata fetch leaves the capture intact and the view card offers
   await expect(dialog).toBeVisible({ timeout: 10_000 });
 
   await dialog.getByRole('button', { name: 'Fetch preview' }).click();
-  await expect(dialog.getByRole('link', { name: 'Example Org' })).toBeVisible({
-    timeout: 10_000,
-  });
+  await expect(dialog.getByRole('textbox', { name: 'Title' })).toHaveValue(
+    'Example Org',
+    { timeout: 10_000 },
+  );
   await expect(dialog.getByText('Recovered metadata')).toBeVisible();
 
   assertNoConsoleErrors(log);

--- a/tests/e2e/desktop/bookmark-enrichment.spec.ts
+++ b/tests/e2e/desktop/bookmark-enrichment.spec.ts
@@ -214,7 +214,9 @@ test('a failed metadata fetch leaves the capture intact and the view card offers
     'Example Org',
     { timeout: 10_000 },
   );
-  await expect(dialog.getByText('Recovered metadata')).toBeVisible();
+  await expect(
+    dialog.getByRole('textbox', { name: 'Description' }),
+  ).toHaveValue('Recovered metadata');
 
   assertNoConsoleErrors(log);
 });


### PR DESCRIPTION
## What changed

- Replace the separate read-only card view and edit transition with one directly editable card workspace.
- Expand the workspace to use most of the available window on desktop and the full viewport on mobile.
- Autosave title, rich content, descriptions, bookmark URLs, email metadata, and todo completion after a short debounce.
- Write every edit immediately to a per-card device-local recovery draft, then clear it after remoteStorage persistence succeeds.
- Restore interrupted drafts automatically after refresh or navigation.
- Surface `Saving…`, `Saved`, local-only, restored-draft, and retry states in the workspace header.
- Flush pending edits before close, collection moves, scheduling, calendar publishing, conversions, bookmark enrichment, and audio transcription.
- Support Escape/backdrop close and Cmd/Ctrl+S without risking pending changes.
- Retain previews, playback, downloads, sharing, filing, scheduling, conversion, and deletion as secondary workspace actions.

## Why

The old flow made users open a card, find Edit, move into a second modal, explicitly save, and risk losing the entire draft if they navigated or refreshed. Card content is the primary object of focus, so viewing and editing should be the same low-friction interaction with clear persistence feedback.

## UX impact

Opening any card or todo now creates a focused editing workspace. Fields behave like normal document controls: click and type, use native undo, tab between controls, press Cmd/Ctrl+S to flush immediately, or simply leave and let autosave handle it. If remoteStorage is unavailable, the draft remains safe on that device and can be retried or restored later.

## Validation

- `npm run check` (passes with two pre-existing non-null-assertion warnings in `tests/e2e/desktop/navigation.spec.ts`)
- `npm run check --workspace=packages/web` (0 errors)
- `npm run test` (801 tests passed)
- Svelte autofixer on every changed Svelte component
- New unit/component coverage for draft round-tripping, malformed-draft rejection, metadata preservation, completion timestamps, immediate recovery writes, debounced persistence, and refresh restoration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline editing for inbox cards with type-specific fields, markdown content, links, notes, and completion status.
  * Drafts are saved locally, autosaved remotely, restored after reopening, and include save-status and retry feedback.
  * Added responsive editing layouts for desktop and mobile screens.
  * Actions such as scheduling, moving, converting, deleting, and closing wait for pending edits to finish.

* **Bug Fixes**
  * Prevented actions from proceeding when edits fail to synchronize.
  * Improved handling of incomplete or invalid saved drafts.
  * Prevented previews and transcription from starting when pending edits cannot be saved.
  * Improved bookmark preview metadata display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->