### PR TITLE
Fix card flag button overlapping favicon and top whitespace

### DIFF
--- a/packages/web/src/components/InboxCard.favicon.svelte.test.ts
+++ b/packages/web/src/components/InboxCard.favicon.svelte.test.ts
@@ -154,13 +154,13 @@ describe('InboxCard bookmark favicon decorator', () => {
     expect(img?.src).toBe('https://example.com/favicon.ico');
   });
 
-  it('does not reserve flow space for the pin button above the kind row', () => {
+  it('keeps the pin button absolutely positioned', () => {
     mountCard(bookmark({ favicon: 'https://example.com/favicon.ico' }));
+    const pin = host.querySelector<HTMLElement>('.pin-button');
     const kind = host.querySelector('.card-kind');
+    expect(pin).not.toBeNull();
     expect(kind).not.toBeNull();
-    // When the pin button incorrectly stays in document flow it sits above the
-    // kind row and pushes the favicon down, leaving a blank band at the top.
-    expect(kind!.offsetTop).toBeLessThan(28);
+    expect(getComputedStyle(pin!).position).toBe('absolute');
   });
 
   it('uses a native selection button without making the card interactive', () => {

--- a/packages/web/src/components/InboxCard.favicon.svelte.test.ts
+++ b/packages/web/src/components/InboxCard.favicon.svelte.test.ts
@@ -154,6 +154,15 @@ describe('InboxCard bookmark favicon decorator', () => {
     expect(img?.src).toBe('https://example.com/favicon.ico');
   });
 
+  it('does not reserve flow space for the pin button above the kind row', () => {
+    mountCard(bookmark({ favicon: 'https://example.com/favicon.ico' }));
+    const kind = host.querySelector('.card-kind');
+    expect(kind).not.toBeNull();
+    // When the pin button incorrectly stays in document flow it sits above the
+    // kind row and pushes the favicon down, leaving a blank band at the top.
+    expect(kind!.offsetTop).toBeLessThan(28);
+  });
+
   it('uses a native selection button without making the card interactive', () => {
     const onselect = vi.fn();
     const item = bookmark();

--- a/packages/web/src/components/InboxCard.svelte
+++ b/packages/web/src/components/InboxCard.svelte
@@ -293,9 +293,12 @@
     outline-offset: -3px;
   }
 
-  /* Keep genuine card controls above the full-card selection surface. */
+  /* Keep genuine card controls above the full-card selection surface. The
+     pin button is excluded — it is absolutely positioned in the card corner
+     and must not pick up `position: relative` (that reserves flow space and
+     shifts the flag into the kind row). */
   .card :global(a),
-  .card :global(button:not(.card-select)),
+  .card :global(button:not(.card-select):not(.pin-button)),
   .card :global(input),
   .card :global(audio),
   .card :global(video) {

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -2,8 +2,8 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
-import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
+import { defineConfig } from 'vitest/config';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const { version } = JSON.parse(
@@ -115,5 +115,8 @@ export default defineConfig({
         capture: path.resolve(__dirname, 'src/capture/main.ts'),
       },
     },
+  },
+  test: {
+    css: true,
   },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After adding the important-flag pin button on inbox cards (#197), bookmark cards showed:
- Extra whitespace at the top of the card body (where the flag sat in document flow)
- The flag icon overlapping the favicon / kind row

## Cause

The rule that keeps interactive controls above the full-card selection overlay applied `position: relative` to every `button` except `.card-select`. That overrode `.pin-button`'s `position: absolute` (higher selector specificity). The pin button stayed in normal flow at the top-left, reserving vertical space, while `top`/`right` offsets shifted it visually into the kind row.

## Fix

Exclude `.pin-button` from the stacking rule so it remains absolutely positioned in the card corner.

Enable Vitest `test.css: true` so component tests can assert computed styles under jsdom.

## Testing

- Regression test asserts `.pin-button` has computed `position: absolute` (not `offsetTop`, which jsdom does not model reliably).
- `npm run check`
- `npm run test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51a73cc6-0380-4abe-93a0-f0ed32f088e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51a73cc6-0380-4abe-93a0-f0ed32f088e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed card layout behavior when a favicon is displayed, keeping controls positioned correctly.
  * Preserved the pin button’s intended absolute positioning so it no longer affects the card’s document flow or causes layout shifts.

* **Tests**
  * Added regression coverage confirming the pin button remains correctly positioned on bookmarked cards with favicons.
  * Improved test styling support to reliably validate visual card behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->