### PR TITLE
Sort collection references newest first

### DIFF
--- a/packages/web/src/lib/collection-todos.test.ts
+++ b/packages/web/src/lib/collection-todos.test.ts
@@ -96,6 +96,30 @@ describe('filterReferenceItems', () => {
     const items: InboxItem[] = [ref('r1'), { ...ref('r2'), archived: true }];
     expect(filterReferenceItems(items).map((i) => i.id)).toEqual(['r1']);
   });
+
+  it('sorts references newest first within pinned and unpinned cards', () => {
+    const items: InboxItem[] = [
+      { ...ref('old'), createdAt: '2026-04-01T00:00:00.000Z' },
+      {
+        ...ref('pinned-old'),
+        pinned: true,
+        createdAt: '2026-04-02T00:00:00.000Z',
+      },
+      { ...ref('new'), createdAt: '2026-04-04T00:00:00.000Z' },
+      {
+        ...ref('pinned-new'),
+        pinned: true,
+        createdAt: '2026-04-03T00:00:00.000Z',
+      },
+    ];
+
+    expect(filterReferenceItems(items).map((i) => i.id)).toEqual([
+      'pinned-new',
+      'pinned-old',
+      'new',
+      'old',
+    ]);
+  });
 });
 
 describe('pinItemsFirst', () => {

--- a/packages/web/src/lib/collection-todos.ts
+++ b/packages/web/src/lib/collection-todos.ts
@@ -14,7 +14,12 @@ export function filterCompletedTodos(todos: InboxItem[]): InboxItem[] {
 
 export function filterReferenceItems(items: InboxItem[]): InboxItem[] {
   return pinItemsFirst(
-    items.filter((i) => !i.isTodo && i.type !== 'todo' && !i.archived),
+    items
+      .filter((i) => !i.isTodo && i.type !== 'todo' && !i.archived)
+      .sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      ),
   );
 }
 


### PR DESCRIPTION
## What changed

- sort collection reference cards by `createdAt` descending
- preserve pinned cards as the first group while sorting newest-first within both pinned and unpinned groups
- add regression coverage for the combined recency and pin ordering

## Why

Inbox cards already display newest first, but references inside collections retained the collection's stored item order. This made newly captured references appear below older cards and made the two card grids behave inconsistently.

## Impact

Collection references now follow the same newest-first ordering as inbox cards. Pinning behavior remains unchanged.

## Validation

- `npm run check` — passed with two pre-existing warnings in `tests/e2e/desktop/navigation.spec.ts`
- `npm run test` — 825 tests passed
