### PR TITLE
Move card deletion into an actions menu

### DIFF
--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -32,6 +32,7 @@
 
   const TITLE_ID = 'view-modal-title';
 
+  let showActions = $state(false);
   let showDelete = $state(false);
   let deleting = $state(false);
 
@@ -330,7 +331,26 @@
     }
     if (e.key !== 'Escape') return;
     if (showDelete || showPicker || showSchedule || showCalendarSheet) return;
+    if (showActions) {
+      showActions = false;
+      return;
+    }
     void requestClose();
+  }
+
+  function handleOverlayClick() {
+    if (showActions) {
+      showActions = false;
+      return;
+    }
+    void requestClose();
+  }
+
+  function handleModalClick(e: MouseEvent) {
+    e.stopPropagation();
+    if (showActions && !(e.target as HTMLElement).closest('.header-actions')) {
+      showActions = false;
+    }
   }
 
   async function openSchedule() {
@@ -356,13 +376,13 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" onclick={() => void requestClose()}>
+<div class="overlay" onclick={handleOverlayClick}>
   <div
     class="modal"
     role="dialog"
     aria-modal="true"
     aria-labelledby={TITLE_ID}
-    onclick={(e) => e.stopPropagation()}
+    onclick={handleModalClick}
   >
     <div class="modal-header">
       <span class="type-badge">{item.type}</span>
@@ -380,28 +400,56 @@
       <div class="header-actions">
         <button
           type="button"
-          class="icon-btn icon-btn-danger"
-          title="Delete"
-          aria-label="Delete"
-          onclick={() => (showDelete = true)}
+          class="icon-btn"
+          title="Card actions"
+          aria-label="Card actions"
+          aria-haspopup="menu"
+          aria-expanded={showActions}
+          onclick={() => (showActions = !showActions)}
         >
           <svg
             aria-hidden="true"
-            width="16"
-            height="16"
+            width="18"
+            height="18"
             viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
+            fill="currentColor"
           >
-            <polyline points="3 6 5 6 21 6"></polyline>
-            <path
-              d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
-            ></path>
+            <circle cx="5" cy="12" r="1.75"></circle>
+            <circle cx="12" cy="12" r="1.75"></circle>
+            <circle cx="19" cy="12" r="1.75"></circle>
           </svg>
         </button>
+        {#if showActions}
+          <div class="actions-menu" role="menu">
+            <button
+              type="button"
+              class="actions-menu-item actions-menu-danger"
+              role="menuitem"
+              onclick={() => {
+                showActions = false;
+                showDelete = true;
+              }}
+            >
+              <svg
+                aria-hidden="true"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polyline points="3 6 5 6 21 6"></polyline>
+                <path
+                  d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
+                ></path>
+              </svg>
+              Delete card
+            </button>
+          </div>
+        {/if}
         <button
           type="button"
           class="icon-btn"
@@ -1069,11 +1117,12 @@
     margin-left: auto;
     display: flex;
     gap: 0.25rem;
+    position: relative;
   }
 
   .icon-btn {
-    width: 32px;
-    height: 32px;
+    width: 40px;
+    height: 40px;
     border-radius: var(--radius-sm);
     display: grid;
     place-items: center;
@@ -1089,9 +1138,59 @@
     color: var(--text);
   }
 
-  .icon-btn-danger:hover {
+  .actions-menu {
+    position: absolute;
+    z-index: 10;
+    top: calc(100% + 0.35rem);
+    right: 44px;
+    min-width: 168px;
+    padding: 0.3rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    box-shadow: 0 12px 32px var(--shadow);
+  }
+
+  .actions-menu-item {
+    width: 100%;
+    min-height: 40px;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.55rem 0.7rem;
+    border: none;
+    border-radius: calc(var(--radius-sm) - 2px);
+    background: none;
+    color: var(--text);
+    font-family: inherit;
+    font-size: 0.9rem;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .actions-menu-danger {
+    color: var(--danger);
+  }
+
+  .actions-menu-danger:hover,
+  .actions-menu-danger:focus-visible {
     color: var(--danger);
     background: color-mix(in srgb, var(--danger) 10%, transparent);
+  }
+
+  @media (max-width: 600px), (display-mode: standalone) {
+    .icon-btn {
+      width: 44px;
+      height: 44px;
+    }
+
+    .actions-menu {
+      right: 48px;
+    }
+
+    .actions-menu-item {
+      min-height: 44px;
+    }
   }
 
   /* ── Meta strip ───────────────────────── */

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { InboxItem } from '@inbox-rs/rs-module';
+  import { tick } from 'svelte';
   import { clearCardDraft } from '../lib/card-draft';
   import {
     collections,
@@ -33,6 +34,8 @@
   const TITLE_ID = 'view-modal-title';
 
   let showActions = $state(false);
+  let actionsTrigger = $state<HTMLButtonElement>();
+  let deleteAction = $state<HTMLButtonElement>();
   let showDelete = $state(false);
   let deleting = $state(false);
 
@@ -332,15 +335,52 @@
     if (e.key !== 'Escape') return;
     if (showDelete || showPicker || showSchedule || showCalendarSheet) return;
     if (showActions) {
-      showActions = false;
+      closeActions(true);
       return;
     }
     void requestClose();
   }
 
+  async function openActions() {
+    showActions = true;
+    await tick();
+    deleteAction?.focus();
+  }
+
+  function closeActions(restoreFocus = false) {
+    showActions = false;
+    if (restoreFocus) actionsTrigger?.focus();
+  }
+
+  function handleActionsTriggerKeydown(e: KeyboardEvent) {
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+    e.preventDefault();
+    void openActions();
+  }
+
+  function handleActionsMenuKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      closeActions(true);
+      return;
+    }
+    if (
+      e.key === 'ArrowDown' ||
+      e.key === 'ArrowUp' ||
+      e.key === 'Home' ||
+      e.key === 'End'
+    ) {
+      e.preventDefault();
+      deleteAction?.focus();
+    } else if (e.key === 'Tab') {
+      closeActions();
+    }
+  }
+
   function handleOverlayClick() {
     if (showActions) {
-      showActions = false;
+      closeActions(true);
       return;
     }
     void requestClose();
@@ -349,7 +389,7 @@
   function handleModalClick(e: MouseEvent) {
     e.stopPropagation();
     if (showActions && !(e.target as HTMLElement).closest('.header-actions')) {
-      showActions = false;
+      closeActions();
     }
   }
 
@@ -399,13 +439,16 @@
       </button>
       <div class="header-actions">
         <button
+          bind:this={actionsTrigger}
           type="button"
           class="icon-btn"
           title="Card actions"
           aria-label="Card actions"
           aria-haspopup="menu"
           aria-expanded={showActions}
-          onclick={() => (showActions = !showActions)}
+          onclick={() =>
+            showActions ? closeActions() : void openActions()}
+          onkeydown={handleActionsTriggerKeydown}
         >
           <svg
             aria-hidden="true"
@@ -420,13 +463,20 @@
           </svg>
         </button>
         {#if showActions}
-          <div class="actions-menu" role="menu">
+          <div
+            class="actions-menu"
+            role="menu"
+            aria-label="Card actions"
+            tabindex="-1"
+            onkeydown={handleActionsMenuKeydown}
+          >
             <button
+              bind:this={deleteAction}
               type="button"
               class="actions-menu-item actions-menu-danger"
               role="menuitem"
               onclick={() => {
-                showActions = false;
+                closeActions();
                 showDelete = true;
               }}
             >

--- a/packages/web/src/components/ViewCardModal.svelte.test.ts
+++ b/packages/web/src/components/ViewCardModal.svelte.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import type { InboxItem } from '@inbox-rs/rs-module';
+import { flushSync, mount, tick, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../lib/stores', async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    collections: writable({}),
+    groups: writable({}),
+    deleteItem: vi.fn().mockResolvedValue(undefined),
+    moveItemToCollection: vi.fn().mockResolvedValue(undefined),
+    storeItem: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import ViewCardModal from './ViewCardModal.svelte';
+
+const item: InboxItem = {
+  id: 'note-1',
+  type: 'note',
+  title: 'Keyboard-accessible actions',
+  body: 'Test body',
+  createdAt: '2026-08-08T10:00:00.000Z',
+};
+
+describe('ViewCardModal actions menu', () => {
+  let host: HTMLElement;
+  let component: ReturnType<typeof mount> | undefined;
+  let onclose: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onclose = vi.fn();
+    host = document.createElement('div');
+    document.body.appendChild(host);
+  });
+
+  afterEach(() => {
+    if (component) unmount(component);
+    component = undefined;
+    host.remove();
+    localStorage.clear();
+  });
+
+  function render() {
+    component = mount(ViewCardModal, {
+      target: host,
+      props: { item, onclose },
+    });
+    flushSync();
+  }
+
+  it('supports keyboard opening, navigation, and focus restoration', async () => {
+    render();
+    const trigger = host.querySelector(
+      '[aria-label="Card actions"]',
+    ) as HTMLButtonElement;
+    trigger.focus();
+
+    trigger.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+    );
+    await tick();
+
+    const deleteAction = host.querySelector(
+      '[role="menuitem"]',
+    ) as HTMLButtonElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(document.activeElement).toBe(deleteAction);
+
+    deleteAction.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }),
+    );
+    expect(document.activeElement).toBe(deleteAction);
+
+    deleteAction.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    );
+    flushSync();
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(host.querySelector('[role="menu"]')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+    expect(onclose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changed

- replaced the persistent Delete icon beside Close with a card-actions overflow button
- moved **Delete card** into an anchored menu while preserving the existing confirmation dialog
- made outside taps and Escape dismiss the menu before dismissing the card modal
- increased header action tap targets to 44×44px on mobile

## Why

Delete and Close were adjacent 32px icon targets with only a 4px gap. On mobile this made accidental taps more likely and gave a destructive action unnecessary prominence.

## Validation

- `npm run check` (passes; reports two pre-existing warnings in `tests/e2e/desktop/navigation.spec.ts`)
- `npm run test` (803 tests pass)
- `npx @sveltejs/mcp svelte-autofixer packages/web/src/components/ViewCardModal.svelte --svelte-version 5`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a header actions menu for accessing delete actions.
  - Added support for closing the menu with Escape or overlay clicks.

- **Style**
  - Improved header action button sizing for better accessibility and touch interaction.
  - Added responsive styling for mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->