### PR TITLE
Test Markdown editor compatibility

### DIFF
--- a/packages/web/src/components/MarkdownEditor.svelte
+++ b/packages/web/src/components/MarkdownEditor.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { Editor } from '@tiptap/core';
-  import StarterKit from '@tiptap/starter-kit';
-  import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
-  import { Markdown } from 'tiptap-markdown';
   import Placeholder from '@tiptap/extension-placeholder';
-  import { common, createLowlight } from 'lowlight';
   import 'highlight.js/styles/github-dark.min.css';
-  import { CodeBlockAutoIndent } from '../lib/tiptap-code-indent';
+  import { createMarkdownEditorExtensions } from '../lib/markdown-editor';
 
   let {
     value = $bindable(''),
@@ -26,31 +22,15 @@
   let editorElement = $state<HTMLDivElement>();
   let editor: Editor | null = null;
 
-  const lowlight = createLowlight(common);
-
   onMount(() => {
     if (!editorElement) return;
     editor = new Editor({
       element: editorElement,
       extensions: [
-        StarterKit.configure({
-          codeBlock: false,
-        }),
-        CodeBlockLowlight.configure({
-          lowlight,
-          enableTabIndentation: true,
-          tabSize: 2,
-        }),
-        Markdown.configure({
-          html: false,
-          breaks: true,
-          tightLists: true,
-          transformPastedText: true,
-        }),
+        ...createMarkdownEditorExtensions(),
         Placeholder.configure({
           placeholder,
         }),
-        CodeBlockAutoIndent,
       ],
       content: value,
       autofocus: focusOnMount ? 'end' : false,

--- a/packages/web/src/components/MarkdownEditor.test.ts
+++ b/packages/web/src/components/MarkdownEditor.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { Editor } from '@tiptap/core';
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+import StarterKit from '@tiptap/starter-kit';
+import { common, createLowlight } from 'lowlight';
+import { Markdown } from 'tiptap-markdown';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CodeBlockAutoIndent } from '../lib/tiptap-code-indent';
+
+type MarkdownStorage = {
+  markdown: { getMarkdown(): string };
+};
+
+describe('MarkdownEditor markdown compatibility', () => {
+  let editor: Editor | undefined;
+
+  afterEach(() => {
+    editor?.destroy();
+    editor = undefined;
+  });
+
+  function roundTrip(markdown: string): string {
+    editor = new Editor({
+      element: document.createElement('div'),
+      extensions: [
+        StarterKit.configure({ codeBlock: false }),
+        CodeBlockLowlight.configure({
+          lowlight: createLowlight(common),
+          enableTabIndentation: true,
+          tabSize: 2,
+        }),
+        Markdown.configure({
+          html: false,
+          breaks: true,
+          tightLists: true,
+          transformPastedText: true,
+        }),
+        CodeBlockAutoIndent,
+      ],
+      content: markdown,
+    });
+
+    return (
+      editor.storage as unknown as MarkdownStorage
+    ).markdown.getMarkdown();
+  }
+
+  it.each([
+    {
+      name: 'headings and inline formatting',
+      markdown: '# Heading\n\nA **bold**, *italic*, and ~~deleted~~ line.',
+    },
+    {
+      name: 'nested ordered and unordered lists',
+      markdown: '- parent\n  - child\n    1. numbered child',
+    },
+    {
+      name: 'fenced code with a language label',
+      markdown: '```typescript\nconst answer: number = 42;\n```',
+    },
+    {
+      name: 'blockquote, rule, and link',
+      markdown: '> quoted [link](https://example.com)\n\n---',
+    },
+  ])('preserves $name through the visual editor', ({ markdown }) => {
+    expect(roundTrip(markdown)).toBe(markdown);
+  });
+
+  it('documents that GFM tables are currently lossy in visual mode', () => {
+    const markdown = '| Name | Value |\n| --- | ---: |\n| One | 1 |';
+
+    expect(roundTrip(markdown)).toBe('NameValueOne1');
+  });
+
+  it('documents that GFM task lists are currently lossy in visual mode', () => {
+    const markdown = '- [x] done\n- [ ] pending';
+
+    expect(roundTrip(markdown)).toBe('- \\[x\\] done\n- \\[ \\] pending');
+  });
+});

--- a/packages/web/src/components/MarkdownEditor.test.ts
+++ b/packages/web/src/components/MarkdownEditor.test.ts
@@ -1,12 +1,8 @@
 // @vitest-environment jsdom
 
 import { Editor } from '@tiptap/core';
-import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
-import StarterKit from '@tiptap/starter-kit';
-import { common, createLowlight } from 'lowlight';
-import { Markdown } from 'tiptap-markdown';
 import { afterEach, describe, expect, it } from 'vitest';
-import { CodeBlockAutoIndent } from '../lib/tiptap-code-indent';
+import { createMarkdownEditorExtensions } from '../lib/markdown-editor';
 
 type MarkdownStorage = {
   markdown: { getMarkdown(): string };
@@ -23,21 +19,7 @@ describe('MarkdownEditor markdown compatibility', () => {
   function roundTrip(markdown: string): string {
     editor = new Editor({
       element: document.createElement('div'),
-      extensions: [
-        StarterKit.configure({ codeBlock: false }),
-        CodeBlockLowlight.configure({
-          lowlight: createLowlight(common),
-          enableTabIndentation: true,
-          tabSize: 2,
-        }),
-        Markdown.configure({
-          html: false,
-          breaks: true,
-          tightLists: true,
-          transformPastedText: true,
-        }),
-        CodeBlockAutoIndent,
-      ],
+      extensions: createMarkdownEditorExtensions(),
       content: markdown,
     });
 

--- a/packages/web/src/lib/markdown-editor.ts
+++ b/packages/web/src/lib/markdown-editor.ts
@@ -1,0 +1,25 @@
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+import StarterKit from '@tiptap/starter-kit';
+import { common, createLowlight } from 'lowlight';
+import { Markdown } from 'tiptap-markdown';
+import { CodeBlockAutoIndent } from './tiptap-code-indent';
+
+export function createMarkdownEditorExtensions() {
+  return [
+    StarterKit.configure({
+      codeBlock: false,
+    }),
+    CodeBlockLowlight.configure({
+      lowlight: createLowlight(common),
+      enableTabIndentation: true,
+      tabSize: 2,
+    }),
+    Markdown.configure({
+      html: false,
+      breaks: true,
+      tightLists: true,
+      transformPastedText: true,
+    }),
+    CodeBlockAutoIndent,
+  ];
+}


### PR DESCRIPTION
## What changed

- Add round-trip coverage for headings, inline formatting, nested lists, fenced code, blockquotes, links, and horizontal rules.
- Document the visual editor's current lossy handling of GFM tables and task lists.

## Why

The application uses separate Markdown paths for the TipTap visual editor and the rendered preview. These tests establish the compatibility boundary and make normalization or data loss visible when either editor dependency changes.

## User impact

No runtime behavior changes. The suite now protects supported Markdown constructs and records why the read-only Preview remains useful alongside Visual and raw Markdown modes.

## Validation

- `npm run check` (passes with two existing warnings in `tests/e2e/desktop/navigation.spec.ts`)
- `npm run test` (810 tests passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added compatibility coverage for Markdown editor conversions.
  * Verified preservation of headings, formatting, lists, code blocks, blockquotes, rules, and links.
  * Documented known conversion limitations for tables and task lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->