### PR TITLE
Fix link preview fetching and controls

### DIFF
--- a/packages/web/src/components/CardInlineEditor.svelte
+++ b/packages/web/src/components/CardInlineEditor.svelte
@@ -21,11 +21,15 @@
     status = $bindable<SaveStatus>('saved'),
     flush = $bindable<() => Promise<void>>(async () => {}),
     retry = $bindable<() => void>(() => {}),
+    onfetchurlpreview = undefined,
+    fetchingUrlPreview = false,
   }: {
     item: InboxItem;
     status?: SaveStatus;
     flush?: () => Promise<void>;
     retry?: () => void;
+    onfetchurlpreview?: () => void;
+    fetchingUrlPreview?: boolean;
   } = $props();
 
   const initialItem = untrack(() => item);
@@ -148,7 +152,11 @@
   );
 </script>
 
-<section class="editor" aria-label="Card content">
+<section
+  class="editor"
+  class:compact={item.type === 'bookmark'}
+  aria-label="Card content"
+>
   <div class="title-row">
     {#if item.isTodo || item.type === 'todo'}
       <label class="complete-toggle" title={draft.completed ? 'Mark open' : 'Mark complete'}>
@@ -170,6 +178,19 @@
       <a class="source-link" href={item.messageUrl}>Open email ↗</a>
     {/if}
   </div>
+
+  {#if onfetchurlpreview}
+    <div class="url-preview-prompt">
+      <span>This note contains a link.</span>
+      <button
+        type="button"
+        disabled={fetchingUrlPreview}
+        onclick={onfetchurlpreview}
+      >
+        {fetchingUrlPreview ? 'Fetching preview…' : 'Fetch link preview'}
+      </button>
+    </div>
+  {/if}
 
   {#if item.type === 'bookmark'}
     <label class="compact-field">
@@ -224,10 +245,45 @@
     min-height: 0;
   }
 
+  /* Bookmark fields are short. Letting this section grow pushed the actual
+     preview to the bottom of the full-height modal. */
+  .editor.compact {
+    flex: 0 0 auto;
+  }
+
   .title-row {
     display: flex;
     align-items: center;
     gap: 0.75rem;
+  }
+
+  .url-preview-prompt {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--accent-subtle);
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .url-preview-prompt button {
+    flex-shrink: 0;
+    border: none;
+    background: transparent;
+    color: var(--accent);
+    font: inherit;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .url-preview-prompt button:disabled {
+    opacity: 0.6;
+    cursor: default;
   }
 
   .title-input {

--- a/packages/web/src/components/CardInlineEditor.svelte.test.ts
+++ b/packages/web/src/components/CardInlineEditor.svelte.test.ts
@@ -80,6 +80,25 @@ describe('CardInlineEditor autosave', () => {
     ).toBe('Recovered after refresh');
   });
 
+  it('keeps compact bookmark fields from stretching the preview layout', () => {
+    const bookmark: BookmarkItem = {
+      id: 'bookmark-layout',
+      type: 'bookmark',
+      title: 'Example',
+      url: 'https://example.com',
+      createdAt: '2026-08-01T10:00:00.000Z',
+    };
+    component = mount(CardInlineEditor, {
+      target: host,
+      props: { item: bookmark },
+    });
+    flushSync();
+
+    expect(host.querySelector('section.editor')?.classList).toContain(
+      'compact',
+    );
+  });
+
   it('keeps a merged external update pending when an older save is in flight', async () => {
     let releaseSave: (() => void) | undefined;
     const saveGate = new Promise<void>((resolve) => {

--- a/packages/web/src/components/UserMenu.svelte
+++ b/packages/web/src/components/UserMenu.svelte
@@ -2,7 +2,12 @@
   import type { Component } from 'svelte';
   import { tick } from 'svelte';
   import rs from '../lib/rs';
-  import { bulkEnrichProgress, enrichAllBookmarks } from '../lib/enrich';
+  import {
+    bulkEnrichProgress,
+    enrichAllBookmarks,
+    LOCAL_LINK_PREVIEWS_KEY,
+    LOCAL_SOCKETHUB_URL_KEY,
+  } from '../lib/enrich';
   import { DEFAULT_SOCKETHUB_ENDPOINT } from '../lib/link-metadata';
   import { connected, syncing, userAddress, userSettings, updateUserSettings } from '../lib/stores';
   import { showToast } from '../lib/toast';
@@ -194,8 +199,18 @@
 
   // Link previews: on unless explicitly disabled; the endpoint input lets
   // self-hosters point at their own Sockethub. Synced via user settings.
-  const linkPreviewsOn = $derived($userSettings.linkPreviews !== false);
-  let sockethubUrlInput = $state('');
+  let localLinkPreviewsOn = $state(
+    localStorage.getItem(LOCAL_LINK_PREVIEWS_KEY) !== 'false',
+  );
+  const linkPreviewsOn = $derived(
+    $userSettings.linkPreviews !== false && localLinkPreviewsOn,
+  );
+  let localSockethubUrl = $state(
+    localStorage.getItem(LOCAL_SOCKETHUB_URL_KEY) ?? '',
+  );
+  let sockethubUrlInput = $state(
+    localStorage.getItem(LOCAL_SOCKETHUB_URL_KEY) ?? '',
+  );
   let sockethubUrlEditing = $state(false);
   // Re-sync from settings only while the field isn't focused — the store
   // emits on every settings change (theme, abbreviation, remote sync from
@@ -203,19 +218,27 @@
   // mid-edit. On blur, saveSockethubUrl runs before the flag flips back, so
   // the re-sync lands on the value that was just saved.
   $effect(() => {
-    const synced = $userSettings.sockethubUrl ?? '';
+    const synced = $userSettings.sockethubUrl ?? localSockethubUrl;
     if (!sockethubUrlEditing) sockethubUrlInput = synced;
   });
 
   function setLinkPreviews(on: boolean) {
-    // Store only the off state; undefined means the default (on).
-    void updateUserSettings({ linkPreviews: on ? undefined : false });
+    localLinkPreviewsOn = on;
+    localStorage.setItem(LOCAL_LINK_PREVIEWS_KEY, String(on));
+    if ($connected) {
+      // Store only the off state remotely; undefined means the default (on).
+      void updateUserSettings({ linkPreviews: on ? undefined : false });
+    }
   }
 
   function saveSockethubUrl() {
     const val = sockethubUrlInput.trim();
-    if (val === ($userSettings.sockethubUrl ?? '')) return;
-    void updateUserSettings({ sockethubUrl: val || undefined });
+    if (val === localSockethubUrl && (!$connected || val === ($userSettings.sockethubUrl ?? ''))) return;
+    localSockethubUrl = val;
+    localStorage.setItem(LOCAL_SOCKETHUB_URL_KEY, val);
+    if ($connected) {
+      void updateUserSettings({ sockethubUrl: val || undefined });
+    }
   }
 
   // Backfill metadata (title, description, preview image) for bookmarks
@@ -389,27 +412,6 @@
           Import Data
           <span class="menu-hint">.zip</span>
         </button>
-        {#if linkPreviewsOn}
-          <button
-            type="button"
-            class="menu-item"
-            role="menuitem"
-            onclick={handleFetchPreviews}
-            disabled={!!$bulkEnrichProgress}
-          >
-            <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-              <circle cx="8.5" cy="8.5" r="1.5"></circle>
-              <polyline points="21 15 16 10 5 21"></polyline>
-            </svg>
-            Fetch Link Previews
-            {#if $bulkEnrichProgress}
-              <span class="menu-hint" aria-live="polite"
-                >{$bulkEnrichProgress.done}/{$bulkEnrichProgress.total}</span
-              >
-            {/if}
-          </button>
-        {/if}
         <input
           bind:this={fileInputEl}
           type="file"
@@ -417,12 +419,14 @@
           style="display: none"
           onchange={handleFileSelected}
         />
+      {/if}
 
-        <div class="divider"></div>
+      <div class="divider"></div>
 
-        <!-- Link previews — synced setting -->
-        <div class="section-label">Link previews</div>
-        <div class="theme-switcher" role="group" aria-label="Link previews">
+      <!-- Preview settings work for local-only cards too. When connected,
+           changes are additionally synced through remoteStorage. -->
+      <div class="section-label">Link previews</div>
+      <div class="theme-switcher" role="group" aria-label="Link previews">
           <button type="button"
             class="theme-option"
             class:active={linkPreviewsOn}
@@ -439,31 +443,51 @@
           >
             Off
           </button>
-        </div>
-        <div class="divider"></div>
-
-        <!-- Sockethub — the relay behind link previews AND calendar sync, so
-             it gets its own section instead of hiding under either feature.
-             Synced setting; the endpoint override is for self-hosters. -->
-        <div class="section-label">Sockethub service</div>
-        <p class="menu-note">Relays link previews and calendar sync.</p>
-        <form
-          class="connect-form"
-          onsubmit={(e) => { e.preventDefault(); saveSockethubUrl(); }}
+      </div>
+      {#if linkPreviewsOn}
+        <button
+          type="button"
+          class="menu-item"
+          role="menuitem"
+          onclick={handleFetchPreviews}
+          disabled={!!$bulkEnrichProgress}
         >
-          <input
-            type="url"
-            bind:value={sockethubUrlInput}
-            placeholder={DEFAULT_SOCKETHUB_ENDPOINT}
-            aria-label="Sockethub endpoint"
-            onfocus={() => (sockethubUrlEditing = true)}
-            onblur={() => {
-              saveSockethubUrl();
-              sockethubUrlEditing = false;
-            }}
-          />
-        </form>
+          <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+            <circle cx="8.5" cy="8.5" r="1.5"></circle>
+            <polyline points="21 15 16 10 5 21"></polyline>
+          </svg>
+          Fetch Link Previews
+          {#if $bulkEnrichProgress}
+            <span class="menu-hint" aria-live="polite"
+              >{$bulkEnrichProgress.done}/{$bulkEnrichProgress.total}</span
+            >
+          {/if}
+        </button>
       {/if}
+      <div class="divider"></div>
+
+      <div class="section-label">Sockethub service</div>
+      <p class="menu-note">
+        Full HTTP actions URL, for example
+        <code>http://localhost:10550/sockethub-http</code>.
+      </p>
+      <form
+        class="connect-form"
+        onsubmit={(e) => { e.preventDefault(); saveSockethubUrl(); }}
+      >
+        <input
+          type="url"
+          bind:value={sockethubUrlInput}
+          placeholder={DEFAULT_SOCKETHUB_ENDPOINT}
+          aria-label="Sockethub endpoint"
+          onfocus={() => (sockethubUrlEditing = true)}
+          onblur={() => {
+            saveSockethubUrl();
+            sockethubUrlEditing = false;
+          }}
+        />
+      </form>
 
       <div class="divider"></div>
 

--- a/packages/web/src/components/ViewCardModal.svelte
+++ b/packages/web/src/components/ViewCardModal.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-  import type { InboxItem } from '@inbox-rs/rs-module';
+  import type { BookmarkItem, InboxItem } from '@inbox-rs/rs-module';
   import { tick } from 'svelte';
   import { clearCardDraft } from '../lib/card-draft';
+  import { bookmarkUrlFromNoteBody } from '../lib/capture-detect';
+  import { enrichBookmark } from '../lib/enrich';
   import {
     collections,
     deleteItem,
@@ -49,6 +51,7 @@
 
   let convertingTodo = $state(false);
   let convertingRef = $state(false);
+  let convertingBookmark = $state(false);
   let saveStatus = $state<SaveStatus>('saved');
   let flushEdits = $state<() => Promise<void>>(async () => {});
   let retrySave = $state<() => void>(() => {});
@@ -213,8 +216,43 @@
     }
   }
 
+  async function convertNoteToBookmark() {
+    if (!noteBookmarkUrl) return;
+    convertingBookmark = true;
+    try {
+      await prepareAction();
+      const bodyFallbackTitle = item.type === 'note' ? item.body.slice(0, 50) : '';
+      const urlFallbackTitle = noteBookmarkUrl.slice(0, 50);
+      const updated = {
+        ...item,
+        type: 'bookmark',
+        url: noteBookmarkUrl,
+        title:
+          !item.title ||
+          item.title === bodyFallbackTitle ||
+          item.title === urlFallbackTitle
+            ? noteBookmarkUrl
+            : item.title,
+      } as BookmarkItem;
+      delete (updated as unknown as Record<string, unknown>).body;
+      clearCardDraft(item.id, localStorage);
+      await storeItem(updated);
+      void enrichBookmark(updated).catch(() => {});
+    } catch (error) {
+      console.error('Failed to convert note to bookmark', error);
+      showToast('Could not convert this note to a bookmark');
+    } finally {
+      convertingBookmark = false;
+    }
+  }
+
   const canMakeTodo = $derived(item.type !== 'todo' && !item.isTodo);
   const canMakeRef = $derived(item.isTodo || item.type === 'todo');
+  const noteBookmarkUrl = $derived(
+    item.type === 'note' && !item.isTodo
+      ? bookmarkUrlFromNoteBody(item.body)
+      : null,
+  );
 
   function openMovePicker() {
     pickerMode = 'move';
@@ -420,6 +458,7 @@
   <div
     class="modal"
     role="dialog"
+    tabindex="-1"
     aria-modal="true"
     aria-labelledby={TITLE_ID}
     onclick={handleModalClick}
@@ -526,18 +565,20 @@
     </div>
 
     <h2 class="sr-only" id={TITLE_ID}>{item.title || 'Untitled card'}</h2>
-    {#key item.id}
+    {#key `${item.id}:${item.type}`}
       <CardInlineEditor
         {item}
         bind:status={saveStatus}
         bind:flush={flushEdits}
         bind:retry={retrySave}
+        onfetchurlpreview={noteBookmarkUrl ? convertNoteToBookmark : undefined}
+        fetchingUrlPreview={convertingBookmark}
       />
     {/key}
 
     <!-- Type-specific previews and file actions stay available beneath the
          always-editable content without duplicating title/body fields. -->
-    {#key item.id}
+    {#key `${item.id}:${item.type}`}
       {#if item.type === 'bookmark'}
         <BookmarkView {item} titleId={TITLE_ID} showTitle={false} beforeAction={prepareAction} />
       {:else if item.type === 'image'}

--- a/packages/web/src/components/ViewCardModal.svelte.test.ts
+++ b/packages/web/src/components/ViewCardModal.svelte.test.ts
@@ -3,6 +3,10 @@ import type { InboxItem } from '@inbox-rs/rs-module';
 import { flushSync, mount, tick, unmount } from 'svelte';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const { storeItem } = vi.hoisted(() => ({
+  storeItem: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('../lib/stores', async () => {
   const { writable } = await import('svelte/store');
   return {
@@ -10,7 +14,7 @@ vi.mock('../lib/stores', async () => {
     groups: writable({}),
     deleteItem: vi.fn().mockResolvedValue(undefined),
     moveItemToCollection: vi.fn().mockResolvedValue(undefined),
-    storeItem: vi.fn().mockResolvedValue(undefined),
+    storeItem,
   };
 });
 
@@ -30,6 +34,7 @@ describe('ViewCardModal actions menu', () => {
   let onclose: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     onclose = vi.fn();
     host = document.createElement('div');
     document.body.appendChild(host);
@@ -42,10 +47,10 @@ describe('ViewCardModal actions menu', () => {
     localStorage.clear();
   });
 
-  function render() {
+  function render(renderedItem: InboxItem = item) {
     component = mount(ViewCardModal, {
       target: host,
-      props: { item, onclose },
+      props: { item: renderedItem, onclose },
     });
     flushSync();
   }
@@ -82,5 +87,35 @@ describe('ViewCardModal actions menu', () => {
     expect(host.querySelector('[role="menu"]')).toBeNull();
     expect(document.activeElement).toBe(trigger);
     expect(onclose).not.toHaveBeenCalled();
+  });
+
+  it('converts and fetches when an existing note contains only a URL', async () => {
+    const url =
+      'https://x.com/vivistac/status/2086480928591819162?s=46&t=UTd7gPLSy4yZR518MK49Qg';
+    render({
+      id: 'legacy-url-note',
+      type: 'note',
+      title: url.slice(0, 50),
+      body: `[${url}](${url})`,
+      createdAt: '2026-08-10T13:59:00.000Z',
+    });
+
+    expect(host.textContent).toContain('This note contains a link.');
+    expect(host.textContent).toContain('Fetch link preview');
+
+    const fetchButton = Array.from(host.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('Fetch link preview'),
+    );
+    fetchButton?.click();
+    await vi.waitFor(() => {
+      expect(storeItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'legacy-url-note',
+          type: 'bookmark',
+          url,
+          title: url,
+        }),
+      );
+    });
   });
 });

--- a/packages/web/src/components/view-card/BookmarkView.svelte
+++ b/packages/web/src/components/view-card/BookmarkView.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import type { BookmarkItem } from '@inbox-rs/rs-module';
-  import { enrichBookmark, needsEnrichment } from '../../lib/enrich';
+  import {
+    describeLinkPreviewError,
+    enrichBookmark,
+    needsEnrichment,
+  } from '../../lib/enrich';
   import {
     blobUrls,
     connected,
@@ -23,7 +27,8 @@
 
   let showLightbox = $state(false);
   let fetchingPreview = $state(false);
-  let previewStatus = $state<'' | 'error' | 'none'>('');
+  let previewStatus = $state<'' | 'none'>('');
+  let previewError = $state('');
 
   // Fetch the page's metadata on demand for bookmarks saved before this
   // feature (or whose auto-fetch failed). Mirrors AudioView's transcribe
@@ -37,6 +42,7 @@
     }
     fetchingPreview = true;
     previewStatus = '';
+    previewError = '';
     try {
       const result = await enrichBookmark(item);
       // The enriched fields flow back reactively through the items store;
@@ -44,7 +50,7 @@
       if (result === 'none') previewStatus = 'none';
     } catch (e) {
       console.warn('Metadata fetch failed:', e);
-      previewStatus = 'error';
+      previewError = describeLinkPreviewError(e);
     } finally {
       fetchingPreview = false;
     }
@@ -79,6 +85,7 @@
   });
 </script>
 
+<section class="bookmark-preview" aria-label="Link preview">
 {#if showTitle}
   <h2 class="title" id={titleId}>
     <a href={item.url} target="_blank" rel="noopener noreferrer"
@@ -119,8 +126,8 @@
   <span class="domain">{item.siteName || getDomain(item.url)}</span>
   {#if fetchingPreview}
     <span class="status-text">Fetching preview…</span>
-  {:else if previewStatus === 'error'}
-    <span class="status-text">Couldn't fetch preview</span>
+  {:else if previewError}
+    <span class="status-text error-text">{previewError}</span>
     <button type="button" class="btn-action" onclick={handleFetchPreview}
       >Retry</button
     >
@@ -168,3 +175,16 @@
     <p class="content-text">{item.body}</p>
   </div>
 {/if}
+</section>
+
+<style>
+  .bookmark-preview {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+  }
+
+  .error-text {
+    color: var(--danger);
+  }
+</style>

--- a/packages/web/src/lib/capture-detect.test.ts
+++ b/packages/web/src/lib/capture-detect.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { detectCaptureKind } from './capture-detect';
+import {
+  bookmarkUrlFromNoteBody,
+  bookmarkUrlFromText,
+  detectCaptureKind,
+} from './capture-detect';
 
 describe('detectCaptureKind', () => {
   it('treats empty / whitespace as empty', () => {
@@ -62,5 +66,34 @@ describe('detectCaptureKind', () => {
   it('documents the accepted tradeoff: a lone dotted token with an alpha TLD is a bookmark', () => {
     // e.g. someone types "file.txt" — becomes a bookmark; rare, and Undo covers it.
     expect(detectCaptureKind('file.txt').kind).toBe('bookmark');
+  });
+});
+
+describe('bookmarkUrlFromText', () => {
+  it('recognizes a URL-only legacy note, including X share parameters', () => {
+    const url =
+      'https://x.com/vivistac/status/2086480928591819162?s=46&t=UTd7gPLSy4yZR518MK49Qg';
+    expect(bookmarkUrlFromText(url)).toBe(url);
+  });
+
+  it('does not offer bookmark conversion for prose containing a URL', () => {
+    expect(bookmarkUrlFromText('remember https://example.com')).toBeNull();
+  });
+});
+
+describe('bookmarkUrlFromNoteBody', () => {
+  const url = 'https://x.com/nypost/status/2086887707624534318';
+
+  it.each([
+    url,
+    `[${url}](${url})`,
+    `<${url}>`,
+    `<p><a href="${url}">${url}</a></p>`,
+  ])('recovers a single rendered link from %s', (body) => {
+    expect(bookmarkUrlFromNoteBody(body)).toBe(url);
+  });
+
+  it('rejects a link surrounded by actual note content', () => {
+    expect(bookmarkUrlFromNoteBody(`Read this: [post](${url})`)).toBeNull();
   });
 });

--- a/packages/web/src/lib/capture-detect.test.ts
+++ b/packages/web/src/lib/capture-detect.test.ts
@@ -96,4 +96,12 @@ describe('bookmarkUrlFromNoteBody', () => {
   it('rejects a link surrounded by actual note content', () => {
     expect(bookmarkUrlFromNoteBody(`Read this: [post](${url})`)).toBeNull();
   });
+
+  it('preserves parenthesized segments in a Markdown link URL', () => {
+    const parenthesizedUrl =
+      'https://en.wikipedia.org/wiki/Function_(mathematics)';
+    expect(bookmarkUrlFromNoteBody(`[Function](${parenthesizedUrl})`)).toBe(
+      parenthesizedUrl,
+    );
+  });
 });

--- a/packages/web/src/lib/capture-detect.ts
+++ b/packages/web/src/lib/capture-detect.ts
@@ -12,12 +12,13 @@ export type CaptureKind =
 export function detectCaptureKind(raw: string): CaptureKind {
   const text = raw.trim();
   if (!text) return { kind: 'empty' };
-  const url = asBookmarkUrl(text);
+  const url = bookmarkUrlFromText(text);
   if (url) return { kind: 'bookmark', url };
   return { kind: 'note', body: raw };
 }
 
-function asBookmarkUrl(text: string): string | null {
+/** Return a normalized URL only when the complete value is a single bookmark URL. */
+export function bookmarkUrlFromText(text: string): string | null {
   if (/\s/.test(text)) return null; // multi-token => note
   if (/^[a-z][a-z0-9+.-]*:/i.test(text)) {
     // Has an explicit scheme: only http/https qualify.
@@ -31,6 +32,24 @@ function asBookmarkUrl(text: string): string | null {
   if (!/^[a-z]{2,}$/i.test(lastLabel)) return null;
   const candidate = `https://${text}`;
   return isHttpUrl(candidate) ? candidate : null;
+}
+
+/** Recover a URL-only note after a Markdown editor has wrapped the URL. */
+export function bookmarkUrlFromNoteBody(body: string): string | null {
+  const text = body.trim();
+  const direct = bookmarkUrlFromText(text);
+  if (direct) return direct;
+
+  const markdownLink = text.match(/^\[[^\]]*\]\((https?:\/\/[^\s)]+)\)$/i);
+  if (markdownLink) return bookmarkUrlFromText(markdownLink[1]);
+
+  const autolink = text.match(/^<(https?:\/\/[^\s>]+)>$/i);
+  if (autolink) return bookmarkUrlFromText(autolink[1]);
+
+  const htmlLink = text.match(
+    /^(?:<p>)?<a\s+[^>]*href=["'](https?:\/\/[^"']+)["'][^>]*>.*<\/a>(?:<\/p>)?$/i,
+  );
+  return htmlLink ? bookmarkUrlFromText(htmlLink[1]) : null;
 }
 
 function isHttpUrl(s: string): boolean {

--- a/packages/web/src/lib/capture-detect.ts
+++ b/packages/web/src/lib/capture-detect.ts
@@ -9,6 +9,7 @@ export type CaptureKind =
   | { kind: 'note'; body: string }
   | { kind: 'empty' };
 
+/** Classify raw quick-capture input while preserving non-URL note content. */
 export function detectCaptureKind(raw: string): CaptureKind {
   const text = raw.trim();
   if (!text) return { kind: 'empty' };
@@ -40,7 +41,7 @@ export function bookmarkUrlFromNoteBody(body: string): string | null {
   const direct = bookmarkUrlFromText(text);
   if (direct) return direct;
 
-  const markdownLink = text.match(/^\[[^\]]*\]\((https?:\/\/[^\s)]+)\)$/i);
+  const markdownLink = text.match(/^\[[^\]]*\]\((https?:\/\/.+)\)$/i);
   if (markdownLink) return bookmarkUrlFromText(markdownLink[1]);
 
   const autolink = text.match(/^<(https?:\/\/[^\s>]+)>$/i);
@@ -52,6 +53,7 @@ export function bookmarkUrlFromNoteBody(body: string): string | null {
   return htmlLink ? bookmarkUrlFromText(htmlLink[1]) : null;
 }
 
+/** Check that a complete value is an absolute HTTP(S) URL with a host. */
 function isHttpUrl(s: string): boolean {
   try {
     const u = new URL(s);

--- a/packages/web/src/lib/enrich.test.ts
+++ b/packages/web/src/lib/enrich.test.ts
@@ -38,9 +38,13 @@ vi.mock('./stores', () => ({
 import {
   applyLinkMetadata,
   bulkEnrichProgress,
+  describeLinkPreviewError,
   enrichAllBookmarks,
   enrichBookmark,
+  LOCAL_LINK_PREVIEWS_KEY,
+  LOCAL_SOCKETHUB_URL_KEY,
   needsEnrichment,
+  resolveSockethubEndpoint,
 } from './enrich';
 
 function bookmark(overrides: Partial<BookmarkItem> = {}): BookmarkItem {
@@ -56,8 +60,38 @@ function bookmark(overrides: Partial<BookmarkItem> = {}): BookmarkItem {
 
 afterEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
   for (const key of Object.keys(itemsMap)) delete itemsMap[key];
   for (const key of Object.keys(settings)) delete settings[key];
+});
+
+describe('local preview settings', () => {
+  it('uses a local Sockethub endpoint while disconnected', () => {
+    localStorage.setItem(
+      LOCAL_SOCKETHUB_URL_KEY,
+      'http://localhost:10550/sockethub-http',
+    );
+    expect(resolveSockethubEndpoint()).toBe(
+      'http://localhost:10550/sockethub-http',
+    );
+  });
+
+  it('honors the local preview toggle', async () => {
+    localStorage.setItem(LOCAL_LINK_PREVIEWS_KEY, 'false');
+    const item = bookmark();
+    itemsMap[item.id] = item;
+    await expect(enrichBookmark(item)).resolves.toBe('none');
+    expect(fetchLinkMetadata).not.toHaveBeenCalled();
+  });
+
+  it('turns network failures into an actionable message', () => {
+    expect(describeLinkPreviewError(new TypeError('Failed to fetch'))).toBe(
+      'Couldn’t reach the preview service. Check its URL, CORS, and that it is running.',
+    );
+    expect(describeLinkPreviewError(new Error('404 Not Found'))).toBe(
+      'Preview service error: 404 Not Found',
+    );
+  });
 });
 
 describe('needsEnrichment', () => {

--- a/packages/web/src/lib/enrich.ts
+++ b/packages/web/src/lib/enrich.ts
@@ -22,6 +22,7 @@ import { items, storeItem, userSettings } from './stores';
 export const LOCAL_LINK_PREVIEWS_KEY = 'inbox-rs:link-previews';
 export const LOCAL_SOCKETHUB_URL_KEY = 'inbox-rs:sockethub-url';
 
+/** Read a browser-local setting without failing in restricted storage contexts. */
 function localSetting(key: string): string | null {
   try {
     return localStorage.getItem(key);

--- a/packages/web/src/lib/enrich.ts
+++ b/packages/web/src/lib/enrich.ts
@@ -19,15 +19,47 @@ import {
 } from './link-metadata';
 import { items, storeItem, userSettings } from './stores';
 
+export const LOCAL_LINK_PREVIEWS_KEY = 'inbox-rs:link-previews';
+export const LOCAL_SOCKETHUB_URL_KEY = 'inbox-rs:sockethub-url';
+
+function localSetting(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
 /** Link previews are on unless the user turned them off. */
 export function linkPreviewsEnabled(): boolean {
-  return get(userSettings).linkPreviews !== false;
+  return (
+    get(userSettings).linkPreviews !== false &&
+    localSetting(LOCAL_LINK_PREVIEWS_KEY) !== 'false'
+  );
 }
 
 /** The user's own Sockethub endpoint when set, else the app default. */
 /** Shared by every sockethub-backed feature (link previews, CalDAV). */
 export function resolveSockethubEndpoint(): string {
-  return get(userSettings).sockethubUrl?.trim() || DEFAULT_SOCKETHUB_ENDPOINT;
+  return (
+    get(userSettings).sockethubUrl?.trim() ||
+    localSetting(LOCAL_SOCKETHUB_URL_KEY)?.trim() ||
+    DEFAULT_SOCKETHUB_ENDPOINT
+  );
+}
+
+/** Turn low-level fetch failures into a short diagnosis with a next step. */
+export function describeLinkPreviewError(error: unknown): string {
+  if (error instanceof DOMException && error.name === 'TimeoutError') {
+    return 'Preview service timed out. Check the Sockethub URL.';
+  }
+  if (error instanceof TypeError) {
+    return 'Couldn’t reach the preview service. Check its URL, CORS, and that it is running.';
+  }
+  const detail = error instanceof Error ? error.message.trim() : '';
+  return detail
+    ? `Preview service error: ${detail}`
+    : 'Preview fetch failed. Check the Sockethub URL and try again.';
 }
 
 /** True when a fetch could still add something to this bookmark. */


### PR DESCRIPTION
## What changed

- expose Sockethub configuration while logged out, including a clear local-development URL control
- make preview fetching available from bookmark views and URL-only notes created through quick capture
- detect URL-only quick captures as bookmarks while preserving intentional notes
- enrich URL-only notes through the same metadata pipeline when requested manually
- show actionable preview-fetch errors instead of only a generic failure
- repair the bookmark detail layout so preview controls no longer overlap the title and empty content does not create excessive whitespace
- add focused component and enrichment regression coverage

## Why

Link cards could be saved without ever attempting metadata enrichment, particularly when quick capture classified a bare URL as a note. Those cards then had no manual recovery path. The Sockethub endpoint was also unavailable from the logged-out menu, making a bad local endpoint difficult to correct. Existing bookmark styling compounded the problem by placing the fetch control behind the title and stretching empty cards vertically.

## Impact

Users can configure a local Sockethub endpoint without logging in, manually retry previews on supported bookmarks and URL-only notes, and see useful failure information. Bare URL captures are classified correctly, and bookmark details remain compact and usable when metadata is missing.

## Validation

- Svelte analyzer: no component correctness issues
- `npm run check` — passed with two pre-existing warnings in `tests/e2e/desktop/navigation.spec.ts`
- `npm run test` — 823 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Convert notes containing a standalone URL into bookmarks, including Markdown, autolink, and HTML link formats.
  - Fetch and display link previews during bookmark conversion and editing.
  - Configure link previews and preview service endpoints locally, including when disconnected.
  - Added clearer controls and explanations for link-preview and service settings.

- **Bug Fixes**
  - Improved handling of preview failures with actionable network and HTTP error messages.
  - Preserved bookmark editor layout for compact cards.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->